### PR TITLE
feat(setup): bundle offline et assistant web de configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         # Routes byte-identiques à la baseline — gate inchangé depuis B.
         # Skip si le projet n'est pas installé (ce qui est le cas ici).
         run: |
-          uv sync --frozen --group dev
+          uv sync --frozen --group dev --extra vision
           uv run python scripts/migration/snapshot_routes.py > /tmp/routes.now.txt
           diff scripts/migration/routes.baseline.txt /tmp/routes.now.txt
 
@@ -108,7 +108,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies (full)
-        run: uv sync --frozen --group dev
+        run: uv sync --frozen --group dev --extra vision
 
       - name: Pytest (suite complète, incl. integration)
         run: uv run pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ config/spotify_token.json
 # ── Modèles ML (binaires lourds — à télécharger via install.sh)
 yolov8n.pt
 models/
+bundle/
 
 # ── Données personnelles de Jarvis ───────────────────────────
 memory_data/

--- a/README.md
+++ b/README.md
@@ -73,31 +73,74 @@ suite complète, incl. les ~28 tests `@pytest.mark.integration`.
 
 ## Prérequis
 
+Deux profils distincts :
+
+### Utilisateur final (Windows, release offline)
+
+Tu télécharges une archive **avec le dossier `bundle/` déjà inclus**. Tu n'as **pas** besoin d'installer Python, uv, cmake, Visual C++ ni LiveKit sur ta machine.
+
+| Requis | Notes |
+|---|---|
+| Windows 10/11 | |
+| PowerShell | Pour lancer `jarvis.ps1` |
+| Navigateur web | Configuration sur `http://127.0.0.1:8765/setup` |
+| Clés API (LLM, etc.) | OpenAI ou Anthropic au minimum — saisies dans l'assistant web |
+
+Le bundle embarque déjà : Python 3.11, les dépendances Python, les modèles ML (YOLO, Piper), `livekit-server` et `uv.exe`.
+
+### Développeur — construire le bundle
+
+Une seule fois, **avec réseau**, pour produire `bundle/` (release ou usage local sans clone vide).
+
 | Outil | Version | Notes |
 |---|---|---|
-| Python | 3.11+ | |
-| [uv](https://docs.astral.sh/uv/) | latest | Gestionnaire de paquets |
-| [LiveKit](https://livekit.io/) | cloud ou self-hosted | Pipeline vocal uniquement |
-| Docker | optionnel | Requis par la fonctionnalité code-agent |
-| `nowplaying-cli` | optionnel (macOS) | Lecture locale « now playing » — `brew install nowplaying-cli` |
+| [uv](https://docs.astral.sh/uv/) | latest | Télécharge Python 3.11 dans `bundle/.venv` |
+| Réseau | | Téléchargement des deps, modèles et binaires |
 
-**Windows (supplémentaire) :**
+Python système et LiveKit **ne sont pas requis** : le script de build les intègre au bundle.
+
+### Modules optionnels (hors install de base)
 
 | Outil | Notes |
 |---|---|
-| Bundle offline | Release ou `scripts/release/build_bundle.ps1` — embarque Python, deps, modèles (aucun VS C++ requis pour l'install de base) |
-| [livekit-server](https://github.com/livekit/livekit/releases) | Inclus dans le bundle ; requis pour le mode vocal local |
+| [LiveKit Cloud](https://livekit.io/) | Alternative au serveur local (déjà dans le bundle) |
+| Docker | Code-agent, Skill Lab sandbox |
+| `uv sync --extra vision` | Reconnaissance faciale (`dlib`) — peut exiger des outils C++ selon l'OS |
+| `nowplaying-cli` | macOS uniquement — lecture locale « now playing » |
 
 ---
 
 ## Installation
 
-L'installation se fait en **deux phases** :
+### Parcours A — Utilisateur final (Windows)
 
-1. **Bundle offline** (une seule fois, avec réseau) — embarque Python, les dépendances, les modèles ML et `livekit-server`
-2. **Configuration web** (locale, sans téléchargement) — assistant sur `http://127.0.0.1:8765/setup`
+**Tu as reçu une release ou une archive avec `bundle/`** — aucun téléchargement à l'installation.
 
-### Étape 1 — Préparer le bundle
+```powershell
+# 1. Décompresser l'archive, puis ouvrir le dossier du projet
+cd jarvis-OS
+
+# 2. Configuration web (navigateur, sans prompt terminal)
+.\jarvis.ps1 setup
+
+# 3. Démarrage
+.\jarvis.ps1 run
+```
+
+L'assistant web configure l'identité, les clés API, les modules optionnels et la photo de référence. Une fois terminé, l'interface admin est sur `http://127.0.0.1:<PORT>/admin` (`PORT` dans `.env`, souvent `8000`).
+
+| Commande | Rôle |
+|---|---|
+| `.\jarvis.ps1 setup` | Assistant de configuration (`:8765`) |
+| `.\jarvis.ps1 run` | LiveKit + API + pipeline vocal |
+| `.\jarvis.ps1 api` | Serveur FastAPI seul |
+| `.\jarvis.ps1 doctor` | Diagnostic rapide |
+
+> **Sans `bundle/`** : ce parcours ne fonctionne pas. Passe au parcours B ou télécharge une release offline.
+
+### Parcours B — Construire le bundle (développeur)
+
+À faire **une fois**, avec réseau, avant de distribuer ou d'utiliser le parcours A.
 
 **Windows :**
 
@@ -105,6 +148,7 @@ L'installation se fait en **deux phases** :
 git clone https://github.com/Grominet95/jarvis-OS.git
 cd jarvis-OS
 .\scripts\release\build_bundle.ps1
+.\jarvis.ps1 setup
 ```
 
 **Linux / macOS :**
@@ -113,27 +157,26 @@ cd jarvis-OS
 git clone https://github.com/Grominet95/jarvis-OS.git
 cd jarvis-OS
 bash scripts/release/build_bundle.sh
-```
-
-> Utilisateurs finaux : télécharge une **release offline** (archive avec `bundle/` inclus) — pas de Python, C++ ou cmake à installer.
-
-### Étape 2 — Configuration web locale
-
-**Windows :**
-
-```powershell
-.\jarvis.ps1 setup
-```
-
-**Linux / macOS :**
-
-```bash
 ./jarvis eclosion
 ```
 
-Un navigateur s'ouvre sur l'assistant (identité, clés API, modules optionnels, photo de référence). Aucun prompt terminal.
+Le script crée `bundle/` : `.venv`, modèles, `livekit-server`, `manifest.json`. Ensuite, la configuration et le démarrage suivent le même flux que le parcours A (sans nouveau téléchargement).
 
-### Démarrage
+### Parcours C — Développement sans bundle (Linux / macOS / Windows)
+
+Installation classique avec uv sur la machine (téléchargements à chaque `uv sync`) :
+
+```bash
+uv sync
+# reconnaissance faciale optionnelle :
+uv sync --extra vision
+```
+
+Puis `./jarvis eclosion` ou `.\jarvis.ps1 setup` selon l'OS.
+
+---
+
+### Démarrage (rappel)
 
 **Windows :**
 
@@ -157,7 +200,7 @@ Les deux peuvent tourner simultanément : le voice agent délègue au gateway du
 
 ## Configuration
 
-Tout est configuré pendant l'éclosion. Pour modifier une clé après coup, édite `.env` à la racine du projet.
+Tout est configuré via l'assistant web (`.\jarvis.ps1 setup` ou `./jarvis eclosion`). Pour modifier une clé après coup, édite `.env` à la racine du projet.
 
 **Intégrations Google (Gmail / Calendar) :** place ton `credentials.json` issu de Google Cloud Console dans `config/google_credentials.json`, puis démarre Jarvis — il ouvrira le flux d'authentification OAuth et sauvegardera les tokens en local (ils sont gitignorés).
 

--- a/README.md
+++ b/README.md
@@ -81,36 +81,75 @@ suite complète, incl. les ~28 tests `@pytest.mark.integration`.
 | Docker | optionnel | Requis par la fonctionnalité code-agent |
 | `nowplaying-cli` | optionnel (macOS) | Lecture locale « now playing » — `brew install nowplaying-cli` |
 
+**Windows (supplémentaire) :**
+
+| Outil | Notes |
+|---|---|
+| Bundle offline | Release ou `scripts/release/build_bundle.ps1` — embarque Python, deps, modèles (aucun VS C++ requis pour l'install de base) |
+| [livekit-server](https://github.com/livekit/livekit/releases) | Inclus dans le bundle ; requis pour le mode vocal local |
+
 ---
 
 ## Installation
 
+L'installation se fait en **deux phases** :
+
+1. **Bundle offline** (une seule fois, avec réseau) — embarque Python, les dépendances, les modèles ML et `livekit-server`
+2. **Configuration web** (locale, sans téléchargement) — assistant sur `http://127.0.0.1:8765/setup`
+
+### Étape 1 — Préparer le bundle
+
+**Windows :**
+
+```powershell
+git clone https://github.com/Grominet95/jarvis-OS.git
+cd jarvis-OS
+.\scripts\release\build_bundle.ps1
+```
+
+**Linux / macOS :**
+
 ```bash
 git clone https://github.com/Grominet95/jarvis-OS.git
 cd jarvis-OS
+bash scripts/release/build_bundle.sh
+```
+
+> Utilisateurs finaux : télécharge une **release offline** (archive avec `bundle/` inclus) — pas de Python, C++ ou cmake à installer.
+
+### Étape 2 — Configuration web locale
+
+**Windows :**
+
+```powershell
+.\jarvis.ps1 setup
+```
+
+**Linux / macOS :**
+
+```bash
 ./jarvis eclosion
 ```
 
-Le wizard interactif :
-1. Vérifie Python 3.11+ et installe `uv` si absent
-2. Installe toutes les dépendances Python (`pyproject.toml`)
-3. Demande ta clé API Anthropic (seule clé obligatoire)
-4. Demande ton prénom (affiché lors du scan biométrique)
-5. Configure ta localisation pour le moteur proactif
-6. Propose les modules optionnels (ElevenLabs, LiveKit, AISstream)
-7. Télécharge les modèles ML (YOLOv8n, Piper TTS)
-8. Génère le `.env` et installe la commande `jarvis` globalement
+Un navigateur s'ouvre sur l'assistant (identité, clés API, modules optionnels, photo de référence). Aucun prompt terminal.
 
-> La première fois, utilise `./jarvis eclosion`. Le wizard installe ensuite la commande globalement, tu peux utiliser `jarvis` depuis n'importe où.
+### Démarrage
 
----
+**Windows :**
 
-## Démarrage
+```powershell
+.\jarvis.ps1 run
+.\jarvis.ps1 api
+```
+
+**Linux / macOS :**
 
 ```bash
-jarvis run      # serveur principal  →  localhost:8000/admin
-jarvis voice    # pipeline vocal LiveKit (optionnel)
+jarvis run
+jarvis voice
 ```
+
+Le port par défaut est `8000` ; l'assistant en choisit un autre si occupé (vérifie `PORT` dans `.env`).
 
 Les deux peuvent tourner simultanément : le voice agent délègue au gateway du serveur principal, donc ils partagent la même session, la même mémoire et les mêmes outils.
 
@@ -125,10 +164,17 @@ Tout est configuré pendant l'éclosion. Pour modifier une clé après coup, éd
 **Reconnaissance faciale (séquence Wake Up) :** pour que le scan biométrique te reconnaisse, place une photo de toi (format JPG, visage bien visible, bonne luminosité) dans :
 
 ```
-vision/faces/référence.jpg
+vision_data/faces/reference.jpg
 ```
 
-Sans cette photo, la séquence de scan s'exécute mais retourne toujours "identité non reconnue". Le dossier `vision/faces/` est gitignorés, ta photo ne sera jamais commitée.
+Sans cette photo, la séquence de scan s'exécute mais retourne toujours "identité non reconnue". Le dossier `vision_data/faces/` est gitignoré. L'upload est possible depuis l'assistant de configuration (`/setup`).
+
+Pour activer la reconnaissance faciale :
+
+```bash
+uv sync --extra vision
+# FACE_RECOGNITION_ENABLED=true dans .env
+```
 
 ---
 

--- a/jarvis.ps1
+++ b/jarvis.ps1
@@ -139,7 +139,7 @@ function Invoke-JarvisRun {
     if (Wait-HttpOk -Url "http://127.0.0.1:7880/" -TimeoutSeconds 40) {
         Write-Host "  LiveKit  ws://localhost:7880" -ForegroundColor Green
     } else {
-        Write-Host "  LiveKit  timeout — voir $lkLog" -ForegroundColor Red
+        Write-Host "  LiveKit  timeout - voir $lkLog" -ForegroundColor Red
         foreach ($p in $procs) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
         exit 1
     }
@@ -155,7 +155,7 @@ function Invoke-JarvisRun {
     if (Wait-HttpOk -Url "http://127.0.0.1:$apiPort/health" -TimeoutSeconds 90) {
         Write-Host "  API      http://localhost:$apiPort" -ForegroundColor Green
     } else {
-        Write-Host "  API      timeout — voir $apiLog" -ForegroundColor Red
+        Write-Host "  API      timeout - voir $apiLog" -ForegroundColor Red
         foreach ($p in $procs) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
         exit 1
     }
@@ -175,7 +175,7 @@ function Invoke-JarvisRun {
     if (Wait-LogMatch -LogPath $voiceLog -Pattern "Jarvis vocal prêt" -TimeoutSeconds 90) {
         Write-Host "  Vocal    pret" -ForegroundColor Green
     } else {
-        Write-Host "  Vocal    prechauffement long — voir $voiceLog" -ForegroundColor Yellow
+        Write-Host "  Vocal    prechauffement long - voir $voiceLog" -ForegroundColor Yellow
     }
 
     Write-Host ""

--- a/jarvis.ps1
+++ b/jarvis.ps1
@@ -1,0 +1,253 @@
+param(
+    [Parameter(Position = 0)]
+    [string]$Command = ""
+)
+
+$ErrorActionPreference = "Stop"
+Set-Location $PSScriptRoot
+
+function Get-JarvisPython {
+    $bundlePy = Join-Path $PSScriptRoot "bundle\.venv\Scripts\python.exe"
+    $venvPy = Join-Path $PSScriptRoot ".venv\Scripts\python.exe"
+    if (Test-Path $bundlePy) { return $bundlePy }
+    if (Test-Path $venvPy) { return $venvPy }
+    return $null
+}
+
+function Invoke-JarvisPython {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$PyArgs)
+    $python = Get-JarvisPython
+    if ($python) {
+        & $python @PyArgs
+        return
+    }
+    & uv run python @PyArgs
+}
+
+function Get-LivekitCommand {
+    $bundled = Join-Path $PSScriptRoot "bundle\bin\livekit-server.exe"
+    if (Test-Path $bundled) { return $bundled }
+    return "livekit-server"
+}
+
+function Get-DotEnvValue {
+    param(
+        [string]$Key,
+        [string]$Default = ""
+    )
+    if (-not (Test-Path ".env")) { return $Default }
+    foreach ($line in Get-Content ".env" -Encoding UTF8) {
+        $trimmed = $line.Trim()
+        if ($trimmed -eq "" -or $trimmed.StartsWith("#")) { continue }
+        $parts = $trimmed -split "=", 2
+        if ($parts.Count -eq 2 -and $parts[0].Trim() -eq $Key) {
+            return $parts[1].Trim()
+        }
+    }
+    return $Default
+}
+
+function Stop-PortListeners {
+    param([int[]]$Ports)
+    foreach ($port in $Ports) {
+        $connections = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue
+        foreach ($conn in $connections) {
+            Stop-Process -Id $conn.OwningProcess -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+function Wait-HttpOk {
+    param(
+        [string]$Url,
+        [int]$TimeoutSeconds = 60
+    )
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 2
+            if ($response.StatusCode -lt 400) { return $true }
+        } catch {
+            Start-Sleep -Milliseconds 300
+        }
+    }
+    return $false
+}
+
+function Wait-LogMatch {
+    param(
+        [string]$LogPath,
+        [string]$Pattern,
+        [int]$TimeoutSeconds = 90
+    )
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-Path $LogPath) {
+            $content = Get-Content $LogPath -Raw -ErrorAction SilentlyContinue
+            if ($content -and ($content -match $Pattern)) { return $true }
+        }
+        Start-Sleep -Milliseconds 300
+    }
+    return $false
+}
+
+function Start-BackgroundProcess {
+    param(
+        [string]$CommandLine,
+        [string]$LogPath
+    )
+    $wrapped = "$CommandLine > `"$LogPath`" 2>&1"
+    return Start-Process -FilePath "cmd.exe" `
+        -ArgumentList @("/c", $wrapped) `
+        -WorkingDirectory $PSScriptRoot `
+        -WindowStyle Hidden `
+        -PassThru
+}
+
+function Invoke-JarvisRun {
+    $apiPort = [int](Get-DotEnvValue -Key "PORT" -Default "8000")
+    $logDir = Join-Path $env:TEMP "jarvis"
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+    $lkLog = Join-Path $logDir "livekit.log"
+    $apiLog = Join-Path $logDir "api.log"
+    $voiceLog = Join-Path $logDir "voice.log"
+    foreach ($log in @($lkLog, $apiLog, $voiceLog)) {
+        "" | Set-Content $log
+    }
+
+    Write-Host ""
+    Write-Host "  J · A · R · V · I · S" -ForegroundColor Cyan
+    Write-Host "  activation systeme" -ForegroundColor DarkGray
+    Write-Host ""
+
+    Stop-Process -Name "livekit-server" -Force -ErrorAction SilentlyContinue
+    Get-CimInstance Win32_Process -Filter "Name = 'python.exe'" -ErrorAction SilentlyContinue |
+        Where-Object { $_.CommandLine -match "jarvis\.(app|interfaces\.voice\.agent)" } |
+        ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+    Stop-PortListeners -Ports @(7880, 7881, $apiPort)
+    Start-Sleep -Milliseconds 300
+
+    $procs = @()
+
+    Write-Host "  LiveKit  demarrage..." -ForegroundColor Yellow
+    $lkCmd = Get-LivekitCommand
+    $lkProc = Start-BackgroundProcess `
+        -CommandLine "$lkCmd --dev --node-ip 127.0.0.1 --keys `"devkey: devsecretdevsecretdevsecretdevsecret`"" `
+        -LogPath $lkLog
+    $procs += $lkProc
+
+    if (Wait-HttpOk -Url "http://127.0.0.1:7880/" -TimeoutSeconds 40) {
+        Write-Host "  LiveKit  ws://localhost:7880" -ForegroundColor Green
+    } else {
+        Write-Host "  LiveKit  timeout — voir $lkLog" -ForegroundColor Red
+        foreach ($p in $procs) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
+        exit 1
+    }
+
+    Write-Host "  API      demarrage..." -ForegroundColor Yellow
+    $python = Get-JarvisPython
+    $apiCmd = if ($python) { "`"$python`" -m jarvis.app" } else { "uv run python -m jarvis.app" }
+    $apiProc = Start-BackgroundProcess `
+        -CommandLine $apiCmd `
+        -LogPath $apiLog
+    $procs += $apiProc
+
+    if (Wait-HttpOk -Url "http://127.0.0.1:$apiPort/health" -TimeoutSeconds 90) {
+        Write-Host "  API      http://localhost:$apiPort" -ForegroundColor Green
+    } else {
+        Write-Host "  API      timeout — voir $apiLog" -ForegroundColor Red
+        foreach ($p in $procs) { Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue }
+        exit 1
+    }
+
+    Write-Host "  Vocal    prechauffement (~10s)..." -ForegroundColor Yellow
+    $python = Get-JarvisPython
+    $voiceCmd = if ($python) {
+        "set PYTHONWARNINGS=ignore&& `"$python`" -m jarvis.interfaces.voice.agent dev --log-level info"
+    } else {
+        "set PYTHONWARNINGS=ignore&& uv run python -m jarvis.interfaces.voice.agent dev --log-level info"
+    }
+    $voiceProc = Start-BackgroundProcess `
+        -CommandLine $voiceCmd `
+        -LogPath $voiceLog
+    $procs += $voiceProc
+
+    if (Wait-LogMatch -LogPath $voiceLog -Pattern "Jarvis vocal prêt" -TimeoutSeconds 90) {
+        Write-Host "  Vocal    pret" -ForegroundColor Green
+    } else {
+        Write-Host "  Vocal    prechauffement long — voir $voiceLog" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+    Write-Host "  Jarvis pret" -ForegroundColor Green
+    Write-Host "  -> http://localhost:$apiPort/admin" -ForegroundColor White
+    Write-Host "  -> clique sur le micro pour le mode vocal" -ForegroundColor DarkGray
+    Write-Host "  -> Ctrl-C pour arreter" -ForegroundColor DarkGray
+    Write-Host "  Logs : $logDir" -ForegroundColor DarkGray
+    Write-Host ""
+
+    try {
+        Wait-Process -Id ($procs | ForEach-Object { $_.Id })
+    } finally {
+        Write-Host ""
+        Write-Host "  arret en cours..." -ForegroundColor DarkGray
+        foreach ($p in $procs) {
+            Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
+        }
+        Stop-Process -Name "livekit-server" -Force -ErrorAction SilentlyContinue
+        Write-Host "  Jarvis arrete" -ForegroundColor DarkGray
+    }
+}
+
+switch ($Command.ToLowerInvariant()) {
+    { $_ -in @("eclosion", "setup") } {
+        & "$PSScriptRoot\setup.ps1"
+    }
+    "api" {
+        Invoke-JarvisPython "-m" "jarvis.app"
+    }
+    "voice" {
+        Invoke-JarvisPython "-m" "jarvis.interfaces.voice.agent" "dev"
+    }
+    "livekit" {
+        $lk = Get-LivekitCommand
+        & $lk --dev --node-ip 127.0.0.1 --keys "devkey: devsecretdevsecretdevsecretdevsecret"
+    }
+    { $_ -in @("run", "start") } {
+        Invoke-JarvisRun
+    }
+    "doctor" {
+        $port = Get-DotEnvValue -Key "PORT" -Default "8000"
+        try {
+            $null = Invoke-WebRequest -Uri "http://localhost:$port/health" -UseBasicParsing -TimeoutSec 3
+            Write-Host "  FastAPI  en ligne (:$port)" -ForegroundColor Green
+        } catch {
+            Write-Host "  FastAPI  eteint (port $port)" -ForegroundColor Yellow
+        }
+        if (Get-Command livekit-server -ErrorAction SilentlyContinue) {
+            Write-Host "  LiveKit  binaire installe" -ForegroundColor Green
+        } else {
+            Write-Host "  LiveKit  binaire absent" -ForegroundColor Yellow
+            Write-Host "  https://github.com/livekit/livekit/releases" -ForegroundColor DarkGray
+        }
+        if (Get-Command uv -ErrorAction SilentlyContinue) {
+            Write-Host "  uv       installe" -ForegroundColor Green
+        } else {
+            Write-Host "  uv       absent" -ForegroundColor Red
+        }
+    }
+    default {
+        Write-Host ""
+        Write-Host "  Usage : .\jarvis.ps1 <commande>"
+        Write-Host ""
+        Write-Host "    run        demarre tout (LiveKit + API + Voice)"
+        Write-Host "    api        serveur FastAPI uniquement"
+        Write-Host "    voice      pipeline vocal LiveKit"
+        Write-Host "    livekit    serveur LiveKit local"
+        Write-Host "    setup      assistant web de configuration"
+        Write-Host "    eclosion   alias de setup"
+        Write-Host "    doctor     diagnostic rapide"
+        Write-Host ""
+        exit 1
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
     # Web framework
     "fastapi>=0.115.0",
+    "python-multipart>=0.0.9",
     "uvicorn[standard]>=0.32.0",
     # Config
     "pydantic>=2.9.0",
@@ -42,7 +43,6 @@ dependencies = [
     "livekit-plugins-elevenlabs>=1.5.1",
     "livekit-api>=1.1.0",
     "sounddevice>=0.5.5",
-    "face-recognition>=1.3.0",
     "bambulabs-api>=2.6.6",
     "hidapi>=0.15.0",
     "pyusb>=1.3.1",
@@ -53,6 +53,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+vision = [
+    "face-recognition>=1.3.0",
+]
 dev = [
     "pytest>=8.3.0",
     "pytest-asyncio>=0.24.0",

--- a/scripts/release/build_bundle.ps1
+++ b/scripts/release/build_bundle.ps1
@@ -8,8 +8,8 @@ $modelsDir = Join-Path $bundleRoot "models"
 $piperDir = Join-Path $modelsDir "piper"
 $binDir = Join-Path $bundleRoot "bin"
 
-Write-Host "Jarvis — build offline bundle (Windows)" -ForegroundColor Cyan
-Write-Host "Ce script telecharge une fois Python, les deps et les modeles." -ForegroundColor DarkGray
+Write-Host "Jarvis - build offline bundle (Windows)" -ForegroundColor Cyan
+Write-Host "This script downloads Python, deps and models once." -ForegroundColor DarkGray
 Write-Host ""
 
 function Ensure-Command {
@@ -18,13 +18,15 @@ function Ensure-Command {
 }
 
 if (-not (Ensure-Command "uv")) {
-    Write-Host "Installation de uv..." -ForegroundColor Yellow
+    Write-Host "Installing uv..." -ForegroundColor Yellow
     powershell -ExecutionPolicy ByPass -NoProfile -Command "irm https://astral.sh/uv/install.ps1 | iex"
     $uvBin = Join-Path $env:USERPROFILE ".local\bin"
-    if ($env:PATH -notlike "*$uvBin*") { $env:PATH = "$uvBin;$env:PATH" }
+    if ($env:PATH -notlike "*$uvBin*") {
+        $env:PATH = "$uvBin;$env:PATH"
+    }
 }
 if (-not (Ensure-Command "uv")) {
-    throw "uv introuvable."
+    throw "uv not found."
 }
 
 New-Item -ItemType Directory -Path $bundleRoot, $modelsDir, $piperDir, $binDir -Force | Out-Null
@@ -36,9 +38,13 @@ if (Test-Path $venvPath) {
 uv venv $venvPath --python 3.11
 uv sync --python $venvPath
 if ($LASTEXITCODE -ne 0) { throw "uv sync failed." }
+uv pip install --python $venvPath -e .
+if ($LASTEXITCODE -ne 0) { throw "jarvis package install failed." }
 
 $bundlePython = Join-Path $venvPath "Scripts\python.exe"
 if (-not (Test-Path $bundlePython)) { throw "bundle python missing." }
+& $bundlePython -c "import jarvis.setup_app"
+if ($LASTEXITCODE -ne 0) { throw "jarvis.setup_app not importable in bundle venv." }
 
 Write-Host "[2/5] Copy uv binary" -ForegroundColor Cyan
 $uvExe = (Get-Command uv).Source
@@ -61,14 +67,27 @@ if (-not (Test-Path $piperOnnx)) {
 Write-Host "[4/5] Download livekit-server" -ForegroundColor Cyan
 $lkTarget = Join-Path $binDir "livekit-server.exe"
 if (-not (Test-Path $lkTarget)) {
-    $release = "https://github.com/livekit/livekit/releases/latest/download/livekit-server_windows_amd64.zip"
-    $zipPath = Join-Path $env:TEMP "livekit-server.zip"
-    curl.exe -L --silent -o $zipPath $release
-    Expand-Archive -Path $zipPath -DestinationPath $binDir -Force
-    $extracted = Get-ChildItem $binDir -Filter "livekit-server*.exe" | Select-Object -First 1
-    if ($extracted) {
-        Move-Item $extracted.FullName $lkTarget -Force
+    $release = Invoke-RestMethod -Uri "https://api.github.com/repos/livekit/livekit/releases/latest" -Headers @{ "User-Agent" = "jarvis-bundle" }
+    $asset = $release.assets | Where-Object { $_.name -match '^livekit_.*_windows_amd64\.zip$' } | Select-Object -First 1
+    if (-not $asset) {
+        throw "livekit windows asset not found in latest release."
     }
+    $zipPath = Join-Path $env:TEMP "livekit-server.zip"
+    if (Test-Path $zipPath) { Remove-Item $zipPath -Force }
+    curl.exe -fL --retry 3 -o $zipPath $asset.browser_download_url
+    if ($LASTEXITCODE -ne 0) { throw "livekit download failed." }
+    $zipSize = (Get-Item $zipPath).Length
+    if ($zipSize -lt 1000000) { throw "livekit zip too small ($zipSize bytes), download likely corrupted." }
+    $extractDir = Join-Path $env:TEMP "livekit-extract"
+    if (Test-Path $extractDir) { Remove-Item $extractDir -Recurse -Force }
+    New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+    tar -xf $zipPath -C $extractDir
+    if ($LASTEXITCODE -ne 0) { throw "livekit zip extraction failed." }
+    $extracted = Get-ChildItem $extractDir -Filter "livekit-server.exe" -Recurse | Select-Object -First 1
+    if (-not $extracted) { throw "livekit-server.exe not found in archive." }
+    Copy-Item $extracted.FullName $lkTarget -Force
+    Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+    Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 Write-Host "[5/5] Write manifest" -ForegroundColor Cyan
@@ -87,8 +106,10 @@ $manifest = @{
         livekit = "bin/livekit-server.exe"
     }
 } | ConvertTo-Json -Depth 5
-Set-Content -Path (Join-Path $bundleRoot "manifest.json") -Value $manifest -Encoding UTF8
+$manifestPath = Join-Path $bundleRoot "manifest.json"
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+[System.IO.File]::WriteAllText($manifestPath, $manifest, $utf8NoBom)
 
 Write-Host ""
 Write-Host "Bundle ready: $bundleRoot" -ForegroundColor Green
-Write-Host "Next: .\jarvis.ps1 eclosion" -ForegroundColor White
+Write-Host 'Next: .\jarvis.ps1 setup' -ForegroundColor White

--- a/scripts/release/build_bundle.ps1
+++ b/scripts/release/build_bundle.ps1
@@ -1,0 +1,94 @@
+$ErrorActionPreference = "Stop"
+Set-Location $PSScriptRoot
+Set-Location ..\..
+
+$bundleRoot = Join-Path (Get-Location) "bundle"
+$venvPath = Join-Path $bundleRoot ".venv"
+$modelsDir = Join-Path $bundleRoot "models"
+$piperDir = Join-Path $modelsDir "piper"
+$binDir = Join-Path $bundleRoot "bin"
+
+Write-Host "Jarvis — build offline bundle (Windows)" -ForegroundColor Cyan
+Write-Host "Ce script telecharge une fois Python, les deps et les modeles." -ForegroundColor DarkGray
+Write-Host ""
+
+function Ensure-Command {
+    param([string]$Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+if (-not (Ensure-Command "uv")) {
+    Write-Host "Installation de uv..." -ForegroundColor Yellow
+    powershell -ExecutionPolicy ByPass -NoProfile -Command "irm https://astral.sh/uv/install.ps1 | iex"
+    $uvBin = Join-Path $env:USERPROFILE ".local\bin"
+    if ($env:PATH -notlike "*$uvBin*") { $env:PATH = "$uvBin;$env:PATH" }
+}
+if (-not (Ensure-Command "uv")) {
+    throw "uv introuvable."
+}
+
+New-Item -ItemType Directory -Path $bundleRoot, $modelsDir, $piperDir, $binDir -Force | Out-Null
+
+Write-Host "[1/5] Sync Python env into bundle/.venv" -ForegroundColor Cyan
+if (Test-Path $venvPath) {
+    Remove-Item -Recurse -Force $venvPath
+}
+uv venv $venvPath --python 3.11
+uv sync --python $venvPath
+if ($LASTEXITCODE -ne 0) { throw "uv sync failed." }
+
+$bundlePython = Join-Path $venvPath "Scripts\python.exe"
+if (-not (Test-Path $bundlePython)) { throw "bundle python missing." }
+
+Write-Host "[2/5] Copy uv binary" -ForegroundColor Cyan
+$uvExe = (Get-Command uv).Source
+Copy-Item $uvExe (Join-Path $binDir "uv.exe") -Force
+
+Write-Host "[3/5] Download ML models" -ForegroundColor Cyan
+if (-not (Test-Path "yolov8n.pt")) {
+    & $bundlePython -c "from ultralytics import YOLO; YOLO('yolov8n.pt')"
+}
+Copy-Item "yolov8n.pt" (Join-Path $modelsDir "yolov8n.pt") -Force
+
+$piperOnnx = Join-Path $piperDir "fr_FR-upmc-medium.onnx"
+$piperJson = "$piperOnnx.json"
+if (-not (Test-Path $piperOnnx)) {
+    $baseUrl = "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/fr/fr_FR/upmc/medium"
+    curl.exe -L --silent -o $piperOnnx "$baseUrl/fr_FR-upmc-medium.onnx"
+    curl.exe -L --silent -o $piperJson "$baseUrl/fr_FR-upmc-medium.onnx.json"
+}
+
+Write-Host "[4/5] Download livekit-server" -ForegroundColor Cyan
+$lkTarget = Join-Path $binDir "livekit-server.exe"
+if (-not (Test-Path $lkTarget)) {
+    $release = "https://github.com/livekit/livekit/releases/latest/download/livekit-server_windows_amd64.zip"
+    $zipPath = Join-Path $env:TEMP "livekit-server.zip"
+    curl.exe -L --silent -o $zipPath $release
+    Expand-Archive -Path $zipPath -DestinationPath $binDir -Force
+    $extracted = Get-ChildItem $binDir -Filter "livekit-server*.exe" | Select-Object -First 1
+    if ($extracted) {
+        Move-Item $extracted.FullName $lkTarget -Force
+    }
+}
+
+Write-Host "[5/5] Write manifest" -ForegroundColor Cyan
+$manifest = @{
+    version = "1"
+    platform = "windows"
+    python = "3.11"
+    venv = ".venv"
+    models = @{
+        yolo = "models/yolov8n.pt"
+        piper_onnx = "models/piper/fr_FR-upmc-medium.onnx"
+        piper_json = "models/piper/fr_FR-upmc-medium.onnx.json"
+    }
+    bin = @{
+        uv = "bin/uv.exe"
+        livekit = "bin/livekit-server.exe"
+    }
+} | ConvertTo-Json -Depth 5
+Set-Content -Path (Join-Path $bundleRoot "manifest.json") -Value $manifest -Encoding UTF8
+
+Write-Host ""
+Write-Host "Bundle ready: $bundleRoot" -ForegroundColor Green
+Write-Host "Next: .\jarvis.ps1 eclosion" -ForegroundColor White

--- a/scripts/release/build_bundle.sh
+++ b/scripts/release/build_bundle.sh
@@ -25,12 +25,14 @@ echo "[1/5] Sync Python env into bundle/.venv"
 rm -rf "$VENV_PATH"
 uv venv "$VENV_PATH" --python 3.11
 uv sync --python "$VENV_PATH" --extra vision
+uv pip install --python "$VENV_PATH" -e .
 
 BUNDLE_PYTHON="$VENV_PATH/bin/python"
 if [[ ! -x "$BUNDLE_PYTHON" ]]; then
   echo "bundle python missing"
   exit 1
 fi
+"$BUNDLE_PYTHON" -c "import jarvis.setup_app"
 
 echo "[2/5] Copy uv binary"
 cp "$(command -v uv)" "$BIN_DIR/uv"
@@ -55,29 +57,42 @@ OS="$(uname -s)"
 ARCH="$(uname -m)"
 LK_TARGET="$BIN_DIR/livekit-server"
 if [[ ! -x "$LK_TARGET" ]]; then
+  RELEASE_JSON="$(curl -fsSL -H "User-Agent: jarvis-bundle" "https://api.github.com/repos/livekit/livekit/releases/latest")"
   case "$OS" in
     Darwin)
       if [[ "$ARCH" == "arm64" ]]; then
-        URL="https://github.com/livekit/livekit/releases/latest/download/livekit-server_darwin_arm64.zip"
+        PATTERN='livekit_.*_darwin_arm64\.tar\.gz'
       else
-        URL="https://github.com/livekit/livekit/releases/latest/download/livekit-server_darwin_amd64.zip"
+        PATTERN='livekit_.*_darwin_amd64\.tar\.gz'
       fi
       ;;
     Linux)
-      URL="https://github.com/livekit/livekit/releases/latest/download/livekit-server_linux_amd64.zip"
+      if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+        PATTERN='livekit_.*_linux_arm64\.tar\.gz'
+      else
+        PATTERN='livekit_.*_linux_amd64\.tar\.gz'
+      fi
       ;;
     *)
       echo "Unsupported OS for bundled livekit-server"
-      URL=""
+      PATTERN=""
       ;;
   esac
-  if [[ -n "$URL" ]]; then
-    TMP_ZIP="$(mktemp).zip"
-    curl -L --silent -o "$TMP_ZIP" "$URL"
-    unzip -o "$TMP_ZIP" -d "$BIN_DIR"
-    chmod +x "$BIN_DIR"/livekit-server*
-    mv "$BIN_DIR"/livekit-server* "$LK_TARGET" 2>/dev/null || true
-    rm -f "$TMP_ZIP"
+  if [[ -n "$PATTERN" ]]; then
+    URL="$(python3 -c "import json,re,sys; r=json.load(sys.stdin); a=next(x for x in r['assets'] if re.search(sys.argv[1], x['name'])); print(a['browser_download_url'])" "$PATTERN" <<< "$RELEASE_JSON")"
+    TMP_ARCHIVE="$(mktemp)"
+    curl -fL --retry 3 -o "$TMP_ARCHIVE" "$URL"
+    EXTRACT_DIR="$(mktemp -d)"
+    tar -xzf "$TMP_ARCHIVE" -C "$EXTRACT_DIR"
+    EXTRACTED="$(find "$EXTRACT_DIR" -name 'livekit-server' -type f | head -n 1)"
+    if [[ -z "$EXTRACTED" ]]; then
+      echo "livekit-server binary not found in archive"
+      exit 1
+    fi
+    cp "$EXTRACTED" "$LK_TARGET"
+    chmod +x "$LK_TARGET"
+    rm -f "$TMP_ARCHIVE"
+    rm -rf "$EXTRACT_DIR"
   fi
 fi
 

--- a/scripts/release/build_bundle.sh
+++ b/scripts/release/build_bundle.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+BUNDLE_ROOT="$ROOT/bundle"
+VENV_PATH="$BUNDLE_ROOT/.venv"
+MODELS_DIR="$BUNDLE_ROOT/models"
+PIPER_DIR="$MODELS_DIR/piper"
+BIN_DIR="$BUNDLE_ROOT/bin"
+
+echo "Jarvis — build offline bundle"
+echo "This script downloads Python deps and models once."
+echo ""
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv missing — install from https://docs.astral.sh/uv/"
+  exit 1
+fi
+
+mkdir -p "$BUNDLE_ROOT" "$MODELS_DIR" "$PIPER_DIR" "$BIN_DIR"
+
+echo "[1/5] Sync Python env into bundle/.venv"
+rm -rf "$VENV_PATH"
+uv venv "$VENV_PATH" --python 3.11
+uv sync --python "$VENV_PATH" --extra vision
+
+BUNDLE_PYTHON="$VENV_PATH/bin/python"
+if [[ ! -x "$BUNDLE_PYTHON" ]]; then
+  echo "bundle python missing"
+  exit 1
+fi
+
+echo "[2/5] Copy uv binary"
+cp "$(command -v uv)" "$BIN_DIR/uv"
+chmod +x "$BIN_DIR/uv"
+
+echo "[3/5] Download ML models"
+if [[ ! -f yolov8n.pt ]]; then
+  uv run --python "$BUNDLE_PYTHON" python -c "from ultralytics import YOLO; YOLO('yolov8n.pt')"
+fi
+cp yolov8n.pt "$MODELS_DIR/yolov8n.pt"
+
+PIPER_ONNX="$PIPER_DIR/fr_FR-upmc-medium.onnx"
+PIPER_JSON="${PIPER_ONNX}.json"
+if [[ ! -f "$PIPER_ONNX" ]]; then
+  BASE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/fr/fr_FR/upmc/medium"
+  curl -L --silent -o "$PIPER_ONNX" "${BASE_URL}/fr_FR-upmc-medium.onnx"
+  curl -L --silent -o "$PIPER_JSON" "${BASE_URL}/fr_FR-upmc-medium.onnx.json"
+fi
+
+echo "[4/5] Download livekit-server"
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+LK_TARGET="$BIN_DIR/livekit-server"
+if [[ ! -x "$LK_TARGET" ]]; then
+  case "$OS" in
+    Darwin)
+      if [[ "$ARCH" == "arm64" ]]; then
+        URL="https://github.com/livekit/livekit/releases/latest/download/livekit-server_darwin_arm64.zip"
+      else
+        URL="https://github.com/livekit/livekit/releases/latest/download/livekit-server_darwin_amd64.zip"
+      fi
+      ;;
+    Linux)
+      URL="https://github.com/livekit/livekit/releases/latest/download/livekit-server_linux_amd64.zip"
+      ;;
+    *)
+      echo "Unsupported OS for bundled livekit-server"
+      URL=""
+      ;;
+  esac
+  if [[ -n "$URL" ]]; then
+    TMP_ZIP="$(mktemp).zip"
+    curl -L --silent -o "$TMP_ZIP" "$URL"
+    unzip -o "$TMP_ZIP" -d "$BIN_DIR"
+    chmod +x "$BIN_DIR"/livekit-server*
+    mv "$BIN_DIR"/livekit-server* "$LK_TARGET" 2>/dev/null || true
+    rm -f "$TMP_ZIP"
+  fi
+fi
+
+echo "[5/5] Write manifest"
+cat > "$BUNDLE_ROOT/manifest.json" <<EOF
+{
+  "version": "1",
+  "platform": "$(echo "$OS" | tr '[:upper:]' '[:lower:]')",
+  "python": "3.11",
+  "venv": ".venv",
+  "models": {
+    "yolo": "models/yolov8n.pt",
+    "piper_onnx": "models/piper/fr_FR-upmc-medium.onnx",
+    "piper_json": "models/piper/fr_FR-upmc-medium.onnx.json"
+  },
+  "bin": {
+    "uv": "bin/uv",
+    "livekit": "bin/livekit-server"
+  }
+}
+EOF
+
+echo ""
+echo "Bundle ready: $BUNDLE_ROOT"
+echo "Next: ./jarvis eclosion"

--- a/setup.ps1
+++ b/setup.ps1
@@ -34,6 +34,15 @@ function Ensure-Uv {
     }
 }
 
+function Ensure-JarvisPackage {
+    param([string]$PythonPath)
+    & $PythonPath -c "import jarvis.setup_app" 2>$null
+    if ($LASTEXITCODE -eq 0) { return }
+    if (-not (Ensure-Command "uv")) { throw "jarvis package missing in venv and uv unavailable." }
+    uv pip install --python $PythonPath -e .
+    if ($LASTEXITCODE -ne 0) { throw "jarvis package install failed." }
+}
+
 if ($Ci) {
     Write-Host "JARVIS V3 - setup --Ci (mode non-interactif)" -ForegroundColor Cyan
     $py = Get-JarvisPython
@@ -94,6 +103,8 @@ if (-not $python) {
 if (-not $python) {
     throw "Impossible de demarrer l'assistant de configuration."
 }
+
+Ensure-JarvisPackage -PythonPath $python
 
 Write-Host "Ouverture de http://127.0.0.1:8765/setup" -ForegroundColor Green
 Write-Host "Ctrl-C pour arreter l'assistant." -ForegroundColor DarkGray

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,271 +1,101 @@
+param(
+    [switch]$Ci
+)
+
 $ErrorActionPreference = "Stop"
-
-function Write-Step {
-    param(
-        [int]$Current,
-        [int]$Total,
-        [string]$Title
-    )
-    Write-Host ""
-    Write-Host ("-" * 60)
-    Write-Host ("[ {0}/{1} ] {2}" -f $Current, $Total, $Title) -ForegroundColor Cyan
-    Write-Host ("-" * 60)
-}
-
-function Require-Value {
-    param(
-        [string]$Prompt,
-        [bool]$Secret = $false,
-        [string]$Default = ""
-    )
-    while ($true) {
-        if ($Secret) {
-            $secure = Read-Host -Prompt $Prompt -AsSecureString
-            $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
-            try {
-                $value = [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
-            } finally {
-                [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
-            }
-        } else {
-            $suffix = ""
-            if ($Default -ne "") {
-                $suffix = " [$Default]"
-            }
-            $inputValue = Read-Host -Prompt "$Prompt$suffix"
-            if ([string]::IsNullOrWhiteSpace($inputValue) -and $Default -ne "") {
-                $value = $Default
-            } else {
-                $value = $inputValue
-            }
-        }
-        if (-not [string]::IsNullOrWhiteSpace($value)) {
-            return $value.Trim()
-        }
-        Write-Host "Valeur requise." -ForegroundColor Yellow
-    }
-}
-
-function Ask-YesNo {
-    param(
-        [string]$Prompt,
-        [bool]$DefaultNo = $true
-    )
-    $defaultLabel = if ($DefaultNo) { "Y/N (default: N)" } else { "Y/N (default: Y)" }
-    $raw = Read-Host -Prompt "$Prompt [$defaultLabel]"
-    if ([string]::IsNullOrWhiteSpace($raw)) {
-        return (-not $DefaultNo)
-    }
-    return $raw.Trim().ToLowerInvariant() -in @("y", "yes", "o", "oui")
-}
+Set-Location $PSScriptRoot
 
 function Ensure-Command {
     param([string]$Name)
     return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
 }
 
-function Add-PathIfNeeded {
-    param([string]$PathToAdd)
-    if ([string]::IsNullOrWhiteSpace($PathToAdd)) {
-        return
-    }
-    if ($env:PATH -notlike "*$PathToAdd*") {
-        $env:PATH = "$PathToAdd;$env:PATH"
-    }
+function Ask-BuildBundle {
+    $raw = Read-Host "Construire le bundle offline maintenant ? [y/N]"
+    return $raw.Trim().ToLowerInvariant() -in @("y", "yes", "o", "oui")
 }
 
-function Get-AvailablePort {
-    param([int]$StartPort = 8000, [int]$MaxAttempts = 20)
-    for ($port = $StartPort; $port -lt ($StartPort + $MaxAttempts); $port++) {
-        $listener = $null
-        try {
-            $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, $port)
-            $listener.Start()
-            return $port
-        } catch {
-            continue
-        } finally {
-            if ($null -ne $listener) {
-                $listener.Stop()
-            }
-        }
-    }
-    return $StartPort
+function Get-JarvisPython {
+    $bundlePy = Join-Path $PSScriptRoot "bundle\.venv\Scripts\python.exe"
+    $venvPy = Join-Path $PSScriptRoot ".venv\Scripts\python.exe"
+    if (Test-Path $bundlePy) { return $bundlePy }
+    if (Test-Path $venvPy) { return $venvPy }
+    return $null
 }
 
-$stepTotal = 8
-
-Write-Host ""
-Write-Host "JARVIS v3.0 - Setup interactif (PowerShell)" -ForegroundColor Cyan
-Write-Host ""
-
-Write-Step -Current 1 -Total $stepTotal -Title "Verification des prerequis"
-
-$pythonCmd = $null
-if (Ensure-Command "python") { $pythonCmd = "python" }
-elseif (Ensure-Command "py") { $pythonCmd = "py -3" }
-
-if (-not $pythonCmd) {
-    throw "Python 3.11+ introuvable. Installe Python et active l'option Add to PATH."
-}
-
-$pyVersionRaw = & $pythonCmd --version 2>&1
-if ($LASTEXITCODE -ne 0) {
-    throw "Impossible de lire la version Python."
-}
-$versionText = ($pyVersionRaw | Select-Object -First 1).ToString()
-$versionMatch = [regex]::Match($versionText, "(\d+)\.(\d+)")
-if (-not $versionMatch.Success) {
-    throw "Version Python invalide: $versionText"
-}
-$major = [int]$versionMatch.Groups[1].Value
-$minor = [int]$versionMatch.Groups[2].Value
-if ($major -lt 3 -or ($major -eq 3 -and $minor -lt 11)) {
-    throw "Python $major.$minor detecte, Python 3.11+ requis."
-}
-Write-Host "Python $major.$minor detecte." -ForegroundColor Green
-
-if (-not (Ensure-Command "uv")) {
+function Ensure-Uv {
+    if (Ensure-Command "uv") { return }
     Write-Host "uv introuvable, installation..." -ForegroundColor Yellow
     powershell -ExecutionPolicy ByPass -NoProfile -Command "irm https://astral.sh/uv/install.ps1 | iex"
     $uvBin = Join-Path $env:USERPROFILE ".local\bin"
-    Add-PathIfNeeded -PathToAdd $uvBin
-}
-if (-not (Ensure-Command "uv")) {
-    $cargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
-    Add-PathIfNeeded -PathToAdd $cargoBin
-}
-if (-not (Ensure-Command "uv")) {
-    throw "uv introuvable apres installation."
-}
-Write-Host "uv detecte." -ForegroundColor Green
-
-Write-Step -Current 2 -Total $stepTotal -Title "Installation des dependances Python"
-uv sync
-Write-Host "Dependances installees." -ForegroundColor Green
-
-Write-Step -Current 3 -Total $stepTotal -Title "Configuration LLM principal"
-$apiBackend = "anthropic"
-$openaiApiKey = ""
-$openaiModel = "gpt-4o-mini"
-$anthropicApiKey = ""
-$anthropicModel = "claude-sonnet-4-6"
-if (Ask-YesNo -Prompt "Utiliser OpenAI comme LLM principal ?" -DefaultNo $true) {
-    $apiBackend = "openai"
-    $openaiApiKey = Require-Value -Prompt "Cle API OpenAI (sk-...)" -Secret $true
-} else {
-    $anthropicApiKey = Require-Value -Prompt "Cle API Anthropic (sk-ant-...)" -Secret $true
+    if ($env:PATH -notlike "*$uvBin*") { $env:PATH = "$uvBin;$env:PATH" }
+    if (-not (Ensure-Command "uv")) {
+        throw "uv introuvable apres installation."
+    }
 }
 
-Write-Step -Current 4 -Total $stepTotal -Title "Identite utilisateur"
-$userFirstname = Require-Value -Prompt "Ton prenom"
-Write-Host "Bonjour, $userFirstname" -ForegroundColor Green
-
-Write-Step -Current 5 -Total $stepTotal -Title "Localisation proactive"
-$proactiveCity = Require-Value -Prompt "Ville" -Default "Paris"
-$proactiveLat = Require-Value -Prompt "Latitude" -Default "48.85"
-$proactiveLon = Require-Value -Prompt "Longitude" -Default "2.35"
-
-Write-Step -Current 6 -Total $stepTotal -Title "Modules optionnels"
-$ttsProvider = "piper"
-$elevenlabsApiKey = ""
-$elevenlabsVoiceId = ""
-$elevenlabsModel = "eleven_flash_v2_5"
-if (Ask-YesNo -Prompt "Utiliser ElevenLabs plutot que Piper ?" -DefaultNo $true) {
-    $ttsProvider = "elevenlabs"
-    $elevenlabsApiKey = Require-Value -Prompt "Cle ElevenLabs (sk_...)" -Secret $true
-    $elevenlabsVoiceId = Require-Value -Prompt "Voice ID ElevenLabs"
-}
-
-$livekitUrl = ""
-$livekitApiKey = ""
-$livekitApiSecret = ""
-$deepgramApiKey = ""
-if (Ask-YesNo -Prompt "Activer le pipeline vocal LiveKit ?" -DefaultNo $true) {
-    $livekitUrl = Require-Value -Prompt "LiveKit URL (wss://...)"
-    $livekitApiKey = Require-Value -Prompt "LiveKit API Key" -Secret $true
-    $livekitApiSecret = Require-Value -Prompt "LiveKit API Secret" -Secret $true
-    $deepgramApiKey = Require-Value -Prompt "Deepgram API Key" -Secret $true
-}
-
-$aisstreamKey = ""
-if (Ask-YesNo -Prompt "Configurer AISstream ?" -DefaultNo $true) {
-    $aisstreamKey = Require-Value -Prompt "Cle AISstream" -Secret $true
-}
-
-Write-Step -Current 7 -Total $stepTotal -Title "Telechargement des modeles ML"
-if (-not (Test-Path "yolov8n.pt")) {
-    uv run python -c "from ultralytics import YOLO; YOLO('yolov8n.pt')"
-}
-
-$piperDir = "models/piper"
-$piperModel = Join-Path $piperDir "fr_FR-upmc-medium.onnx"
-$piperJson = "$piperModel.json"
-if (-not (Test-Path $piperModel)) {
-    New-Item -ItemType Directory -Path $piperDir -Force | Out-Null
-    $baseUrl = "https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/fr/fr_FR/upmc/medium"
-    curl.exe -L --silent -o $piperModel "$baseUrl/fr_FR-upmc-medium.onnx"
-    curl.exe -L --silent -o $piperJson "$baseUrl/fr_FR-upmc-medium.onnx.json"
-}
-
-Write-Step -Current 8 -Total $stepTotal -Title "Generation de l'environnement"
-New-Item -ItemType Directory -Path "memory_data/sessions" -Force | Out-Null
-New-Item -ItemType Directory -Path "memory_data/topics" -Force | Out-Null
-New-Item -ItemType Directory -Path "memory_data/conso" -Force | Out-Null
-New-Item -ItemType Directory -Path "memory_data/initiatives" -Force | Out-Null
-New-Item -ItemType Directory -Path "workspace/projects" -Force | Out-Null
-New-Item -ItemType Directory -Path "vision/faces" -Force | Out-Null
-
-if (Test-Path ".env") {
-    $stamp = Get-Date -Format "yyyyMMdd_HHmmss"
-    Copy-Item ".env" ".env.backup.$stamp"
-}
-
-$serverPort = Get-AvailablePort -StartPort 8000
-if ($serverPort -ne 8000) {
-    Write-Host "Port 8000 indisponible, utilisation du port $serverPort." -ForegroundColor Yellow
-}
-
-$envContent = @"
-USER_FIRSTNAME=$userFirstname
+if ($Ci) {
+    Write-Host "JARVIS V3 - setup --Ci (mode non-interactif)" -ForegroundColor Cyan
+    $py = Get-JarvisPython
+    if (-not $py) {
+        Ensure-Uv
+        uv sync --frozen --group dev
+        $py = Get-JarvisPython
+    }
+    if (-not $py) { throw "Python runtime introuvable." }
+    & $py -c "from jarvis.kernel.setup_layout import ensure_runtime_layout; ensure_runtime_layout()"
+    if (-not (Test-Path ".env")) {
+        @"
 LLM_PROVIDER=api
-API_BACKEND=$apiBackend
-ANTHROPIC_API_KEY=$anthropicApiKey
-ANTHROPIC_MODEL=$anthropicModel
-OPENAI_API_KEY=$openaiApiKey
-OPENAI_MODEL=$openaiModel
-HOST=0.0.0.0
-PORT=$serverPort
-ENVIRONMENT=development
-LOG_LEVEL=INFO
-PROACTIVE_LAT=$proactiveLat
-PROACTIVE_LON=$proactiveLon
-PROACTIVE_CITY=$proactiveCity
-TTS_PROVIDER=$ttsProvider
-ELEVENLABS_API_KEY=$elevenlabsApiKey
-ELEVENLABS_VOICE_ID=$elevenlabsVoiceId
-ELEVENLABS_MODEL=$elevenlabsModel
-WHISPER_MODEL=tiny
-LIVEKIT_URL=$livekitUrl
-LIVEKIT_API_KEY=$livekitApiKey
-LIVEKIT_API_SECRET=$livekitApiSecret
-DEEPGRAM_API_KEY=$deepgramApiKey
-AISSTREAM_KEY=$aisstreamKey
-MISTRAL_API_KEY=
-MISTRAL_MODEL=mistral-large-latest
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=mistral
-GOOGLE_API_KEY=
-"@
-
-Set-Content -Path ".env" -Value $envContent -Encoding UTF8
-
-Write-Host ""
-Write-Host ("=" * 60) -ForegroundColor Cyan
-Write-Host "Systeme pret." -ForegroundColor Green
-Write-Host "Lancer le serveur: uv run python main.py" -ForegroundColor White
-if (-not [string]::IsNullOrWhiteSpace($livekitUrl)) {
-    Write-Host "Lancer la voix: uv run python voice_agent.py dev" -ForegroundColor White
+API_BACKEND=anthropic
+ANTHROPIC_API_KEY=unused-in-fake-llm-mode
+ANTHROPIC_MODEL=claude-sonnet-4-6
+VOICE_ANTHROPIC_MODEL=claude-haiku-4-5-20251001
+USER_FIRSTNAME=B9
+HOME_CITY=Paris
+MEMORY_DIR=memory_data
+PORT=8000
+"@ | Set-Content -Path ".env" -Encoding UTF8
+    }
+    Write-Host "setup --Ci OK" -ForegroundColor Green
+    exit 0
 }
-Write-Host ("=" * 60) -ForegroundColor Cyan
+
 Write-Host ""
+Write-Host "JARVIS - Configuration web locale" -ForegroundColor Cyan
+Write-Host ""
+
+$python = Get-JarvisPython
+if (-not $python) {
+    if (Test-Path (Join-Path $PSScriptRoot "bundle\manifest.json")) {
+        throw "Bundle detecte mais bundle/.venv manquant. Relance scripts\release\build_bundle.ps1"
+    }
+    Write-Host "Aucun runtime pre-packaged detecte." -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Option A (recommandee) : telecharge une release Jarvis avec bundle offline" -ForegroundColor White
+    Write-Host "Option B (maintainer)    : scripts\release\build_bundle.ps1 (une fois, avec reseau)" -ForegroundColor White
+    Write-Host "Option C (dev)           : uv sync puis relance .\setup.ps1" -ForegroundColor White
+    Write-Host ""
+    if (Ask-BuildBundle) {
+        & "$PSScriptRoot\scripts\release\build_bundle.ps1"
+        $python = Get-JarvisPython
+    }
+}
+
+if (-not $python) {
+    Ensure-Uv
+    if (-not (Test-Path ".venv")) {
+        uv sync
+        if ($LASTEXITCODE -ne 0) { throw "uv sync a echoue." }
+    }
+    $python = Get-JarvisPython
+}
+
+if (-not $python) {
+    throw "Impossible de demarrer l'assistant de configuration."
+}
+
+Write-Host "Ouverture de http://127.0.0.1:8765/setup" -ForegroundColor Green
+Write-Host "Ctrl-C pour arreter l'assistant." -ForegroundColor DarkGray
+Write-Host ""
+& $python -m jarvis.setup_app

--- a/setup.sh
+++ b/setup.sh
@@ -84,6 +84,10 @@ if [[ -z "$PYTHON_BIN" ]]; then
   exit 1
 fi
 
+if ! "$PYTHON_BIN" -c "import jarvis.setup_app" 2>/dev/null; then
+  uv pip install --python "$PYTHON_BIN" -e .
+fi
+
 echo ""
 echo "Ouverture de http://127.0.0.1:8765/setup"
 echo "Ctrl-C pour arreter l'assistant."

--- a/setup.sh
+++ b/setup.sh
@@ -1,20 +1,9 @@
 #!/usr/bin/env bash
-# ================================================================
-#  JARVIS V3 — Setup interactif
-# ================================================================
 set -euo pipefail
 
-# ── Mode CI / non-interactif (Phase F §B.9) ──────────────────────
-# `setup.sh --ci` : crée la disposition de données (memory_data/,
-# vision_data/faces/, skills_data/{installed,candidates}/, workspace/),
-# génère un .env minimal pour les tests si absent, lance `uv sync`,
-# puis exit 0 SANS lancer le wizard. Utilisé par le job GitHub Actions
-# `b9_cold_install`. Aucun téléchargement de modèles ML lourds (cf.
-# CDC §C.1.7 — le smoke utilise --fake-llm).
 if [[ "${1:-}" == "--ci" ]]; then
   echo "JARVIS V3 — setup --ci (mode non-interactif)"
 
-  # Disposition cible (cf. kernel/paths.py)
   mkdir -p memory_data/sessions \
            memory_data/topics \
            memory_data/conso \
@@ -24,13 +13,9 @@ if [[ "${1:-}" == "--ci" ]]; then
            skills_data/installed \
            skills_data/candidates \
            workspace/projects
-  echo "  ✓ Disposition créée (memory_data/, vision_data/, skills_data/)"
+  echo "  Disposition creee"
 
-  # .env minimal si absent (clés stubs — le smoke utilise --fake-llm)
   if [[ ! -f .env ]]; then
-    # Mode CI fake-llm : aucune clé réelle requise, le boot n'appelle jamais
-    # l'API. Cette valeur sentinel doit rester ostensiblement non-secrète —
-    # ne JAMAIS y coller une clé réelle (le fichier est dans un repo public).
     cat > .env <<'EOF'
 LLM_PROVIDER=api
 API_BACKEND=anthropic
@@ -40,18 +25,16 @@ VOICE_ANTHROPIC_MODEL=claude-haiku-4-5-20251001
 USER_FIRSTNAME=B9
 HOME_CITY=Paris
 MEMORY_DIR=memory_data
+PORT=8000
 EOF
-    echo "  ✓ .env minimal généré"
-  else
-    echo "  ✓ .env pré-existant conservé"
+    echo "  .env minimal genere"
   fi
 
-  # uv sync — toutes deps (les deps système doivent déjà être installées)
   if command -v uv > /dev/null 2>&1; then
-    uv sync --frozen --group dev
-    echo "  ✓ uv sync terminé"
+    uv sync --frozen --group dev --extra vision
+    echo "  uv sync termine"
   else
-    echo "  ! uv absent du PATH — installer uv avant 'setup.sh --ci'"
+    echo "  uv absent du PATH"
     exit 1
   fi
 
@@ -59,512 +42,50 @@ EOF
   exit 0
 fi
 
-# ── Couleurs & styles ────────────────────────────────────────────
-RESET='\033[0m'
-BOLD='\033[1m'
-DIM='\033[2m'
-
-BLACK='\033[30m'
-RED='\033[91m'
-GREEN='\033[92m'
-YELLOW='\033[93m'
-BLUE='\033[94m'
-MAGENTA='\033[95m'
-CYAN='\033[96m'
-WHITE='\033[97m'
-
-BG_BLACK='\033[40m'
-
-# True color
-TC_CYAN='\033[38;2;0;212;255m'
-TC_BLUE='\033[38;2;0;100;255m'
-TC_TEAL='\033[38;2;0;255;180m'
-TC_GRAY='\033[38;2;120;130;150m'
-TC_DIMGRAY='\033[38;2;70;80;95m'
-TC_WHITE='\033[38;2;220;230;255m'
-
-# ── Compteur de steps ─────────────────────────────────────────────
-STEP_CURRENT=0
-STEP_TOTAL=8
-
-# ── Utilitaires visuels ──────────────────────────────────────────
-nl()  { echo ""; }
-sep() { echo -e "${TC_DIMGRAY}$(printf '─%.0s' {1..60})${RESET}"; }
-
-badge_ok()   { echo -e "  ${TC_TEAL}${BOLD}✓${RESET}  $*"; }
-badge_warn() { echo -e "  ${YELLOW}${BOLD}!${RESET}  $*"; }
-badge_err()  { echo -e "  ${RED}${BOLD}✗${RESET}  $*"; }
-badge_info() { echo -e "  ${TC_CYAN}${BOLD}›${RESET}  $*"; }
-badge_skip() { echo -e "  ${TC_GRAY}${BOLD}–${RESET}  ${TC_GRAY}$*${RESET}"; }
-
-step() {
-  STEP_CURRENT=$((STEP_CURRENT + 1))
-  nl
-  echo -e "${TC_DIMGRAY}$(printf '─%.0s' {1..60})${RESET}"
-  echo -e "  ${TC_CYAN}${BOLD}[ ${STEP_CURRENT}/${STEP_TOTAL} ]${RESET}  ${WHITE}${BOLD}$*${RESET}"
-  echo -e "${TC_DIMGRAY}$(printf '─%.0s' {1..60})${RESET}"
-}
-
-# ── Spinner ───────────────────────────────────────────────────────
-SPINNER_PID=""
-spinner_start() {
-  local msg="$1"
-  local frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
-  (
-    i=0
-    while true; do
-      printf "\r  ${TC_CYAN}${frames[$((i % 10))]}${RESET}  ${TC_GRAY}%s${RESET}   " "$msg"
-      i=$((i + 1))
-      sleep 0.08
-    done
-  ) &
-  SPINNER_PID=$!
-}
-
-spinner_stop() {
-  if [[ -n "$SPINNER_PID" ]]; then
-    kill "$SPINNER_PID" 2>/dev/null || true
-    wait "$SPINNER_PID" 2>/dev/null || true
-    SPINNER_PID=""
-    printf "\r\033[2K"
+resolve_python() {
+  if [[ -x bundle/.venv/bin/python ]]; then
+    echo bundle/.venv/bin/python
+  elif [[ -x .venv/bin/python ]]; then
+    echo .venv/bin/python
   fi
 }
 
-run_task() {
-  local msg="$1"
-  shift
-  spinner_start "$msg"
-  if "$@" > /tmp/jarvis_setup_out.log 2>&1; then
-    spinner_stop
-    badge_ok "$msg"
-  else
-    spinner_stop
-    badge_err "$msg"
-    echo ""
-    echo -e "${TC_GRAY}$(tail -5 /tmp/jarvis_setup_out.log)${RESET}"
-    echo ""
+PYTHON_BIN="$(resolve_python || true)"
+
+if [[ -z "$PYTHON_BIN" ]]; then
+  if [[ -f bundle/manifest.json ]]; then
+    echo "Bundle detecte mais bundle/.venv manquant. Lance scripts/release/build_bundle.sh"
     exit 1
   fi
-}
-
-# ── Lecture sécurisée ─────────────────────────────────────────────
-ask() {
-  # ask "Label" VAR_NAME [default]
-  local label="$1" varname="$2" default="${3:-}"
-  local hint=""
-  [[ -n "$default" ]] && hint=" ${TC_GRAY}(défaut : $default)${RESET}"
-  printf "  ${TC_WHITE}${BOLD}%s${RESET}%s\n  ${TC_DIMGRAY}›${RESET} " "$label" "$hint"
-  read -r "$varname"
-  if [[ -z "${!varname}" && -n "$default" ]]; then
-    printf -v "$varname" '%s' "$default"
+  echo ""
+  echo "JARVIS — aucun runtime pre-packaged detecte."
+  echo "  A) Telecharge une release Jarvis avec bundle offline"
+  echo "  B) bash scripts/release/build_bundle.sh (une fois, avec reseau)"
+  echo "  C) uv sync puis relance ./setup.sh"
+  echo ""
+  read -r -p "Construire le bundle offline maintenant ? [y/N] " ans
+  if [[ "$ans" =~ ^[Yy]$ ]]; then
+    bash scripts/release/build_bundle.sh
+    PYTHON_BIN="$(resolve_python || true)"
   fi
-}
+fi
 
-ask_secret() {
-  local label="$1" varname="$2"
-  printf "  ${TC_WHITE}${BOLD}%s${RESET}\n  ${TC_DIMGRAY}›${RESET} " "$label"
-  read -rs "$varname"
-  echo ""
-}
+if [[ -z "$PYTHON_BIN" ]]; then
+  if ! command -v uv >/dev/null 2>&1; then
+    echo "uv introuvable — installe-le depuis https://docs.astral.sh/uv/"
+    exit 1
+  fi
+  uv sync --extra vision
+  PYTHON_BIN="$(resolve_python || true)"
+fi
 
-ask_yesno() {
-  # returns 0 (yes) or 1 (no)
-  local label="$1" default="${2:-n}"
-  local opts
-  [[ "$default" == "y" ]] && opts="${TC_TEAL}o${RESET}/${TC_GRAY}n${RESET}" || opts="${TC_GRAY}o${RESET}/${TC_TEAL}n${RESET}"
-  printf "  ${TC_WHITE}${BOLD}%s${RESET}  [%b] " "$label" "$opts"
-  read -r _yn
-  _yn="${_yn:-$default}"
-  [[ "$_yn" =~ ^[oOyY] ]]
-}
-
-# ── Logo JARVIS ───────────────────────────────────────────────────
-print_logo() {
-  clear
-  echo ""
-  echo -e "${TC_BLUE}${BOLD}    ██╗ █████╗ ██████╗ ██╗   ██╗██╗███████╗${RESET}"
-  echo -e "${TC_CYAN}${BOLD}    ██║██╔══██╗██╔══██╗██║   ██║██║██╔════╝${RESET}"
-  echo -e "${TC_CYAN}${BOLD}    ██║███████║██████╔╝██║   ██║██║███████╗${RESET}"
-  echo -e "${TC_TEAL}${BOLD}██  ██║██╔══██║██╔══██╗╚██╗ ██╔╝██║╚════██║${RESET}"
-  echo -e "${TC_TEAL}${BOLD}╚█████╔╝██║  ██║██║  ██║ ╚████╔╝ ██║███████║${RESET}"
-  echo -e "${TC_GRAY}${BOLD} ╚════╝ ╚═╝  ╚═╝╚═╝  ╚═╝  ╚═══╝  ╚═╝╚══════╝${RESET}"
-  echo ""
-  echo -e "  ${TC_GRAY}Assistant IA temps réel  ·  v3.0  ·  Setup interactif${RESET}"
-  echo ""
-  echo -e "${TC_DIMGRAY}$(printf '═%.0s' {1..60})${RESET}"
-  echo ""
-}
-
-# ── Abort propre ──────────────────────────────────────────────────
-abort() {
-  spinner_stop
-  nl
-  echo -e "${RED}${BOLD}  Annulé.${RESET}"
-  nl
-  exit 1
-}
-trap abort INT TERM
-
-# ════════════════════════════════════════════════════════════════
-#  DÉBUT
-# ════════════════════════════════════════════════════════════════
-
-print_logo
-
-echo -e "  ${TC_WHITE}${BOLD}Bienvenue dans le wizard de configuration de JARVIS.${RESET}"
-echo -e "  ${TC_GRAY}Ce script va installer les dépendances, configurer tes clés${RESET}"
-echo -e "  ${TC_GRAY}API et préparer l'environnement en quelques minutes.${RESET}"
-nl
-
-# ── STEP 1 — Prérequis ───────────────────────────────────────────
-step "Vérification des prérequis"
-
-# Python
-if ! command -v python3 &>/dev/null; then
-  badge_err "Python 3.11+ introuvable — installe-le sur https://python.org"
+if [[ -z "$PYTHON_BIN" ]]; then
+  echo "Impossible de demarrer l'assistant de configuration."
   exit 1
 fi
-PY_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-PY_MAJOR=$(echo "$PY_VERSION" | cut -d. -f1)
-PY_MINOR=$(echo "$PY_VERSION" | cut -d. -f2)
-if [[ "$PY_MAJOR" -lt 3 || ( "$PY_MAJOR" -eq 3 && "$PY_MINOR" -lt 11 ) ]]; then
-  badge_err "Python $PY_VERSION détecté — JARVIS nécessite Python 3.11+"
-  exit 1
-fi
-badge_ok "Python $PY_VERSION"
 
-# uv
-if ! command -v uv &>/dev/null; then
-  badge_info "uv introuvable — installation automatique..."
-  run_task "Installation de uv" bash -c "curl -LsSf https://astral.sh/uv/install.sh | sh"
-  export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
-fi
-badge_ok "uv $(uv --version 2>/dev/null | awk '{print $2}')"
-
-# curl
-if ! command -v curl &>/dev/null; then
-  badge_err "curl introuvable — requis pour les téléchargements"
-  exit 1
-fi
-badge_ok "curl"
-
-# ── STEP 2 — Dépendances Python ──────────────────────────────────
-step "Installation des dépendances Python"
-
-run_task "uv sync (pyproject.toml)" uv sync
-badge_info ".venv/ prêt"
-
-# ── STEP 3 — LLM principal ───────────────────────────────────────
-step "Configuration — LLM principal (obligatoire)"
-
-nl
-echo -e "  ${TC_CYAN}${BOLD}Choisis ton backend API principal${RESET}"
-echo -e "  ${TC_GRAY}Anthropic (Claude) ou OpenAI.${RESET}"
-nl
-
-API_BACKEND="anthropic"
-ANTHROPIC_API_KEY=""
-ANTHROPIC_MODEL="claude-sonnet-4-6"
-OPENAI_API_KEY=""
-OPENAI_MODEL="gpt-4o-mini"
-if ask_yesno "Utiliser OpenAI comme LLM principal ?" "n"; then
-  API_BACKEND="openai"
-  while [[ -z "$OPENAI_API_KEY" ]]; do
-    ask_secret "Clé API OpenAI  (sk-...)" OPENAI_API_KEY
-    if [[ -z "$OPENAI_API_KEY" ]]; then
-      badge_warn "La clé OpenAI est obligatoire avec ce backend."
-    fi
-  done
-  badge_ok "Backend principal → OpenAI"
-else
-  while [[ -z "$ANTHROPIC_API_KEY" ]]; do
-    ask_secret "Clé API Anthropic  (sk-ant-...)" ANTHROPIC_API_KEY
-    if [[ -z "$ANTHROPIC_API_KEY" ]]; then
-      badge_warn "La clé Anthropic est obligatoire avec ce backend."
-    fi
-  done
-  badge_ok "Backend principal → Anthropic"
-fi
-
-# ── STEP 4 — Identité utilisateur ───────────────────────────────
-step "Ton identité"
-
-nl
-echo -e "  ${TC_GRAY}Utilisée pour personnaliser la séquence de démarrage et le scan biométrique.${RESET}"
-nl
-
-USER_FIRSTNAME=""
-while [[ -z "$USER_FIRSTNAME" ]]; do
-  ask "Ton prénom" USER_FIRSTNAME ""
-  if [[ -z "$USER_FIRSTNAME" ]]; then
-    badge_warn "Le prénom est requis pour personnaliser JARVIS."
-  fi
-done
-
-badge_ok "Bonjour, ${USER_FIRSTNAME} !"
-
-nl
-echo -e "  ${TC_CYAN}${BOLD}Photo de référence (reconnaissance faciale)${RESET}"
-echo -e "  ${TC_GRAY}Si tu veux activer la séquence de scan biométrique, place une photo de toi${RESET}"
-echo -e "  ${TC_GRAY}(format JPG, visage bien visible) dans :${RESET}"
-nl
-echo -e "  ${TC_WHITE}    vision_data/faces/référence.jpg${RESET}"
-nl
-echo -e "  ${TC_GRAY}Sans cette photo, le scan s'exécutera mais ne pourra pas t'identifier.${RESET}"
-badge_info "Tu peux ajouter la photo après l'installation."
-
-nl
-
-# ── STEP 5 — Localisation (météo proactive) ─────────────────────
-step "Localisation (moteur proactif)"
-
-nl
-echo -e "  ${TC_GRAY}Utilisée pour les alertes météo et contexte local.${RESET}"
-nl
-
-ask "Ville" PROACTIVE_CITY "Paris"
-ask "Latitude" PROACTIVE_LAT "48.85"
-ask "Longitude" PROACTIVE_LON "2.35"
-
-badge_ok "Localisation : $PROACTIVE_CITY ($PROACTIVE_LAT, $PROACTIVE_LON)"
-
-# ── STEP 6 — Modules optionnels ──────────────────────────────────
-step "Modules optionnels"
-
-nl
-echo -e "  ${TC_GRAY}Active uniquement ce dont tu as besoin maintenant.${RESET}"
-echo -e "  ${TC_GRAY}Tu pourras compléter le .env plus tard.${RESET}"
-nl
-
-# TTS
-TTS_PROVIDER="piper"
-ELEVENLABS_API_KEY=""
-ELEVENLABS_VOICE_ID=""
-ELEVENLABS_MODEL="eleven_flash_v2_5"
-
-echo -e "  ${TC_CYAN}${BOLD}Synthèse vocale (TTS)${RESET}"
-echo -e "  ${TC_GRAY}  Piper = local, gratuit / ElevenLabs = cloud, voix naturelles${RESET}"
-nl
-if ask_yesno "Utiliser ElevenLabs (cloud) plutôt que Piper (local) ?" "n"; then
-  TTS_PROVIDER="elevenlabs"
-  ask_secret "Clé ElevenLabs  (sk_...)" ELEVENLABS_API_KEY
-  ask "Voice ID ElevenLabs" ELEVENLABS_VOICE_ID ""
-  badge_ok "TTS → ElevenLabs"
-else
-  badge_ok "TTS → Piper (local)"
-fi
-
-nl
-# LiveKit voice pipeline
-LIVEKIT_URL=""
-LIVEKIT_API_KEY=""
-LIVEKIT_API_SECRET=""
-DEEPGRAM_API_KEY=""
-
-echo -e "  ${TC_CYAN}${BOLD}Pipeline vocal temps réel (LiveKit + Deepgram)${RESET}"
-echo -e "  ${TC_GRAY}  Requis pour parler à voix haute avec JARVIS.${RESET}"
-echo -e "  ${TC_GRAY}  Par défaut : LiveKit tourne en local sur ta machine (zéro config).${RESET}"
-echo -e "  ${TC_GRAY}  Deepgram (STT) : compte gratuit sur deepgram.com (200h/mois).${RESET}"
-nl
-if ask_yesno "Activer le pipeline vocal ?" "n"; then
-  # Installer livekit-server local si absent
-  if ! command -v livekit-server &>/dev/null; then
-    case "$(uname -s)" in
-      Darwin)
-        if command -v brew &>/dev/null; then
-          run_task "Installation de livekit-server (Homebrew)" brew install livekit
-        else
-          badge_warn "Homebrew introuvable — installe livekit-server manuellement : https://github.com/livekit/livekit/releases"
-        fi
-        ;;
-      Linux)
-        run_task "Installation de livekit-server" bash -c "curl -sSL https://get.livekit.io | bash"
-        ;;
-      *)
-        badge_warn "OS non supporté — installe livekit-server manuellement : https://github.com/livekit/livekit/releases"
-        ;;
-    esac
-  else
-    badge_ok "livekit-server déjà installé ($(livekit-server --version 2>&1 | awk '{print $NF}' | head -1))"
-  fi
-
-  # Choix local vs cloud
-  if ask_yesno "Utiliser LiveKit Cloud plutôt que le serveur local ?" "n"; then
-    ask "LiveKit URL  (wss://...)" LIVEKIT_URL ""
-    ask_secret "LiveKit API Key" LIVEKIT_API_KEY
-    ask_secret "LiveKit API Secret" LIVEKIT_API_SECRET
-    badge_ok "LiveKit → Cloud ($LIVEKIT_URL)"
-  else
-    # Clés de dev hardcodées (matchent celles passées à livekit-server --dev dans le script jarvis)
-    LIVEKIT_URL="ws://localhost:7880"
-    LIVEKIT_API_KEY="devkey"
-    LIVEKIT_API_SECRET="devsecretdevsecretdevsecretdevsecret"
-    badge_ok "LiveKit → local (ws://localhost:7880)"
-  fi
-
-  ask_secret "Deepgram API Key  (STT)" DEEPGRAM_API_KEY
-  badge_ok "Pipeline vocal configuré"
-else
-  badge_skip "Pipeline vocal ignoré"
-fi
-
-nl
-# AISstream (navires)
-AISSTREAM_KEY=""
-echo -e "  ${TC_CYAN}${BOLD}AISstream${RESET} ${TC_GRAY}— tracking navires temps réel (globe 3D)${RESET}"
-echo -e "  ${TC_GRAY}  Clé gratuite sur aisstream.io${RESET}"
-nl
-if ask_yesno "Configurer AISstream ?" "n"; then
-  ask_secret "Clé AISstream" AISSTREAM_KEY
-  badge_ok "AISstream configuré"
-else
-  badge_skip "AISstream ignoré"
-fi
-
-# ── STEP 7 — Modèles ML ──────────────────────────────────────────
-step "Téléchargement des modèles ML"
-
-# YOLOv8
-if [[ ! -f "yolov8n.pt" ]]; then
-  run_task "YOLOv8n (~6 Mo) — vision objet" \
-    uv run python -c "from ultralytics import YOLO; YOLO('yolov8n.pt')"
-else
-  badge_ok "YOLOv8n déjà présent"
-fi
-
-# Piper TTS
-PIPER_MODEL="models/piper/fr_FR-upmc-medium.onnx"
-if [[ ! -f "$PIPER_MODEL" ]]; then
-  mkdir -p models/piper
-  BASE_URL="https://huggingface.co/rhasspy/piper-voices/resolve/v1.0.0/fr/fr_FR/upmc/medium"
-  run_task "Piper TTS français (~73 Mo)" \
-    bash -c "curl -L --silent -o '$PIPER_MODEL' '${BASE_URL}/fr_FR-upmc-medium.onnx' && curl -L --silent -o '${PIPER_MODEL}.json' '${BASE_URL}/fr_FR-upmc-medium.onnx.json'"
-else
-  badge_ok "Modèle Piper déjà présent"
-fi
-
-# ── STEP 8 — Génération .env + dossiers ──────────────────────────
-step "Génération de l'environnement"
-
-mkdir -p memory_data/sessions memory_data/topics memory_data/conso memory_data/initiatives
-mkdir -p memory_data/curator_reports
-mkdir -p workspace/projects
-mkdir -p vision_data/faces
-mkdir -p skills_data/installed skills_data/candidates
-badge_ok "Dossiers runtime créés"
-
-# Écriture du .env
-ENV_FILE=".env"
-if [[ -f "$ENV_FILE" ]]; then
-  cp "$ENV_FILE" "${ENV_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
-  badge_info ".env existant sauvegardé"
-fi
-
-cat > "$ENV_FILE" <<EOF
-# ================================================================
-# JARVIS V3 — Configuration  (généré par setup.sh)
-# ================================================================
-
-# ── Identité ─────────────────────────────────────────────────────
-USER_FIRSTNAME=${USER_FIRSTNAME}
-
-# ── LLM ──────────────────────────────────────────────────────────
-LLM_PROVIDER=api
-API_BACKEND=${API_BACKEND}
-ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-ANTHROPIC_MODEL=${ANTHROPIC_MODEL}
-OPENAI_API_KEY=${OPENAI_API_KEY}
-OPENAI_MODEL=${OPENAI_MODEL}
-
-# ── Serveur ───────────────────────────────────────────────────────
-HOST=0.0.0.0
-PORT=8000
-ENVIRONMENT=development
-LOG_LEVEL=INFO
-
-# ── Localisation ──────────────────────────────────────────────────
-PROACTIVE_LAT=${PROACTIVE_LAT}
-PROACTIVE_LON=${PROACTIVE_LON}
-PROACTIVE_CITY=${PROACTIVE_CITY}
-
-# ── TTS ───────────────────────────────────────────────────────────
-TTS_PROVIDER=${TTS_PROVIDER}
-ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
-ELEVENLABS_VOICE_ID=${ELEVENLABS_VOICE_ID}
-ELEVENLABS_MODEL=${ELEVENLABS_MODEL}
-WHISPER_MODEL=tiny
-
-# ── LiveKit ───────────────────────────────────────────────────────
-LIVEKIT_URL=${LIVEKIT_URL}
-LIVEKIT_API_KEY=${LIVEKIT_API_KEY}
-LIVEKIT_API_SECRET=${LIVEKIT_API_SECRET}
-
-# ── Deepgram ──────────────────────────────────────────────────────
-DEEPGRAM_API_KEY=${DEEPGRAM_API_KEY}
-
-# ── AISstream ─────────────────────────────────────────────────────
-AISSTREAM_KEY=${AISSTREAM_KEY}
-
-# ── Providers LLM alternatifs ─────────────────────────────────────
-MISTRAL_API_KEY=
-MISTRAL_MODEL=mistral-large-latest
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=mistral
-GOOGLE_API_KEY=
-EOF
-
-badge_ok ".env généré"
-
-# Enrichissement avec les clés optionnelles de .env.example
-# (couverture Discord, Notion, Mapbox, Vision, Spotify, Printer, etc. —
-# préserve l'onboarding complet auparavant assuré par install.sh).
-if [[ -f .env.example ]]; then
-  added=0
-  while IFS= read -r line; do
-    [[ "$line" =~ ^#.*$ ]] && continue
-    [[ -z "$line" ]] && continue
-    key="${line%%=*}"
-    if ! grep -q "^${key}=" "$ENV_FILE"; then
-      echo "$line" >> "$ENV_FILE"
-      added=$((added + 1))
-    fi
-  done < .env.example
-  badge_ok ".env enrichi avec $added clés optionnelles de .env.example"
-fi
-
-# ── Installation commande globale ────────────────────────────────
-JARVIS_BIN="/usr/local/bin/jarvis"
-JARVIS_SRC="$(cd "$(dirname "$0")" && pwd)/jarvis"
-if [[ ! -f "$JARVIS_BIN" ]]; then
-  nl
-  echo -e "  ${TC_GRAY}Installation de la commande ${TC_WHITE}jarvis${TC_GRAY} dans /usr/local/bin...${RESET}"
-  if sudo ln -sf "$JARVIS_SRC" "$JARVIS_BIN" 2>/dev/null; then
-    badge_ok "Commande \`jarvis\` disponible globalement"
-  else
-    badge_skip "Symlink ignoré — utilise ./jarvis depuis le repo"
-  fi
-else
-  badge_ok "Commande \`jarvis\` déjà installée"
-fi
-
-# ── Résumé final ─────────────────────────────────────────────────
-nl
-echo -e "${TC_DIMGRAY}$(printf '═%.0s' {1..60})${RESET}"
-nl
-echo -e "  ${TC_TEAL}${BOLD}Système prêt.${RESET}"
-nl
-echo -e "  ${TC_GRAY}Noyau principal :${RESET}"
-nl
-echo -e "  ${TC_CYAN}  jarvis run${RESET}"
-echo -e "  ${TC_GRAY}  ↳ ${TC_WHITE}localhost:8000/admin${RESET}"
-nl
-if [[ -n "$LIVEKIT_URL" ]]; then
-  echo -e "  ${TC_GRAY}Interface vocale :${RESET}"
-  nl
-  echo -e "  ${TC_CYAN}  jarvis voice${RESET}"
-  nl
-fi
-echo -e "  ${TC_DIMGRAY}Config  →  .env${RESET}"
-nl
-echo -e "${TC_DIMGRAY}$(printf '═%.0s' {1..60})${RESET}"
-nl
+echo ""
+echo "Ouverture de http://127.0.0.1:8765/setup"
+echo "Ctrl-C pour arreter l'assistant."
+echo ""
+exec "$PYTHON_BIN" -m jarvis.setup_app

--- a/src/jarvis/interfaces/api/config/_env.py
+++ b/src/jarvis/interfaces/api/config/_env.py
@@ -95,7 +95,7 @@ def _read_env() -> dict[str, str]:
     if not _ENV_PATH.exists():
         return {}
     result: dict[str, str] = {}
-    for line in _ENV_PATH.read_text(encoding="utf-8").splitlines():
+    for line in _ENV_PATH.read_text(encoding="utf-8-sig").splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue
@@ -106,7 +106,7 @@ def _read_env() -> dict[str, str]:
 
 
 def _write_env(updates: dict[str, str]) -> None:
-    lines = _ENV_PATH.read_text(encoding="utf-8").splitlines() if _ENV_PATH.exists() else []
+    lines = _ENV_PATH.read_text(encoding="utf-8-sig").splitlines() if _ENV_PATH.exists() else []
     written: set[str] = set()
     new_lines: list[str] = []
     for line in lines:

--- a/src/jarvis/interfaces/api/config/_env.py
+++ b/src/jarvis/interfaces/api/config/_env.py
@@ -125,3 +125,7 @@ def _write_env(updates: dict[str, str]) -> None:
         if key not in written:
             new_lines.append(f"{key}={val}")
     _ENV_PATH.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+
+
+def write_env_batch(updates: dict[str, str]) -> None:
+    _write_env(updates)

--- a/src/jarvis/interfaces/api/setup_wizard.py
+++ b/src/jarvis/interfaces/api/setup_wizard.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+from typing import Literal
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+from pydantic import BaseModel
+
+from jarvis.interfaces.api.config._env import write_env_batch
+from jarvis.kernel.bundle import prerequisites_status, stage_models_from_bundle
+from jarvis.kernel.paths import FACES_DIR, PROJECT_ROOT
+from jarvis.kernel.setup_layout import ensure_runtime_layout, is_setup_complete, read_env_file
+
+router = APIRouter()
+
+
+class SetupCompletePayload(BaseModel):
+    user_firstname: str
+    api_backend: Literal["anthropic", "openai"] = "anthropic"
+    anthropic_api_key: str = ""
+    anthropic_model: str = "claude-sonnet-4-6"
+    openai_api_key: str = ""
+    openai_model: str = "gpt-4o-mini"
+    proactive_city: str = "Paris"
+    proactive_lat: str = "48.85"
+    proactive_lon: str = "2.35"
+    tts_provider: Literal["piper", "elevenlabs"] = "piper"
+    elevenlabs_api_key: str = ""
+    elevenlabs_voice_id: str = ""
+    elevenlabs_model: str = "eleven_flash_v2_5"
+    voice_enabled: bool = False
+    livekit_cloud: bool = False
+    livekit_url: str = ""
+    livekit_api_key: str = ""
+    livekit_api_secret: str = ""
+    deepgram_api_key: str = ""
+    aisstream_key: str = ""
+    face_recognition_enabled: bool = False
+    port: int | None = None
+
+
+def _find_available_port(start: int = 8000, attempts: int = 20) -> int:
+    for port in range(start, start + attempts):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            try:
+                sock.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
+    return start
+
+
+@router.get("/api/setup/status")
+async def setup_status() -> dict:
+    env_path = PROJECT_ROOT / ".env"
+    env = read_env_file(env_path)
+    return {
+        "complete": is_setup_complete(env_path),
+        "env_exists": env_path.is_file(),
+        "user_firstname": env.get("USER_FIRSTNAME", ""),
+        "api_backend": env.get("API_BACKEND", "anthropic"),
+        "port": int(env.get("PORT", "8000") or "8000"),
+        "prerequisites": prerequisites_status(),
+        "layout_created": ensure_runtime_layout(),
+    }
+
+
+@router.get("/api/setup/prerequisites")
+async def setup_prerequisites() -> dict:
+    return prerequisites_status()
+
+
+@router.post("/api/setup/bootstrap")
+async def setup_bootstrap() -> dict:
+    created = ensure_runtime_layout()
+    staged = stage_models_from_bundle()
+    return {"layout_created": created, "models_staged": staged}
+
+
+@router.post("/api/setup/complete")
+async def setup_complete(body: SetupCompletePayload) -> dict:
+    if body.api_backend == "openai" and not body.openai_api_key.strip():
+        raise HTTPException(400, "Cle API OpenAI requise.")
+    if body.api_backend == "anthropic" and not body.anthropic_api_key.strip():
+        raise HTTPException(400, "Cle API Anthropic requise.")
+    if not body.user_firstname.strip():
+        raise HTTPException(400, "Prenom requis.")
+
+    ensure_runtime_layout()
+    staged = stage_models_from_bundle()
+
+    port = body.port or _find_available_port()
+    livekit_url = ""
+    livekit_api_key = ""
+    livekit_api_secret = ""
+    deepgram_api_key = ""
+
+    if body.voice_enabled:
+        deepgram_api_key = body.deepgram_api_key.strip()
+        if not deepgram_api_key:
+            raise HTTPException(400, "Cle Deepgram requise pour le pipeline vocal.")
+        if body.livekit_cloud:
+            livekit_url = body.livekit_url.strip()
+            livekit_api_key = body.livekit_api_key.strip()
+            livekit_api_secret = body.livekit_api_secret.strip()
+            if not livekit_url or not livekit_api_key or not livekit_api_secret:
+                raise HTTPException(400, "URL et cles LiveKit Cloud requises.")
+        else:
+            livekit_url = "ws://localhost:7880"
+            livekit_api_key = "devkey"
+            livekit_api_secret = "devsecretdevsecretdevsecretdevsecret"
+
+    updates = {
+        "USER_FIRSTNAME": body.user_firstname.strip(),
+        "LLM_PROVIDER": "api",
+        "API_BACKEND": body.api_backend,
+        "ANTHROPIC_API_KEY": body.anthropic_api_key.strip(),
+        "ANTHROPIC_MODEL": body.anthropic_model,
+        "VOICE_ANTHROPIC_MODEL": "claude-haiku-4-5-20251001",
+        "OPENAI_API_KEY": body.openai_api_key.strip(),
+        "OPENAI_MODEL": body.openai_model,
+        "HOST": "127.0.0.1",
+        "PORT": str(port),
+        "ENVIRONMENT": "development",
+        "LOG_LEVEL": "INFO",
+        "PROACTIVE_LAT": body.proactive_lat.strip(),
+        "PROACTIVE_LON": body.proactive_lon.strip(),
+        "PROACTIVE_CITY": body.proactive_city.strip(),
+        "TTS_PROVIDER": body.tts_provider,
+        "ELEVENLABS_API_KEY": body.elevenlabs_api_key.strip(),
+        "ELEVENLABS_VOICE_ID": body.elevenlabs_voice_id.strip(),
+        "ELEVENLABS_MODEL": body.elevenlabs_model,
+        "WHISPER_MODEL": "tiny",
+        "LIVEKIT_URL": livekit_url,
+        "LIVEKIT_API_KEY": livekit_api_key,
+        "LIVEKIT_API_SECRET": livekit_api_secret,
+        "DEEPGRAM_API_KEY": deepgram_api_key,
+        "AISSTREAM_KEY": body.aisstream_key.strip(),
+        "FACE_RECOGNITION_ENABLED": "true" if body.face_recognition_enabled else "false",
+        "SETUP_COMPLETE": "true",
+        "MISTRAL_API_KEY": "",
+        "MISTRAL_MODEL": "mistral-large-latest",
+        "OLLAMA_BASE_URL": "http://localhost:11434",
+        "OLLAMA_MODEL": "mistral",
+        "GOOGLE_API_KEY": "",
+    }
+
+    write_env_batch(updates)
+    return {
+        "ok": True,
+        "port": port,
+        "models_staged": staged,
+        "next": f"http://127.0.0.1:{port}/admin",
+    }
+
+
+@router.post("/api/setup/upload-face")
+async def setup_upload_face(file: UploadFile = File(...)) -> dict:
+    if not file.filename or not file.filename.lower().endswith((".jpg", ".jpeg")):
+        raise HTTPException(400, "Fichier JPG requis.")
+    FACES_DIR.mkdir(parents=True, exist_ok=True)
+    target = FACES_DIR / "reference.jpg"
+    content = await file.read()
+    if len(content) < 1024:
+        raise HTTPException(400, "Image trop petite.")
+    target.write_bytes(content)
+    return {"saved": str(target.relative_to(PROJECT_ROOT)).replace("\\", "/")}

--- a/src/jarvis/interfaces/ui/static/setup.css
+++ b/src/jarvis/interfaces/ui/static/setup.css
@@ -1,0 +1,180 @@
+.setup-shell {
+  position: relative;
+  z-index: 3;
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 32px 24px 24px;
+}
+
+.setup-header {
+  margin-bottom: 24px;
+}
+
+.setup-brand {
+  font-size: 14px;
+  letter-spacing: 0.35em;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.setup-sub {
+  margin-top: 8px;
+  color: var(--fg-2);
+  font-size: 13px;
+}
+
+.setup-steps {
+  display: flex;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.setup-step-dot {
+  flex: 1;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--line-2);
+  transition: background 0.2s ease;
+}
+
+.setup-step-dot.active {
+  background: var(--accent);
+}
+
+.setup-step-dot.done {
+  background: var(--green);
+}
+
+.setup-main {
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.setup-card {
+  background: rgba(15, 20, 31, 0.72);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-4);
+  padding: 24px;
+  backdrop-filter: blur(12px);
+}
+
+.setup-title {
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.setup-lead {
+  color: var(--fg-2);
+  margin: 0 0 24px;
+  line-height: 1.6;
+}
+
+.setup-field {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.setup-field label {
+  color: var(--fg-1);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.setup-field input,
+.setup-field select {
+  width: 100%;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: var(--r-2);
+  color: var(--fg-0);
+  padding: 10px 12px;
+  font: inherit;
+}
+
+.setup-field input:focus,
+.setup-field select:focus {
+  outline: none;
+  border-color: var(--accent-line);
+}
+
+.setup-check {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+  color: var(--fg-1);
+}
+
+.setup-check input {
+  width: auto;
+}
+
+.setup-status-list {
+  display: grid;
+  gap: 10px;
+}
+
+.setup-status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--line-1);
+  border-radius: var(--r-2);
+  background: rgba(6, 8, 13, 0.35);
+}
+
+.setup-status-row span:last-child {
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.setup-status-ok { color: var(--green); }
+.setup-status-warn { color: #f5c542; }
+.setup-status-err { color: var(--red); }
+
+.setup-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+.setup-footer .m-btn {
+  min-width: 120px;
+}
+
+.setup-done {
+  text-align: center;
+  padding: 24px 0;
+}
+
+.setup-done h2 {
+  margin: 0 0 12px;
+  color: var(--green);
+}
+
+.setup-done p {
+  color: var(--fg-2);
+  margin: 0 0 20px;
+}
+
+.setup-done a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.setup-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+@media (max-width: 640px) {
+  .setup-grid-2 { grid-template-columns: 1fr; }
+}

--- a/src/jarvis/interfaces/ui/static/setup.html
+++ b/src/jarvis/interfaces/ui/static/setup.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jarvis — Configuration</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/_shared.css">
+  <link rel="stylesheet" href="/static/setup.css">
+</head>
+<body>
+  <div class="atmo atmo--vignette"></div>
+  <div class="setup-shell">
+    <header class="setup-header">
+      <div class="setup-brand">J · A · R · V · I · S</div>
+      <div class="setup-sub">Configuration initiale</div>
+      <div class="setup-steps" id="step-indicator"></div>
+    </header>
+    <main class="setup-main" id="setup-root"></main>
+    <footer class="setup-footer">
+      <button type="button" class="m-btn m-btn--ghost" id="btn-back" hidden>Retour</button>
+      <button type="button" class="m-btn" id="btn-next">Continuer</button>
+    </footer>
+  </div>
+  <script src="/static/_shared.js"></script>
+  <script src="/static/setup.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/setup.js
+++ b/src/jarvis/interfaces/ui/static/setup.js
@@ -228,6 +228,8 @@
     try {
       cachedStatus = await J.api.get("/api/setup/status");
       await J.api.post("/api/setup/bootstrap", {});
+      if (cachedStatus.user_firstname) form.user_firstname = cachedStatus.user_firstname;
+      if (cachedStatus.api_backend) form.api_backend = cachedStatus.api_backend;
       if (cachedStatus.complete && step < STEPS.length - 1) {
         doneUrl = "http://127.0.0.1:" + (cachedStatus.port || 8000) + "/admin";
         step = STEPS.length - 1;

--- a/src/jarvis/interfaces/ui/static/setup.js
+++ b/src/jarvis/interfaces/ui/static/setup.js
@@ -1,0 +1,314 @@
+(function () {
+  "use strict";
+
+  const J = window.Jarvis;
+  const el = J.el;
+  const root = document.getElementById("setup-root");
+  const btnBack = document.getElementById("btn-back");
+  const btnNext = document.getElementById("btn-next");
+  const stepIndicator = document.getElementById("step-indicator");
+
+  const STEPS = [
+    { id: "welcome", title: "Bienvenue" },
+    { id: "identity", title: "Identite" },
+    { id: "llm", title: "LLM" },
+    { id: "location", title: "Localisation" },
+    { id: "modules", title: "Modules" },
+    { id: "finish", title: "Terminer" },
+  ];
+
+  let step = 0;
+  let doneUrl = "";
+
+  const form = {
+    user_firstname: "",
+    api_backend: "anthropic",
+    anthropic_api_key: "",
+    openai_api_key: "",
+    proactive_city: "Paris",
+    proactive_lat: "48.85",
+    proactive_lon: "2.35",
+    tts_provider: "piper",
+    elevenlabs_api_key: "",
+    elevenlabs_voice_id: "",
+    voice_enabled: false,
+    livekit_cloud: false,
+    livekit_url: "",
+    livekit_api_key: "",
+    livekit_api_secret: "",
+    deepgram_api_key: "",
+    aisstream_key: "",
+    face_recognition_enabled: false,
+    elevenlabs_enabled: false,
+    aisstream_enabled: false,
+  };
+
+  function field(label, key, opts) {
+    const options = opts || {};
+    const wrap = el("div", { class: "setup-field" });
+    wrap.appendChild(el("label", { text: label, for: key }));
+    const input = el("input", {
+      id: key,
+      type: options.type || "text",
+      value: form[key] || "",
+      placeholder: options.placeholder || "",
+    });
+    input.addEventListener("input", () => {
+      form[key] = input.value;
+    });
+    wrap.appendChild(input);
+    return wrap;
+  }
+
+  function checkbox(label, key) {
+    const wrap = el("label", { class: "setup-check" });
+    const input = el("input", { type: "checkbox" });
+    input.checked = !!form[key];
+    input.addEventListener("change", () => {
+      form[key] = input.checked;
+      render();
+    });
+    wrap.appendChild(input);
+    wrap.appendChild(el("span", { text: label }));
+    return wrap;
+  }
+
+  function statusRow(label, ok, detail) {
+    const cls = ok ? "setup-status-ok" : "setup-status-warn";
+    const row = el("div", { class: "setup-status-row" });
+    row.appendChild(el("span", { text: label }));
+    row.appendChild(el("span", { class: cls, text: detail }));
+    return row;
+  }
+
+  function renderIndicator() {
+    stepIndicator.innerHTML = "";
+    STEPS.forEach((s, i) => {
+      const dot = el("div", {
+        class: "setup-step-dot" + (i < step ? " done" : i === step ? " active" : ""),
+        title: s.title,
+      });
+      stepIndicator.appendChild(dot);
+    });
+  }
+
+  function renderWelcome(status) {
+    const card = el("div", { class: "setup-card" });
+    card.appendChild(el("h1", { class: "setup-title", text: "Configuration Jarvis" }));
+    card.appendChild(el("p", {
+      class: "setup-lead",
+      text: "Cet assistant configure ton instance locale. Avec un bundle offline, aucun telechargement supplementaire n'est necessaire.",
+    }));
+    const list = el("div", { class: "setup-status-list" });
+    const prereq = status.prerequisites || {};
+    list.appendChild(statusRow("Bundle offline", prereq.bundle, prereq.bundle ? "pret" : "absent"));
+    list.appendChild(statusRow("Python", prereq.python, prereq.python ? "pret" : "manquant"));
+    list.appendChild(statusRow("Modele YOLO", prereq.yolo_model, prereq.yolo_model ? "pret" : "a copier"));
+    list.appendChild(statusRow("Modele Piper", prereq.piper_model, prereq.piper_model ? "pret" : "a copier"));
+    list.appendChild(statusRow("LiveKit local", prereq.livekit_binary, prereq.livekit_binary ? "pret" : "optionnel"));
+    card.appendChild(list);
+    if (!prereq.offline_ready) {
+      card.appendChild(el("p", {
+        class: "setup-lead",
+        text: "Sans bundle, lance scripts/release/build_bundle une fois avec reseau, ou telecharge une release pre-packaged.",
+      }));
+    }
+    return card;
+  }
+
+  function renderIdentity() {
+    const card = el("div", { class: "setup-card" });
+    card.appendChild(el("h1", { class: "setup-title", text: "Identite" }));
+    card.appendChild(el("p", { class: "setup-lead", text: "Ton prenom est affiche lors du scan biométrique et dans l'interface." }));
+    card.appendChild(field("Prenom", "user_firstname", { placeholder: "Maxime" }));
+    const face = el("div", { class: "setup-field" });
+    face.appendChild(el("label", { text: "Photo de reference (optionnel)" }));
+    const file = el("input", { type: "file", accept: ".jpg,.jpeg" });
+    file.addEventListener("change", async () => {
+      if (!file.files || !file.files[0]) return;
+      const body = new FormData();
+      body.append("file", file.files[0]);
+      try {
+        await fetch("/api/setup/upload-face", { method: "POST", body });
+        J.notify({ kind: "ok", text: "Photo enregistree dans vision_data/faces/" });
+      } catch (_) {
+        J.notify({ kind: "err", text: "Echec upload photo" });
+      }
+    });
+    face.appendChild(file);
+    card.appendChild(face);
+    return card;
+  }
+
+  function renderLlm() {
+    const card = el("div", { class: "setup-card" });
+    card.appendChild(el("h1", { class: "setup-title", text: "LLM principal" }));
+    card.appendChild(el("p", { class: "setup-lead", text: "Choisis le fournisseur utilise pour le chat et les missions." }));
+    const backend = el("div", { class: "setup-field" });
+    backend.appendChild(el("label", { text: "Backend" }));
+    const select = el("select");
+    ["anthropic", "openai"].forEach((v) => {
+      const opt = el("option", { value: v, text: v });
+      if (form.api_backend === v) opt.selected = true;
+      select.appendChild(opt);
+    });
+    select.addEventListener("change", () => {
+      form.api_backend = select.value;
+      render();
+    });
+    backend.appendChild(select);
+    card.appendChild(backend);
+    if (form.api_backend === "openai") {
+      card.appendChild(field("Cle API OpenAI", "openai_api_key", { type: "password" }));
+    } else {
+      card.appendChild(field("Cle API Anthropic", "anthropic_api_key", { type: "password" }));
+    }
+    return card;
+  }
+
+  function renderLocation() {
+    const card = el("div", { class: "setup-card" });
+    card.appendChild(el("h1", { class: "setup-title", text: "Localisation" }));
+    card.appendChild(el("p", { class: "setup-lead", text: "Utilisee par le moteur proactif (meteo, briefing)." }));
+    card.appendChild(field("Ville", "proactive_city"));
+    const grid = el("div", { class: "setup-grid-2" });
+    grid.appendChild(field("Latitude", "proactive_lat"));
+    grid.appendChild(field("Longitude", "proactive_lon"));
+    card.appendChild(grid);
+    return card;
+  }
+
+  function renderModules() {
+    const card = el("div", { class: "setup-card" });
+    card.appendChild(el("h1", { class: "setup-title", text: "Modules optionnels" }));
+    card.appendChild(checkbox("Utiliser ElevenLabs (sinon Piper local)", "elevenlabs_enabled"));
+    if (form.elevenlabs_enabled) {
+      form.tts_provider = "elevenlabs";
+      card.appendChild(field("Cle ElevenLabs", "elevenlabs_api_key", { type: "password" }));
+      card.appendChild(field("Voice ID", "elevenlabs_voice_id"));
+    } else {
+      form.tts_provider = "piper";
+    }
+    card.appendChild(checkbox("Activer le pipeline vocal LiveKit", "voice_enabled"));
+    if (form.voice_enabled) {
+      card.appendChild(checkbox("Utiliser LiveKit Cloud (sinon serveur local)", "livekit_cloud"));
+      card.appendChild(field("Cle Deepgram (STT)", "deepgram_api_key", { type: "password" }));
+      if (form.livekit_cloud) {
+        card.appendChild(field("LiveKit URL", "livekit_url", { placeholder: "wss://..." }));
+        card.appendChild(field("LiveKit API Key", "livekit_api_key", { type: "password" }));
+        card.appendChild(field("LiveKit API Secret", "livekit_api_secret", { type: "password" }));
+      }
+    }
+    card.appendChild(checkbox("Configurer AISstream (globe maritime)", "aisstream_enabled"));
+    if (form.aisstream_enabled) {
+      card.appendChild(field("Cle AISstream", "aisstream_key", { type: "password" }));
+    }
+    card.appendChild(checkbox("Reconnaissance faciale (extra vision installe)", "face_recognition_enabled"));
+    return card;
+  }
+
+  function renderFinish() {
+    const card = el("div", { class: "setup-card setup-done" });
+    card.appendChild(el("h2", { text: "Configuration terminee" }));
+    card.appendChild(el("p", { text: "Jarvis est pret. Lance le serveur principal depuis le terminal." }));
+    if (doneUrl) {
+      const link = el("a", { href: doneUrl, text: doneUrl });
+      link.target = "_blank";
+      card.appendChild(link);
+    }
+    card.appendChild(el("p", {
+      text: "Commande Windows : .\\jarvis.ps1 run — Linux/macOS : jarvis run",
+    }));
+    return card;
+  }
+
+  let cachedStatus = null;
+
+  async function loadStatus() {
+    try {
+      cachedStatus = await J.api.get("/api/setup/status");
+      await J.api.post("/api/setup/bootstrap", {});
+      if (cachedStatus.complete && step < STEPS.length - 1) {
+        doneUrl = "http://127.0.0.1:" + (cachedStatus.port || 8000) + "/admin";
+        step = STEPS.length - 1;
+      }
+    } catch (_) {
+      cachedStatus = { prerequisites: {} };
+    }
+  }
+
+  function render() {
+    renderIndicator();
+    root.innerHTML = "";
+    const current = STEPS[step];
+    let body;
+    if (current.id === "welcome") body = renderWelcome(cachedStatus || {});
+    else if (current.id === "identity") body = renderIdentity();
+    else if (current.id === "llm") body = renderLlm();
+    else if (current.id === "location") body = renderLocation();
+    else if (current.id === "modules") body = renderModules();
+    else body = renderFinish();
+    root.appendChild(body);
+
+    btnBack.hidden = step === 0 || step === STEPS.length - 1;
+    btnNext.textContent = step === STEPS.length - 2 ? "Terminer" : step === STEPS.length - 1 ? "Fermer" : "Continuer";
+  }
+
+  async function submit() {
+    btnNext.disabled = true;
+    btnNext.textContent = "Enregistrement...";
+    try {
+      const payload = {
+        user_firstname: form.user_firstname,
+        api_backend: form.api_backend,
+        anthropic_api_key: form.anthropic_api_key,
+        openai_api_key: form.openai_api_key,
+        proactive_city: form.proactive_city,
+        proactive_lat: form.proactive_lat,
+        proactive_lon: form.proactive_lon,
+        tts_provider: form.tts_provider,
+        elevenlabs_api_key: form.elevenlabs_api_key,
+        elevenlabs_voice_id: form.elevenlabs_voice_id,
+        voice_enabled: form.voice_enabled,
+        livekit_cloud: form.livekit_cloud,
+        livekit_url: form.livekit_url,
+        livekit_api_key: form.livekit_api_key,
+        livekit_api_secret: form.livekit_api_secret,
+        deepgram_api_key: form.deepgram_api_key,
+        aisstream_key: form.aisstream_key,
+        face_recognition_enabled: form.face_recognition_enabled,
+      };
+      const resp = await J.api.post("/api/setup/complete", payload);
+      doneUrl = resp.next;
+      step = STEPS.length - 1;
+      render();
+    } catch (err) {
+      J.notify({ kind: "err", text: err.message || "Echec configuration" });
+      btnNext.textContent = "Terminer";
+    } finally {
+      btnNext.disabled = false;
+    }
+  }
+
+  btnBack.addEventListener("click", () => {
+    if (step > 0) {
+      step -= 1;
+      render();
+    }
+  });
+
+  btnNext.addEventListener("click", async () => {
+    if (step === STEPS.length - 1) {
+      window.close();
+      return;
+    }
+    if (step === STEPS.length - 2) {
+      await submit();
+      return;
+    }
+    step += 1;
+    render();
+  });
+
+  loadStatus().then(render);
+})();

--- a/src/jarvis/kernel/bundle.py
+++ b/src/jarvis/kernel/bundle.py
@@ -26,7 +26,7 @@ def bundle_available() -> bool:
 def load_manifest() -> dict[str, Any]:
     if not MANIFEST_PATH.is_file():
         return {}
-    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8-sig"))
 
 
 def resolve_python() -> Path:

--- a/src/jarvis/kernel/bundle.py
+++ b/src/jarvis/kernel/bundle.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import platform
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+from jarvis.kernel.paths import PROJECT_ROOT
+
+BUNDLE_DIR = PROJECT_ROOT / "bundle"
+MANIFEST_PATH = BUNDLE_DIR / "manifest.json"
+
+
+def _venv_python() -> Path:
+    if sys.platform == "win32":
+        return BUNDLE_DIR / ".venv" / "Scripts" / "python.exe"
+    return BUNDLE_DIR / ".venv" / "bin" / "python"
+
+
+def bundle_available() -> bool:
+    return MANIFEST_PATH.is_file() and _venv_python().is_file()
+
+
+def load_manifest() -> dict[str, Any]:
+    if not MANIFEST_PATH.is_file():
+        return {}
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def resolve_python() -> Path:
+    if bundle_available():
+        return _venv_python()
+    if sys.platform == "win32":
+        candidates = (PROJECT_ROOT / ".venv" / "Scripts" / "python.exe",)
+    else:
+        candidates = (PROJECT_ROOT / ".venv" / "bin" / "python",)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(
+        "Python runtime introuvable. Utilise un bundle offline (scripts/release/build_bundle) "
+        "ou lance uv sync depuis le depot."
+    )
+
+
+def resolve_uv() -> str:
+    if sys.platform == "win32":
+        bundled = BUNDLE_DIR / "bin" / "uv.exe"
+    else:
+        bundled = BUNDLE_DIR / "bin" / "uv"
+    if bundled.is_file():
+        return str(bundled)
+    return "uv"
+
+
+def _platform_bin_name(name: str) -> str:
+    if sys.platform == "win32":
+        return f"{name}.exe"
+    return name
+
+
+def resolve_livekit_binary() -> Path | None:
+    manifest = load_manifest()
+    rel = manifest.get("bin", {}).get("livekit")
+    if rel:
+        path = BUNDLE_DIR / rel
+        if path.is_file():
+            return path
+    for candidate in (
+        BUNDLE_DIR / "bin" / _platform_bin_name("livekit-server"),
+        PROJECT_ROOT / "bin" / _platform_bin_name("livekit-server"),
+    ):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def stage_models_from_bundle() -> list[str]:
+    if not bundle_available():
+        return []
+    manifest = load_manifest()
+    models = manifest.get("models", {})
+    staged: list[str] = []
+
+    yolo_rel = models.get("yolo")
+    if yolo_rel:
+        src = BUNDLE_DIR / yolo_rel
+        dst = PROJECT_ROOT / "yolov8n.pt"
+        if src.is_file() and not dst.is_file():
+            shutil.copy2(src, dst)
+            staged.append(str(dst))
+
+    piper_rel = models.get("piper_onnx")
+    piper_json_rel = models.get("piper_json")
+    if piper_rel:
+        src = BUNDLE_DIR / piper_rel
+        dst = PROJECT_ROOT / "models" / "piper" / "fr_FR-upmc-medium.onnx"
+        if src.is_file() and not dst.is_file():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            staged.append(str(dst))
+    if piper_json_rel:
+        src = BUNDLE_DIR / piper_json_rel
+        dst = PROJECT_ROOT / "models" / "piper" / "fr_FR-upmc-medium.onnx.json"
+        if src.is_file() and not dst.is_file():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            staged.append(str(dst))
+
+    return staged
+
+
+def prerequisites_status() -> dict[str, Any]:
+    manifest = load_manifest()
+    yolo_ok = (PROJECT_ROOT / "yolov8n.pt").is_file()
+    piper_ok = (PROJECT_ROOT / "models" / "piper" / "fr_FR-upmc-medium.onnx").is_file()
+    livekit = resolve_livekit_binary()
+    python_path: str | None = None
+    python_ok = False
+    try:
+        python_path = str(resolve_python())
+        python_ok = True
+    except FileNotFoundError:
+        pass
+
+    return {
+        "bundle": bundle_available(),
+        "bundle_version": manifest.get("version"),
+        "platform": platform.system().lower(),
+        "python": python_ok,
+        "python_path": python_path,
+        "yolo_model": yolo_ok,
+        "piper_model": piper_ok,
+        "livekit_binary": livekit is not None,
+        "livekit_path": str(livekit) if livekit else None,
+        "offline_ready": bundle_available() and python_ok and yolo_ok and piper_ok,
+    }

--- a/src/jarvis/kernel/setup_layout.py
+++ b/src/jarvis/kernel/setup_layout.py
@@ -36,7 +36,7 @@ def read_env_file(env_path: Path) -> dict[str, str]:
     if not env_path.exists():
         return {}
     result: dict[str, str] = {}
-    for line in env_path.read_text(encoding="utf-8").splitlines():
+    for line in env_path.read_text(encoding="utf-8-sig").splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#") or "=" not in stripped:
             continue
@@ -48,7 +48,7 @@ def read_env_file(env_path: Path) -> dict[str, str]:
 def is_setup_complete(env_path: Path | None = None) -> bool:
     path = env_path or Path(".env")
     env = read_env_file(path)
-    if env.get("SETUP_COMPLETE", "").lower() not in ("true", "1", "yes"):
+    if not env.get("USER_FIRSTNAME", "").strip():
         return False
     if env.get("API_BACKEND") == "openai":
         return bool(env.get("OPENAI_API_KEY", "").strip())

--- a/src/jarvis/kernel/setup_layout.py
+++ b/src/jarvis/kernel/setup_layout.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from jarvis.kernel.paths import (
+    FACES_DIR,
+    MEMORY_DATA_DIR,
+    SKILLS_CANDIDATES_DIR,
+    SKILLS_INSTALLED_DIR,
+    WORKSPACE_DIR,
+)
+
+_RUNTIME_DIRS: tuple[Path, ...] = (
+    MEMORY_DATA_DIR / "sessions",
+    MEMORY_DATA_DIR / "topics",
+    MEMORY_DATA_DIR / "conso",
+    MEMORY_DATA_DIR / "initiatives",
+    MEMORY_DATA_DIR / "curator_reports",
+    FACES_DIR,
+    SKILLS_INSTALLED_DIR,
+    SKILLS_CANDIDATES_DIR,
+    WORKSPACE_DIR / "projects",
+)
+
+
+def ensure_runtime_layout() -> list[str]:
+    created: list[str] = []
+    for path in _RUNTIME_DIRS:
+        if not path.exists():
+            path.mkdir(parents=True, exist_ok=True)
+            created.append(str(path))
+    return created
+
+
+def read_env_file(env_path: Path) -> dict[str, str]:
+    if not env_path.exists():
+        return {}
+    result: dict[str, str] = {}
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        result[key.strip()] = value.strip()
+    return result
+
+
+def is_setup_complete(env_path: Path | None = None) -> bool:
+    path = env_path or Path(".env")
+    env = read_env_file(path)
+    if env.get("SETUP_COMPLETE", "").lower() not in ("true", "1", "yes"):
+        return False
+    if env.get("API_BACKEND") == "openai":
+        return bool(env.get("OPENAI_API_KEY", "").strip())
+    return bool(env.get("ANTHROPIC_API_KEY", "").strip())

--- a/src/jarvis/setup_app.py
+++ b/src/jarvis/setup_app.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import threading
+import webbrowser
+
+import uvicorn
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+from jarvis.interfaces.api.setup_wizard import router as setup_router
+from jarvis.kernel.paths import PROJECT_ROOT, UI_STATIC_DIR
+from jarvis.kernel.setup_layout import ensure_runtime_layout
+
+SETUP_PORT = 8765
+SETUP_HOST = "127.0.0.1"
+
+load_dotenv(PROJECT_ROOT / ".env", override=False)
+ensure_runtime_layout()
+
+app = FastAPI(title="Jarvis Setup", docs_url=None, redoc_url=None)
+app.include_router(setup_router)
+
+
+@app.get("/setup")
+async def setup_page() -> FileResponse:
+    return FileResponse(UI_STATIC_DIR / "setup.html")
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "setup"}
+
+
+app.mount("/static", StaticFiles(directory=str(UI_STATIC_DIR)), name="setup-static")
+
+
+def _open_browser() -> None:
+    webbrowser.open(f"http://{SETUP_HOST}:{SETUP_PORT}/setup", new=1)
+
+
+def main() -> None:
+    threading.Timer(1.0, _open_browser).start()
+    uvicorn.run(
+        "jarvis.setup_app:app",
+        host=SETUP_HOST,
+        port=SETUP_PORT,
+        log_level="warning",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1347,7 +1347,6 @@ dependencies = [
     { name = "anthropic" },
     { name = "bambulabs-api" },
     { name = "beautifulsoup4" },
-    { name = "face-recognition" },
     { name = "fastapi" },
     { name = "fastembed" },
     { name = "faster-whisper" },
@@ -1373,6 +1372,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "python-telegram-bot" },
     { name = "pyusb" },
     { name = "pyyaml" },
@@ -1389,6 +1389,9 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
+vision = [
+    { name = "face-recognition" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1404,7 +1407,7 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
     { name = "bambulabs-api", specifier = ">=2.6.6" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
-    { name = "face-recognition", specifier = ">=1.3.0" },
+    { name = "face-recognition", marker = "extra == 'vision'", specifier = ">=1.3.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastembed", specifier = ">=0.4.0" },
     { name = "faster-whisper", specifier = ">=1.1.0" },
@@ -1432,6 +1435,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "python-telegram-bot", specifier = ">=21.0" },
     { name = "pyusb", specifier = ">=1.3.1" },
     { name = "pyyaml", specifier = ">=6.0.0" },
@@ -1442,7 +1446,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "yt-dlp", specifier = ">=2026.3.17" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["vision", "dev"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3303,6 +3307,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Contexte

L'installation actuelle posait deux problèmes :

1. **Téléchargements à chaque install** — Python, `uv`, wheels PyPI, modèles ML, `livekit-server`, et parfois compilation `dlib` (Visual Studio C++ sur Windows)
2. **Configuration en terminal** — `setup.ps1` / `setup.sh` posent des questions en CLI ; `./jarvis eclosion` n'existe pas nativement sous Windows

## Solution

### 1. Bundle offline (`bundle/`)

Scripts de build one-shot (avec réseau, côté maintainer ou release) :

| Script | Plateforme |
|---|---|
| `scripts/release/build_bundle.ps1` | Windows |
| `scripts/release/build_bundle.sh` | Linux / macOS |

Le bundle embarque :

- `bundle/.venv` — environnement Python complet (`uv sync` + `jarvis` installé en editable)
- `bundle/models/` — YOLOv8n + Piper TTS
- `bundle/bin/` — `uv` + `livekit-server`
- `bundle/manifest.json` — inventaire pour détection offline (écrit sans BOM UTF-8)

**Install utilisateur final** : extraire une release avec `bundle/` → **aucun téléchargement** lors de la configuration. Pas de Python, uv, cmake ou Visual C++ requis sur la machine cible.

### 2. Assistant web local (`:8765/setup`)

| Composant | Rôle |
|---|---|
| `src/jarvis/setup_app.py` | Serveur FastAPI minimal (sans `bootstrap.build()`) |
| `src/jarvis/interfaces/api/setup_wizard.py` | API status / bootstrap / complete / upload photo |
| `static/setup.{html,js,css}` | Wizard 6 étapes (style `_shared.css`) |

**Lancement :**

```powershell
.\jarvis.ps1 setup      # Windows
```

```bash
./jarvis eclosion       # Linux / macOS
```

Ouvre automatiquement `http://127.0.0.1:8765/setup` dans le navigateur.

### 3. Correctifs post-review (commit `3bacb65`)

- **`uv pip install -e .`** dans les scripts de build — le package `jarvis` est importable dans `bundle/.venv`
- **Téléchargement LiveKit** via l'API GitHub (anciennes URLs 404) + validation taille archive
- **Lecture `utf-8-sig`** pour `manifest.json` et `.env` (BOM PowerShell)
- **Auto-réparation** dans `setup.ps1` / `setup.sh` si le package manque dans un bundle existant
- **Détection config existante** — `.env` avec prénom + clé API reconnu comme complet (sans exiger `SETUP_COMPLETE`)
- **README** — parcours A (utilisateur final) / B (build bundle) / C (dev sans bundle)

### 4. Autres changements

- `face-recognition` → extra optionnel `vision` (plus de `dlib` obligatoire à l'install)
- `python-multipart` ajouté (upload photo dans le wizard)
- `jarvis.ps1` — CLI Windows bundle-aware (`run`, `api`, `voice`, `setup`)
- `setup.ps1` / `setup.sh` — réduits à un lanceur web (+ mode `-Ci` / `--ci` inchangé pour la CI)

## Parcours utilisateur

```mermaid
flowchart LR
  A[Release ou build_bundle] --> B[bundle/ pret]
  B --> C[jarvis setup / eclosion]
  C --> D[Web :8765/setup]
  D --> E[.env + dossiers]
  E --> F[jarvis run]
```

## Test plan

- [ ] `.\scripts\release\build_bundle.ps1` — crée `bundle/manifest.json` + `.venv` + modèles + `import jarvis.setup_app` OK
- [ ] `.\jarvis.ps1 setup` — ouvre le wizard web, détecte un `.env` existant, génère `.env` avec clés
- [ ] `.\jarvis.ps1 run` — démarre avec le Python du bundle (sans `uv sync`)
- [ ] Upload photo JPG depuis l'étape Identité → `vision_data/faces/reference.jpg`
- [ ] `bash setup.sh --ci` — CI B9 inchangée
- [ ] Linux : `bash scripts/release/build_bundle.sh` puis `./jarvis eclosion`

## Notes

- Le dossier `bundle/` est **gitignoré** — distribué via releases GitHub
- Mode dev sans bundle : `uv sync` reste possible en fallback
- Reconnaissance faciale : `uv sync --extra vision` + `FACE_RECOGNITION_ENABLED=true`
