### PR TITLE
fix(skills/lab): gate sandbox accepte les vrais skills (import order)

### DIFF
--- a/skills/lab.py
+++ b/skills/lab.py
@@ -106,7 +106,19 @@ _SANDBOX_TEST_SCRIPT = textwrap.dedent(
         sys.stdout.write(json.dumps({"layer": layer, "ok": True, "notes": message}))
 
 
-    # 1) Import du skill.py
+    # 1) Rendre `skills.base` résolvable AVANT d'importer skill.py — la
+    # candidate fait `from skills.base import SkillBase` au top, donc le
+    # sys.path doit déjà contenir la racine du repo. (Ce sys.path.insert
+    # arrivait après exec_module dans une version antérieure ; tous les
+    # skills réels étaient alors rejetés à la couche import.)
+    sys.path.insert(0, "/jarvis_src")
+    try:
+        from skills.base import SkillBase
+    except Exception as exc:
+        _fail("import", f"SkillBase indisponible dans la sandbox : {exc!r}")
+
+
+    # 2) Import du skill.py de la candidate.
     if not SKILL_PY.exists():
         _fail("import", f"skill.py introuvable dans {SKILL_DIR}")
 
@@ -116,14 +128,6 @@ _SANDBOX_TEST_SCRIPT = textwrap.dedent(
         spec.loader.exec_module(module)
     except Exception as exc:
         _fail("import", f"import a échoué : {exc!r}\\n{traceback.format_exc()[:600]}")
-
-
-    # 2) Trouver la classe SkillBase (recherche dans le module + dans sys.modules)
-    try:
-        sys.path.insert(0, "/jarvis_src")
-        from skills.base import SkillBase
-    except Exception as exc:
-        _fail("import", f"SkillBase indisponible dans la sandbox : {exc!r}")
 
     skill_class = None
     for attr_name in dir(module):


### PR DESCRIPTION
## Diagnostic

Le smoke test sandbox du Skill Lab rejetait toute candidate qui importe
`skills.base` au top de son `skill.py` — c'est-à-dire tous les skills
réels (clock, weather, astronomy, bambulab-printer…). Cause : ordre
d'opérations inversé dans `_SANDBOX_TEST_SCRIPT`.

Avant :
  1. exec_module(candidate skill.py)   ← échoue : "from skills.base" non résolu
  2. sys.path.insert(0, "/jarvis_src") ← trop tard
  3. from skills.base import SkillBase

Après :
  1. sys.path.insert(0, "/jarvis_src")
  2. from skills.base import SkillBase
  3. exec_module(candidate skill.py)

Bug latent des deux côtés : `--workdir=/workspace` en Docker ne met pas
`/jarvis_src` dans sys.path non plus. Jamais détecté parce qu'aucun skill
réel n'avait été passé end-to-end par le gate jusqu'ici.

## Preuve par l'usage

VRAI skill (skills/installed/clock) → passed=True, layer=ok
skill cassé (pas de SkillBase)     → passed=False, layer=import

## Tests

6 tests précédemment rouges → verts :
- test_skill_lab::test_propose_from_event_good_skill_passes_sandbox
- test_capability_engine (3 tests)
- test_skills::test_skill_create_tool_succes
- test_skill_create_tool_no_backdoor::*_jamais_dans_installed

Suite : 589 passed, 1 failed (le 1 = test_settings_defaults, PR séparée).