### PR TITLE
fix(windows): installation native et dépendance vision optionnelle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies (full)
-        run: uv sync --frozen --group dev
+        run: uv sync --frozen --group dev --extra vision
 
       - name: Pytest (suite complète, incl. integration)
         run: uv run pytest -q

--- a/README.md
+++ b/README.md
@@ -81,9 +81,18 @@ suite complète, incl. les ~28 tests `@pytest.mark.integration`.
 | Docker | optionnel | Requis par la fonctionnalité code-agent |
 | `nowplaying-cli` | optionnel (macOS) | Lecture locale « now playing » — `brew install nowplaying-cli` |
 
+**Windows (supplémentaire) :**
+
+| Outil | Notes |
+|---|---|
+| [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) | Uniquement si tu installes la reconnaissance faciale (`uv sync --extra vision`) — compile `dlib` |
+| [livekit-server](https://github.com/livekit/livekit/releases) | Binaire `livekit-server.exe` dans le PATH pour le mode vocal local |
+
 ---
 
 ## Installation
+
+### Linux / macOS
 
 ```bash
 git clone https://github.com/Grominet95/jarvis-OS.git
@@ -91,26 +100,48 @@ cd jarvis-OS
 ./jarvis eclosion
 ```
 
-Le wizard interactif :
+### Windows
+
+```powershell
+git clone https://github.com/Grominet95/jarvis-OS.git
+cd jarvis-OS
+.\jarvis.ps1 eclosion
+```
+
+Le wizard interactif (`setup.sh` ou `setup.ps1`) :
 1. Vérifie Python 3.11+ et installe `uv` si absent
-2. Installe toutes les dépendances Python (`pyproject.toml`)
-3. Demande ta clé API Anthropic (seule clé obligatoire)
+2. Installe les dépendances Python (`pyproject.toml`) — la reconnaissance faciale est **optionnelle** sur Windows
+3. Demande ta clé API Anthropic ou OpenAI
 4. Demande ton prénom (affiché lors du scan biométrique)
 5. Configure ta localisation pour le moteur proactif
-6. Propose les modules optionnels (ElevenLabs, LiveKit, AISstream)
+6. Propose les modules optionnels (ElevenLabs, LiveKit local ou cloud, AISstream)
 7. Télécharge les modèles ML (YOLOv8n, Piper TTS)
-8. Génère le `.env` et installe la commande `jarvis` globalement
+8. Génère le `.env` et crée la disposition de données (`memory_data/`, `vision_data/faces/`, …)
 
-> La première fois, utilise `./jarvis eclosion`. Le wizard installe ensuite la commande globalement, tu peux utiliser `jarvis` depuis n'importe où.
+> **Linux / macOS :** `./jarvis eclosion` puis `jarvis run` depuis n'importe où (symlink global).
+>
+> **Windows :** `.\jarvis.ps1 eclosion` puis `.\jarvis.ps1 run` depuis le dossier du projet.
 
 ---
 
 ## Démarrage
 
+### Linux / macOS
+
 ```bash
 jarvis run      # serveur principal  →  localhost:8000/admin
 jarvis voice    # pipeline vocal LiveKit (optionnel)
 ```
+
+### Windows
+
+```powershell
+.\jarvis.ps1 run     # LiveKit + API + Voice
+.\jarvis.ps1 api     # serveur FastAPI uniquement
+.\jarvis.ps1 voice   # pipeline vocal LiveKit (optionnel)
+```
+
+Le port par défaut est `8000` ; si occupé, `setup.ps1` en choisit un autre (vérifie `PORT` dans `.env`).
 
 Les deux peuvent tourner simultanément : le voice agent délègue au gateway du serveur principal, donc ils partagent la même session, la même mémoire et les mêmes outils.
 
@@ -125,10 +156,17 @@ Tout est configuré pendant l'éclosion. Pour modifier une clé après coup, éd
 **Reconnaissance faciale (séquence Wake Up) :** pour que le scan biométrique te reconnaisse, place une photo de toi (format JPG, visage bien visible, bonne luminosité) dans :
 
 ```
-vision/faces/référence.jpg
+vision_data/faces/référence.jpg
 ```
 
-Sans cette photo, la séquence de scan s'exécute mais retourne toujours "identité non reconnue". Le dossier `vision/faces/` est gitignorés, ta photo ne sera jamais commitée.
+Sans cette photo, la séquence de scan s'exécute mais retourne toujours "identité non reconnue". Le dossier `vision_data/faces/` est gitignoré, ta photo ne sera jamais commitée.
+
+Pour activer la reconnaissance faciale, installe le extra Python puis active-la dans `.env` :
+
+```bash
+uv sync --extra vision        # Linux/macOS, ou Windows avec Visual Studio C++
+# FACE_RECOGNITION_ENABLED=true
+```
 
 ---
 

--- a/jarvis.ps1
+++ b/jarvis.ps1
@@ -1,0 +1,218 @@
+param(
+    [Parameter(Position = 0)]
+    [string]$Command = ""
+)
+
+$ErrorActionPreference = "Stop"
+Set-Location $PSScriptRoot
+
+function Get-DotEnvValue {
+    param(
+        [string]$Key,
+        [string]$Default = ""
+    )
+    if (-not (Test-Path ".env")) { return $Default }
+    foreach ($line in Get-Content ".env" -Encoding UTF8) {
+        $trimmed = $line.Trim()
+        if ($trimmed -eq "" -or $trimmed.StartsWith("#")) { continue }
+        $parts = $trimmed -split "=", 2
+        if ($parts.Count -eq 2 -and $parts[0].Trim() -eq $Key) {
+            return $parts[1].Trim()
+        }
+    }
+    return $Default
+}
+
+function Stop-PortListeners {
+    param([int[]]$Ports)
+    foreach ($port in $Ports) {
+        $connections = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+        foreach ($conn in $connections) {
+            Stop-Process -Id $conn.OwningProcess -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Wait-HttpOk {
+    param(
+        [string]$Url,
+        [int]$TimeoutSeconds = 60
+    )
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 2
+            if ($response.StatusCode -lt 400) { return $true }
+        } catch {
+            Start-Sleep -Milliseconds 300
+        }
+    }
+    return $false
+}
+
+function Wait-LogMatch {
+    param(
+        [string]$LogPath,
+        [string]$Pattern,
+        [int]$TimeoutSeconds = 90
+    )
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-Path $LogPath) {
+            $content = Get-Content $LogPath -Raw -ErrorAction SilentlyContinue
+            if ($content -and ($content -match $Pattern)) { return $true }
+        }
+        Start-Sleep -Milliseconds 300
+    }
+    return $false
+}
+
+function Start-BackgroundProcess {
+    param(
+        [string]$CommandLine,
+        [string]$LogPath
+    )
+    $wrapped = "$CommandLine > `"$LogPath`" 2>&1"
+    return Start-Process -FilePath "cmd.exe" `
+        -ArgumentList @("/c", $wrapped) `
+        -WorkingDirectory $PSScriptRoot `
+        -WindowStyle Hidden `
+        -PassThru
+}
+
+function Invoke-JarvisRun {
+    $apiPort = [int](Get-DotEnvValue -Key "PORT" -Default "8000")
+    $logDir = Join-Path $env:TEMP "jarvis"
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+    $lkLog = Join-Path $logDir "livekit.log"
+    $apiLog = Join-Path $logDir "api.log"
+    $voiceLog = Join-Path $logDir "voice.log"
+    foreach ($log in @($lkLog, $apiLog, $voiceLog)) {
+        "" | Set-Content $log
+    }
+
+    Write-Host ""
+    Write-Host "  J · A · R · V · I · S" -ForegroundColor Cyan
+    Write-Host "  activation systeme" -ForegroundColor DarkGray
+    Write-Host ""
+
+    Stop-Process -Name "livekit-server" -Force -ErrorAction SilentlyContinue
+    Get-CimInstance Win32_Process -Filter "Name = 'python.exe'" -ErrorAction SilentlyContinue |
+        Where-Object { $_.CommandLine -match "jarvis\.(app|interfaces\.voice\.agent)" } |
+        ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+    Stop-PortListeners -Ports @(7880, 7881, $apiPort)
+    Start-Sleep -Milliseconds 300
+
+    $procs = @()
+
+    Write-Host "  LiveKit  demarrage..." -ForegroundColor Yellow
+    $lkProc = Start-BackgroundProcess `
+        -CommandLine 'livekit-server --dev --node-ip 127.0.0.1 --keys "devkey: devsecretdevsecretdevsecretdevsecret"' `
+        -LogPath $lkLog
+    $procs += $lkProc
+
+    if (Wait-HttpOk -Url "http://127.0.0.1:7880/" -TimeoutSeconds 40) {
+        Write-Host "  LiveKit  ws://localhost:7880" -ForegroundColor Green
+    } else {
+        Write-Host "  LiveKit  timeout — voir $lkLog" -ForegroundColor Red
+        foreach ($p in $procs) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
+        exit 1
+    }
+
+    Write-Host "  API      demarrage..." -ForegroundColor Yellow
+    $apiProc = Start-BackgroundProcess `
+        -CommandLine "uv run python -m jarvis.app" `
+        -LogPath $apiLog
+    $procs += $apiProc
+
+    if (Wait-HttpOk -Url "http://127.0.0.1:$apiPort/health" -TimeoutSeconds 90) {
+        Write-Host "  API      http://localhost:$apiPort" -ForegroundColor Green
+    } else {
+        Write-Host "  API      timeout — voir $apiLog" -ForegroundColor Red
+        foreach ($p in $procs) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
+        exit 1
+    }
+
+    Write-Host "  Vocal    prechauffement (~10s)..." -ForegroundColor Yellow
+    $voiceProc = Start-BackgroundProcess `
+        -CommandLine "set PYTHONWARNINGS=ignore&& uv run python -m jarvis.interfaces.voice.agent dev --log-level info" `
+        -LogPath $voiceLog
+    $procs += $voiceProc
+
+    if (Wait-LogMatch -LogPath $voiceLog -Pattern "Jarvis vocal prêt" -TimeoutSeconds 90) {
+        Write-Host "  Vocal    pret" -ForegroundColor Green
+    } else {
+        Write-Host "  Vocal    prechauffement long — voir $voiceLog" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+    Write-Host "  Jarvis pret" -ForegroundColor Green
+    Write-Host "  -> http://localhost:$apiPort/admin" -ForegroundColor White
+    Write-Host "  -> clique sur le micro pour le mode vocal" -ForegroundColor DarkGray
+    Write-Host "  -> Ctrl-C pour arreter" -ForegroundColor DarkGray
+    Write-Host "  Logs : $logDir" -ForegroundColor DarkGray
+    Write-Host ""
+
+    try {
+        Wait-Process -Id ($procs | ForEach-Object { $_.Id })
+    } finally {
+        Write-Host ""
+        Write-Host "  arret en cours..." -ForegroundColor DarkGray
+        foreach ($p in $procs) {
+            Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+        }
+        Stop-Process -Name "livekit-server" -Force -ErrorAction SilentlyContinue
+        Write-Host "  Jarvis arrete" -ForegroundColor DarkGray
+    }
+}
+
+switch ($Command.ToLowerInvariant()) {
+    "eclosion" {
+        & "$PSScriptRoot\setup.ps1"
+    }
+    "api" {
+        uv run python -m jarvis.app
+    }
+    "voice" {
+        uv run python -m jarvis.interfaces.voice.agent dev
+    }
+    "livekit" {
+        livekit-server --dev --node-ip 127.0.0.1 --keys "devkey: devsecretdevsecretdevsecretdevsecret"
+    }
+    { $_ -in @("run", "start") } {
+        Invoke-JarvisRun
+    }
+    "doctor" {
+        $port = Get-DotEnvValue -Key "PORT" -Default "8000"
+        try {
+            $null = Invoke-WebRequest -Uri "http://localhost:$port/health" -UseBasicParsing -TimeoutSec 3
+            Write-Host "  FastAPI  en ligne (:$port)" -ForegroundColor Green
+        } catch {
+            Write-Host "  FastAPI  eteint (port $port)" -ForegroundColor Yellow
+        }
+        if (Get-Command livekit-server -ErrorAction SilentlyContinue) {
+            Write-Host "  LiveKit  binaire installe" -ForegroundColor Green
+        } else {
+            Write-Host "  LiveKit  binaire absent" -ForegroundColor Yellow
+            Write-Host "  https://github.com/livekit/livekit/releases" -ForegroundColor DarkGray
+        }
+        if (Get-Command uv -ErrorAction SilentlyContinue) {
+            Write-Host "  uv       installe" -ForegroundColor Green
+        } else {
+            Write-Host "  uv       absent" -ForegroundColor Red
+        }
+    }
+    default {
+        Write-Host ""
+        Write-Host "  Usage : .\jarvis.ps1 <commande>"
+        Write-Host ""
+        Write-Host "    run        demarre tout (LiveKit + API + Voice)"
+        Write-Host "    api        serveur FastAPI uniquement"
+        Write-Host "    voice      pipeline vocal LiveKit"
+        Write-Host "    livekit    serveur LiveKit local"
+        Write-Host "    eclosion   installation et configuration (setup.ps1)"
+        Write-Host "    doctor     diagnostic rapide"
+        Write-Host ""
+        exit 1
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "livekit-plugins-elevenlabs>=1.5.1",
     "livekit-api>=1.1.0",
     "sounddevice>=0.5.5",
-    "face-recognition>=1.3.0",
     "bambulabs-api>=2.6.6",
     "hidapi>=0.15.0",
     "pyusb>=1.3.1",
@@ -53,6 +52,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+vision = [
+    "face-recognition>=1.3.0",
+]
 dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.24.0",

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,4 +1,9 @@
+param(
+    [switch]$Ci
+)
+
 $ErrorActionPreference = "Stop"
+Set-Location $PSScriptRoot
 
 function Write-Step {
     param(
@@ -28,10 +33,7 @@ function Require-Value {
                 [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
             }
         } else {
-            $suffix = ""
-            if ($Default -ne "") {
-                $suffix = " [$Default]"
-            }
+            $suffix = if ($Default -ne "") { " [$Default]" } else { "" }
             $inputValue = Read-Host -Prompt "$Prompt$suffix"
             if ([string]::IsNullOrWhiteSpace($inputValue) -and $Default -ne "") {
                 $value = $Default
@@ -66,9 +68,7 @@ function Ensure-Command {
 
 function Add-PathIfNeeded {
     param([string]$PathToAdd)
-    if ([string]::IsNullOrWhiteSpace($PathToAdd)) {
-        return
-    }
+    if ([string]::IsNullOrWhiteSpace($PathToAdd)) { return }
     if ($env:PATH -notlike "*$PathToAdd*") {
         $env:PATH = "$PathToAdd;$env:PATH"
     }
@@ -85,12 +85,92 @@ function Get-AvailablePort {
         } catch {
             continue
         } finally {
-            if ($null -ne $listener) {
-                $listener.Stop()
-            }
+            if ($null -ne $listener) { $listener.Stop() }
         }
     }
     return $StartPort
+}
+
+function Ensure-JarvisLayout {
+    $dirs = @(
+        "memory_data/sessions",
+        "memory_data/topics",
+        "memory_data/conso",
+        "memory_data/initiatives",
+        "memory_data/curator_reports",
+        "vision_data/faces",
+        "skills_data/installed",
+        "skills_data/candidates",
+        "workspace/projects"
+    )
+    foreach ($dir in $dirs) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    }
+}
+
+function Ensure-Uv {
+    if (Ensure-Command "uv") { return }
+    Write-Host "uv introuvable, installation..." -ForegroundColor Yellow
+    powershell -ExecutionPolicy ByPass -NoProfile -Command "irm https://astral.sh/uv/install.ps1 | iex"
+    Add-PathIfNeeded -PathToAdd (Join-Path $env:USERPROFILE ".local\bin")
+    Add-PathIfNeeded -PathToAdd (Join-Path $env:USERPROFILE ".cargo\bin")
+    if (-not (Ensure-Command "uv")) {
+        throw "uv introuvable apres installation."
+    }
+}
+
+function Get-PythonVersion {
+    if (Ensure-Command "python") {
+        $raw = & python --version 2>&1 | Select-Object -First 1
+        return $raw.ToString()
+    }
+    if (Ensure-Command "py") {
+        $raw = & py -3 --version 2>&1 | Select-Object -First 1
+        return $raw.ToString()
+    }
+    throw "Python 3.11+ introuvable. Installe Python et active l'option Add to PATH."
+}
+
+function Invoke-UvSync {
+    param([switch]$WithVision)
+    $args = @("sync")
+    if ($WithVision) { $args += "--extra"; $args += "vision" }
+    & uv @args
+    if ($LASTEXITCODE -ne 0) {
+        if ($WithVision) {
+            Write-Host ""
+            Write-Host "Echec install vision (dlib). Sur Windows, installe Visual Studio Build Tools" -ForegroundColor Yellow
+            Write-Host "avec le workload C++, puis relance: uv sync --extra vision" -ForegroundColor Yellow
+            Write-Host "https://visualstudio.microsoft.com/visual-cpp-build-tools/" -ForegroundColor Yellow
+        }
+        throw "uv sync a echoue (code $LASTEXITCODE)."
+    }
+}
+
+if ($Ci) {
+    Write-Host "JARVIS V3 - setup --Ci (mode non-interactif)" -ForegroundColor Cyan
+    Ensure-JarvisLayout
+    Write-Host "  Disposition creee (memory_data/, vision_data/, skills_data/)" -ForegroundColor Green
+    if (-not (Test-Path ".env")) {
+        @"
+LLM_PROVIDER=api
+API_BACKEND=anthropic
+ANTHROPIC_API_KEY=unused-in-fake-llm-mode
+ANTHROPIC_MODEL=claude-sonnet-4-6
+VOICE_ANTHROPIC_MODEL=claude-haiku-4-5-20251001
+USER_FIRSTNAME=B9
+HOME_CITY=Paris
+MEMORY_DIR=memory_data
+PORT=8000
+"@ | Set-Content -Path ".env" -Encoding UTF8
+        Write-Host "  .env minimal genere" -ForegroundColor Green
+    } else {
+        Write-Host "  .env pre-existant conserve" -ForegroundColor Green
+    }
+    Ensure-Uv
+    Invoke-UvSync
+    Write-Host "setup --Ci OK" -ForegroundColor Green
+    exit 0
 }
 
 $stepTotal = 8
@@ -101,19 +181,7 @@ Write-Host ""
 
 Write-Step -Current 1 -Total $stepTotal -Title "Verification des prerequis"
 
-$pythonCmd = $null
-if (Ensure-Command "python") { $pythonCmd = "python" }
-elseif (Ensure-Command "py") { $pythonCmd = "py -3" }
-
-if (-not $pythonCmd) {
-    throw "Python 3.11+ introuvable. Installe Python et active l'option Add to PATH."
-}
-
-$pyVersionRaw = & $pythonCmd --version 2>&1
-if ($LASTEXITCODE -ne 0) {
-    throw "Impossible de lire la version Python."
-}
-$versionText = ($pyVersionRaw | Select-Object -First 1).ToString()
+$versionText = Get-PythonVersion
 $versionMatch = [regex]::Match($versionText, "(\d+)\.(\d+)")
 if (-not $versionMatch.Success) {
     throw "Version Python invalide: $versionText"
@@ -125,23 +193,16 @@ if ($major -lt 3 -or ($major -eq 3 -and $minor -lt 11)) {
 }
 Write-Host "Python $major.$minor detecte." -ForegroundColor Green
 
-if (-not (Ensure-Command "uv")) {
-    Write-Host "uv introuvable, installation..." -ForegroundColor Yellow
-    powershell -ExecutionPolicy ByPass -NoProfile -Command "irm https://astral.sh/uv/install.ps1 | iex"
-    $uvBin = Join-Path $env:USERPROFILE ".local\bin"
-    Add-PathIfNeeded -PathToAdd $uvBin
-}
-if (-not (Ensure-Command "uv")) {
-    $cargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
-    Add-PathIfNeeded -PathToAdd $cargoBin
-}
-if (-not (Ensure-Command "uv")) {
-    throw "uv introuvable apres installation."
-}
+Ensure-Uv
 Write-Host "uv detecte." -ForegroundColor Green
 
 Write-Step -Current 2 -Total $stepTotal -Title "Installation des dependances Python"
-uv sync
+$installVision = $false
+if (Ask-YesNo -Prompt "Installer la reconnaissance faciale (face-recognition / dlib) ?" -DefaultNo $true) {
+    Write-Host "Necessite Visual Studio Build Tools (C++) sur Windows." -ForegroundColor DarkGray
+    $installVision = $true
+}
+Invoke-UvSync -WithVision:$installVision
 Write-Host "Dependances installees." -ForegroundColor Green
 
 Write-Step -Current 3 -Total $stepTotal -Title "Configuration LLM principal"
@@ -182,10 +243,23 @@ $livekitApiKey = ""
 $livekitApiSecret = ""
 $deepgramApiKey = ""
 if (Ask-YesNo -Prompt "Activer le pipeline vocal LiveKit ?" -DefaultNo $true) {
-    $livekitUrl = Require-Value -Prompt "LiveKit URL (wss://...)"
-    $livekitApiKey = Require-Value -Prompt "LiveKit API Key" -Secret $true
-    $livekitApiSecret = Require-Value -Prompt "LiveKit API Secret" -Secret $true
-    $deepgramApiKey = Require-Value -Prompt "Deepgram API Key" -Secret $true
+    if (-not (Ensure-Command "livekit-server")) {
+        Write-Host "livekit-server absent." -ForegroundColor Yellow
+        Write-Host "Telecharge livekit-server.exe depuis:" -ForegroundColor Yellow
+        Write-Host "https://github.com/livekit/livekit/releases" -ForegroundColor Yellow
+        Write-Host "Place-le dans un dossier du PATH." -ForegroundColor Yellow
+    }
+    if (Ask-YesNo -Prompt "Utiliser LiveKit Cloud plutot que le serveur local ?" -DefaultNo $true) {
+        $livekitUrl = Require-Value -Prompt "LiveKit URL (wss://...)"
+        $livekitApiKey = Require-Value -Prompt "LiveKit API Key" -Secret $true
+        $livekitApiSecret = Require-Value -Prompt "LiveKit API Secret" -Secret $true
+    } else {
+        $livekitUrl = "ws://localhost:7880"
+        $livekitApiKey = "devkey"
+        $livekitApiSecret = "devsecretdevsecretdevsecretdevsecret"
+        Write-Host "LiveKit local (ws://localhost:7880)" -ForegroundColor Green
+    }
+    $deepgramApiKey = Require-Value -Prompt "Deepgram API Key (STT)" -Secret $true
 }
 
 $aisstreamKey = ""
@@ -196,6 +270,7 @@ if (Ask-YesNo -Prompt "Configurer AISstream ?" -DefaultNo $true) {
 Write-Step -Current 7 -Total $stepTotal -Title "Telechargement des modeles ML"
 if (-not (Test-Path "yolov8n.pt")) {
     uv run python -c "from ultralytics import YOLO; YOLO('yolov8n.pt')"
+    if ($LASTEXITCODE -ne 0) { throw "Telechargement YOLOv8 echoue." }
 }
 
 $piperDir = "models/piper"
@@ -209,12 +284,7 @@ if (-not (Test-Path $piperModel)) {
 }
 
 Write-Step -Current 8 -Total $stepTotal -Title "Generation de l'environnement"
-New-Item -ItemType Directory -Path "memory_data/sessions" -Force | Out-Null
-New-Item -ItemType Directory -Path "memory_data/topics" -Force | Out-Null
-New-Item -ItemType Directory -Path "memory_data/conso" -Force | Out-Null
-New-Item -ItemType Directory -Path "memory_data/initiatives" -Force | Out-Null
-New-Item -ItemType Directory -Path "workspace/projects" -Force | Out-Null
-New-Item -ItemType Directory -Path "vision/faces" -Force | Out-Null
+Ensure-JarvisLayout
 
 if (Test-Path ".env") {
     $stamp = Get-Date -Format "yyyyMMdd_HHmmss"
@@ -226,15 +296,18 @@ if ($serverPort -ne 8000) {
     Write-Host "Port 8000 indisponible, utilisation du port $serverPort." -ForegroundColor Yellow
 }
 
+$faceRecognitionEnabled = if ($installVision) { "true" } else { "false" }
+
 $envContent = @"
 USER_FIRSTNAME=$userFirstname
 LLM_PROVIDER=api
 API_BACKEND=$apiBackend
 ANTHROPIC_API_KEY=$anthropicApiKey
 ANTHROPIC_MODEL=$anthropicModel
+VOICE_ANTHROPIC_MODEL=claude-haiku-4-5-20251001
 OPENAI_API_KEY=$openaiApiKey
 OPENAI_MODEL=$openaiModel
-HOST=0.0.0.0
+HOST=127.0.0.1
 PORT=$serverPort
 ENVIRONMENT=development
 LOG_LEVEL=INFO
@@ -251,6 +324,7 @@ LIVEKIT_API_KEY=$livekitApiKey
 LIVEKIT_API_SECRET=$livekitApiSecret
 DEEPGRAM_API_KEY=$deepgramApiKey
 AISSTREAM_KEY=$aisstreamKey
+FACE_RECOGNITION_ENABLED=$faceRecognitionEnabled
 MISTRAL_API_KEY=
 MISTRAL_MODEL=mistral-large-latest
 OLLAMA_BASE_URL=http://localhost:11434
@@ -263,9 +337,13 @@ Set-Content -Path ".env" -Value $envContent -Encoding UTF8
 Write-Host ""
 Write-Host ("=" * 60) -ForegroundColor Cyan
 Write-Host "Systeme pret." -ForegroundColor Green
-Write-Host "Lancer le serveur: uv run python main.py" -ForegroundColor White
+Write-Host "Installation : .\setup.ps1" -ForegroundColor DarkGray
+Write-Host "Demarrer tout : .\jarvis.ps1 run" -ForegroundColor White
+Write-Host "API seule     : .\jarvis.ps1 api  -> http://localhost:$serverPort/admin" -ForegroundColor White
 if (-not [string]::IsNullOrWhiteSpace($livekitUrl)) {
-    Write-Host "Lancer la voix: uv run python voice_agent.py dev" -ForegroundColor White
+    Write-Host "Voix          : .\jarvis.ps1 voice" -ForegroundColor White
 }
+Write-Host ""
+Write-Host "Reconnaissance faciale : place une photo JPG dans vision_data/faces/" -ForegroundColor DarkGray
 Write-Host ("=" * 60) -ForegroundColor Cyan
 Write-Host ""

--- a/setup.sh
+++ b/setup.sh
@@ -48,7 +48,7 @@ EOF
 
   # uv sync — toutes deps (les deps système doivent déjà être installées)
   if command -v uv > /dev/null 2>&1; then
-    uv sync --frozen --group dev
+    uv sync --frozen --group dev --extra vision
     echo "  ✓ uv sync terminé"
   else
     echo "  ! uv absent du PATH — installer uv avant 'setup.sh --ci'"
@@ -251,7 +251,7 @@ badge_ok "curl"
 # ── STEP 2 — Dépendances Python ──────────────────────────────────
 step "Installation des dépendances Python"
 
-run_task "uv sync (pyproject.toml)" uv sync
+run_task "uv sync (pyproject.toml + vision)" uv sync --extra vision
 badge_info ".venv/ prêt"
 
 # ── STEP 3 — LLM principal ───────────────────────────────────────

--- a/src/jarvis/providers/vision/face_recognizer.py
+++ b/src/jarvis/providers/vision/face_recognizer.py
@@ -1,6 +1,6 @@
 """
 Face recognition avec face_recognition (ageitgey/dlib).
-Compare chaque frame webcam avec les photos de référence dans vision/faces/.
+Compare les frames webcam avec les visages de référence dans vision_data/faces/.
 """
 
 from __future__ import annotations

--- a/uv.lock
+++ b/uv.lock
@@ -1347,7 +1347,6 @@ dependencies = [
     { name = "anthropic" },
     { name = "bambulabs-api" },
     { name = "beautifulsoup4" },
-    { name = "face-recognition" },
     { name = "fastapi" },
     { name = "fastembed" },
     { name = "faster-whisper" },
@@ -1389,6 +1388,9 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+vision = [
+    { name = "face-recognition" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1404,7 +1406,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "bambulabs-api", specifier = ">=2.6.6" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
-    { name = "face-recognition", specifier = ">=1.3.0" },
+    { name = "face-recognition", marker = "extra == 'vision'", specifier = ">=1.3.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastembed", specifier = ">=0.4.0" },
     { name = "faster-whisper", specifier = ">=1.1.0" },
@@ -1442,7 +1444,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "yt-dlp", specifier = ">=2026.3.17" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["vision", "dev"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Contexte

Sous Windows, `uv sync` échouait systématiquement sur la compilation de **dlib** (dépendance transitive de `face-recognition`), faute de Visual Studio Build Tools. Par ailleurs, le README et les scripts d'installation pointaient vers `./jarvis eclosion` — commande **bash uniquement**, inexistante en natif Windows.

## Changements

### Dépendances (`pyproject.toml`)

- `face-recognition` retiré des dépendances obligatoires
- Ajout d'un extra optionnel **`vision`** :

  ```bash
  uv sync                  # install de base (sans dlib)
  uv sync --extra vision   # reconnaissance faciale (nécessite VS C++ sur Windows)
  ```

- `uv.lock` régénéré en conséquence

### CLI Windows (`jarvis.ps1`)

Équivalent PowerShell du script bash `jarvis` :

| Commande | Rôle |
|---|---|
| `.\jarvis.ps1 eclosion` | Lance `setup.ps1` (installation interactive) |
| `.\jarvis.ps1 run` | Démarre LiveKit + API + pipeline vocal |
| `.\jarvis.ps1 api` | Serveur FastAPI seul |
| `.\jarvis.ps1 voice` | Pipeline vocal LiveKit seul |
| `.\jarvis.ps1 livekit` | Serveur LiveKit local |
| `.\jarvis.ps1 doctor` | Diagnostic rapide |

### Setup Windows (`setup.ps1`)

- Mode non-interactif : `.\setup.ps1 -Ci` (aligné sur `setup.sh --ci`)
- Vérification du code retour de `uv sync` (plus de faux « Dépendances installées »)
- Question optionnelle pour installer le extra `vision`
- Dossiers runtime corrigés : `vision_data/faces/` (au lieu de `vision/faces/`)
- LiveKit local par défaut (`ws://localhost:7880` + clés dev), comme sur Linux
- `HOST=127.0.0.1` par défaut + détection automatique d'un port libre
- Instructions de démarrage via `jarvis.ps1`

### Documentation (`README.md`)

- Sections **Installation** et **Démarrage** séparées Linux/macOS / Windows
- Prérequis Windows documentés (Visual Studio Build Tools, `livekit-server.exe`)
- Chemin reconnaissance faciale corrigé : `vision_data/faces/référence.jpg`

### CI / Linux (`setup.sh`, `ci.yml`)

- `uv sync --extra vision` dans la lane complète et le mode `--ci` (comportement inchangé côté Linux)

## Test plan

- [ ] **Windows — install de base** : `.\jarvis.ps1 eclosion`, répondre **non** à la reconnaissance faciale → `uv sync` réussit sans Visual Studio
- [ ] **Windows — démarrage** : `.\jarvis.ps1 api` → UI accessible sur `http://localhost:<PORT>/admin`
- [ ] **Windows — run complet** : `livekit-server.exe` dans le PATH → `.\jarvis.ps1 run` démarre les 3 processus
- [ ] **Linux — régression** : `bash setup.sh --ci` puis `uv sync --extra vision` → suite CI inchangée
- [ ] **Vision optionnelle** : `uv sync --extra vision` + `FACE_RECOGNITION_ENABLED=true` → reconnaissance faciale active (si dlib compilé)

## Notes

- La suppression locale de `.env.example` n'est **pas** incluse dans cette PR
- Pour activer la reconnaissance faciale sous Windows après coup :

  ```powershell
  # Installer Visual Studio Build Tools (workload « Développement Desktop en C++ »)
  uv sync --extra vision
  # Puis dans .env : FACE_RECOGNITION_ENABLED=true
  ```
