### PR TITLE
fix(tests): test_settings_defaults — isoler du .env du dev

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,19 +1,28 @@
 from __future__ import annotations
 
+import pytest
+
 from config.settings import Settings
 
 
 def test_settings_load() -> None:
-    """Vérifie que les settings se chargent sans erreur."""
+    """Vérifie que les settings se chargent sans erreur (avec .env du dev)."""
     s = Settings()
     assert s.llm_provider in ("api", "local")
     assert s.port > 0
     assert s.log_level in ("DEBUG", "INFO", "WARNING", "ERROR")
 
 
-def test_settings_defaults() -> None:
-    """Vérifie les valeurs par défaut."""
-    s = Settings()
+def test_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Vérifie les défauts déclarés DANS LE CODE, isolés du .env du dev.
+
+    Sans isolation, Settings() lit `.env` (qui définit HOST=0.0.0.0 pour
+    l'usage Tailscale) et l'environnement shell, et écrase les défauts —
+    le test deviendrait dépendant du dev qui le lance.
+    """
+    for var in ("HOST", "PORT", "ANTHROPIC_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+    s = Settings(_env_file=None)
     assert s.host == "127.0.0.1"
     assert s.port == 8000
     assert s.anthropic_model == "claude-sonnet-4-6"


### PR DESCRIPTION
## Diagnostic

`Settings()` lit `.env` via pydantic-settings, et le `.env` de ce repo
définit `HOST=0.0.0.0` (exposition Tailscale documentée).
`test_settings_defaults` testait les **défauts déclarés dans le code**
mais sans s'isoler du chargement `.env` → assertion `s.host == "127.0.0.1"`
échouait avec `'0.0.0.0'`.

Bug d'isolation du test, pas de bug prod.

## Fix

- `monkeypatch.delenv(HOST/PORT/ANTHROPIC_MODEL, raising=False)`
- `Settings(_env_file=None)` pour ignorer le fichier `.env`

`test_settings_load` reste inchangé : il teste justement le chargement
depuis `.env`, c'est sa raison d'être complémentaire.

## Tests

Suite complète : **590 passed, 0 failed**.