### PR TITLE
fix(windows): compatibilité verrouillage fichiers et port serveur

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -74,6 +74,25 @@ function Add-PathIfNeeded {
     }
 }
 
+function Get-AvailablePort {
+    param([int]$StartPort = 8000, [int]$MaxAttempts = 20)
+    for ($port = $StartPort; $port -lt ($StartPort + $MaxAttempts); $port++) {
+        $listener = $null
+        try {
+            $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $port)
+            $listener.Start()
+            return $port
+        } catch {
+            continue
+        } finally {
+            if ($null -ne $listener) {
+                $listener.Stop()
+            }
+        }
+    }
+    return $StartPort
+}
+
 $stepTotal = 8
 
 Write-Host ""
@@ -202,6 +221,11 @@ if (Test-Path ".env") {
     Copy-Item ".env" ".env.backup.$stamp"
 }
 
+$serverPort = Get-AvailablePort -StartPort 8000
+if ($serverPort -ne 8000) {
+    Write-Host "Port 8000 indisponible, utilisation du port $serverPort." -ForegroundColor Yellow
+}
+
 $envContent = @"
 USER_FIRSTNAME=$userFirstname
 LLM_PROVIDER=api
@@ -211,7 +235,7 @@ ANTHROPIC_MODEL=$anthropicModel
 OPENAI_API_KEY=$openaiApiKey
 OPENAI_MODEL=$openaiModel
 HOST=0.0.0.0
-PORT=8000
+PORT=$serverPort
 ENVIRONMENT=development
 LOG_LEVEL=INFO
 PROACTIVE_LAT=$proactiveLat

--- a/src/jarvis/app.py
+++ b/src/jarvis/app.py
@@ -240,7 +240,9 @@ app = FastAPI(
 # CORS : origines explicites si configurées, localhost par défaut en mode local.
 # allow_credentials=True exige des origines nommées (jamais "*" + credentials).
 _cors_origins: list[str] = settings.cors_allow_origins or (
-    ["http://localhost:8000", "http://127.0.0.1:8000"] if not settings.api_auth_enabled else []
+    [f"http://localhost:{settings.port}", f"http://127.0.0.1:{settings.port}"]
+    if not settings.api_auth_enabled
+    else []
 )
 app.add_middleware(
     CORSMiddleware,

--- a/src/jarvis/engine/mission/project_store.py
+++ b/src/jarvis/engine/mission/project_store.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import fcntl
 import json
 import uuid
 from datetime import datetime
@@ -10,6 +9,7 @@ from pathlib import Path
 
 from jarvis.engine.mission.schemas import LogEntry, Project, ProjectStatus, Step, StepStatus
 from jarvis.engine.vocab import AccessLevel
+from jarvis.kernel.file_lock import exclusive_file_lock
 from jarvis.kernel.paths import WORKSPACE_DIR as _WORKSPACE
 
 WORKSPACE_DIR = _WORKSPACE / "projects"
@@ -110,24 +110,20 @@ class ProjectStore:
         claims_file = jarvis_dir / "step_claims.json"
         lock_path = jarvis_dir / "claims.lock"
 
-        with lock_path.open("w") as lf:
-            fcntl.flock(lf, fcntl.LOCK_EX)
-            try:
-                claims: dict[str, str] = {}
-                if claims_file.exists():
-                    try:
-                        claims = json.loads(claims_file.read_text(encoding="utf-8"))
-                    except Exception:
-                        pass
+        with exclusive_file_lock(lock_path):
+            claims: dict[str, str] = {}
+            if claims_file.exists():
+                try:
+                    claims = json.loads(claims_file.read_text(encoding="utf-8"))
+                except Exception:
+                    pass
 
-                if step_id in claims:
-                    return False  # déjà réclamée
+            if step_id in claims:
+                return False
 
-                claims[step_id] = worker_id
-                claims_file.write_text(json.dumps(claims, indent=2), encoding="utf-8")
-                return True
-            finally:
-                fcntl.flock(lf, fcntl.LOCK_UN)
+            claims[step_id] = worker_id
+            claims_file.write_text(json.dumps(claims, indent=2), encoding="utf-8")
+            return True
 
     def release_step_claim(self, project_id: str, step_id: str) -> None:
         """Libère le claim d'une étape (budget pause ou fin normale)."""
@@ -136,18 +132,14 @@ class ProjectStore:
         if not claims_file.exists():
             return
 
-        with lock_path.open("w") as lf:
-            fcntl.flock(lf, fcntl.LOCK_EX)
+        with exclusive_file_lock(lock_path):
+            claims: dict[str, str] = {}
             try:
-                claims: dict[str, str] = {}
-                try:
-                    claims = json.loads(claims_file.read_text(encoding="utf-8"))
-                except Exception:
-                    pass
-                claims.pop(step_id, None)
-                claims_file.write_text(json.dumps(claims, indent=2), encoding="utf-8")
-            finally:
-                fcntl.flock(lf, fcntl.LOCK_UN)
+                claims = json.loads(claims_file.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+            claims.pop(step_id, None)
+            claims_file.write_text(json.dumps(claims, indent=2), encoding="utf-8")
 
     # ── Pause / reprise budget ─────────────────────────────────────────────────
 

--- a/src/jarvis/kernel/file_lock.py
+++ b/src/jarvis/kernel/file_lock.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+
+@contextmanager
+def exclusive_file_lock(lock_path: Path) -> Generator[None, None, None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w") as lf:
+        if sys.platform == "win32":
+            msvcrt.locking(lf.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            fcntl.flock(lf, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            if sys.platform == "win32":
+                msvcrt.locking(lf.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                fcntl.flock(lf, fcntl.LOCK_UN)


### PR DESCRIPTION
## Summary
- Remplacent `fnctl `(Unix only) par un verrou cross-platform` \msvcrt\cntl\`) dans  `ProjectStore\ `
Aligne les origines CORS par défaut sur settings.port au lieu de 8000 en dur
- Détecte automatiquement un port libre dans` setup.ps1` lorsque 8000 est indisponible (ex. occupé par un service Windows)

## Test plan
- `uv run python main.py` démarre sous Windows sans `ModuleNotFoundError: fcntl`
Si le port 8000 est pris, `setup.ps1` propose un port alternatif
- L'UI est accessible sur `http://localhost:<PORT>/admin`  avec CORS fonctionnel