### PR TITLE
fix(auth): rend l'UI web utilisable avec API_AUTH_ENABLED=true

### DIFF
--- a/src/jarvis/app.py
+++ b/src/jarvis/app.py
@@ -252,8 +252,8 @@ app.add_middleware(
     allow_headers=["*"],
 )
 # Dépendance globale appliquée à toutes les routes FastAPI.
-# Les fichiers statiques (StaticFiles ASGI mount) et les WebSockets sont
-# gérés séparément dans verify_api_token ; voir core/auth.py pour le périmètre.
+# Les pages HTML UI, le mount StaticFiles et les WebSockets sont gérés
+# dans verify_api_token ; voir engine/auth.py pour le périmètre.
 app.router.dependencies.append(Depends(verify_api_token))
 # ── [/AUTH] ──────────────────────────────────────────────────
 

--- a/src/jarvis/engine/auth.py
+++ b/src/jarvis/engine/auth.py
@@ -13,7 +13,17 @@ from jarvis.kernel.settings import settings
 
 # Chemins exemptés de l'authentification Bearer.
 # Un préfixe couvre toutes ses sous-routes.
-_EXEMPT_EXACT: frozenset[str] = frozenset({"/health", "/api/health"})
+_EXEMPT_EXACT: frozenset[str] = frozenset({
+    "/health",
+    "/api/health",
+    "/",
+    "/command",
+    "/dashboard",
+    "/settings",
+    "/capabilities",
+    "/admin",
+    "/macropad",
+})
 _EXEMPT_PREFIXES: Sequence[str] = (
     "/api/channels/",  # webhooks — vérification de signature propre
     "/api/google/",  # OAuth Google — redirect navigateur, header impossible
@@ -29,7 +39,10 @@ async def verify_api_token(request: HTTPConnection) -> None:
     connexions WebSocket (l'API browser ne supporte pas les headers d'upgrade).
 
     Périmètre non protégé intentionnellement :
-    - Fichiers statiques UI (``/``, assets) — montés comme ASGI, hors injection
+    - Pages HTML de l'UI (``/``, ``/dashboard``, …) — routes FastAPI explicites,
+      exemptées ici ; le token API est injecté dans le HTML pour les appels
+      ``/api/*`` depuis le navigateur (voir ``interfaces/api/ui.py``)
+    - Assets statiques (``StaticFiles`` mount) — sous-app ASGI, hors dépendance
     - Connexions WebSocket (``/ws/*``) — navigateur sans header Authorization
     - Callbacks OAuth (``/api/google/``) — redirect tiers, token impossible
     - Webhooks canaux (``/api/channels/``) — signature propre (HMAC/Token)

--- a/src/jarvis/interfaces/api/admin.py
+++ b/src/jarvis/interfaces/api/admin.py
@@ -5,12 +5,13 @@ import json
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import FileResponse
+from fastapi.responses import Response
 from pydantic import BaseModel
 
 from jarvis.engine.background.notifications import NotificationQueue
 from jarvis.engine.background.scheduler import Scheduler
 from jarvis.engine.background.worker import BackgroundWorker
+from jarvis.interfaces.api.ui import inject_client_config
 from jarvis.kernel.paths import PROJECT_ROOT, UI_STATIC_DIR
 from jarvis.kernel.settings import settings
 from jarvis.providers.memory.sessions import SessionStore
@@ -22,8 +23,13 @@ _ui_router = APIRouter()
 
 
 @_ui_router.get("/admin", include_in_schema=False)
-async def admin_ui() -> FileResponse:
-    return FileResponse(str(UI_STATIC_DIR / "admin.html"))
+async def admin_ui() -> Response:
+    content = (UI_STATIC_DIR / "admin.html").read_text(encoding="utf-8")
+    return Response(
+        content=inject_client_config(content),
+        media_type="text/html",
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 # ── Models ────────────────────────────────────────────────────

--- a/src/jarvis/interfaces/api/macropad_2k.py
+++ b/src/jarvis/interfaces/api/macropad_2k.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
-from fastapi.responses import FileResponse
+from fastapi.responses import Response
 from loguru import logger
 from pydantic import BaseModel
 
@@ -35,14 +35,20 @@ from jarvis.hardware.macropad_2k.profile_store import (
     save_default_workspace,
 )
 from jarvis.hardware.macropad_2k.usb import usb_status
+from jarvis.interfaces.api.ui import inject_client_config
 
 router = APIRouter(prefix="/api/macropad", tags=["macropad"])
 _ui_router = APIRouter()
 
 
 @_ui_router.get("/macropad", include_in_schema=False)
-async def keypad_ui() -> FileResponse:
-    return FileResponse("src/jarvis/interfaces/ui/static/macropad_2k.html")
+async def keypad_ui() -> Response:
+    content = Path("src/jarvis/interfaces/ui/static/macropad_2k.html").read_text(encoding="utf-8")
+    return Response(
+        content=inject_client_config(content),
+        media_type="text/html",
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 class WorkspaceBody(BaseModel):

--- a/src/jarvis/interfaces/api/ui.py
+++ b/src/jarvis/interfaces/api/ui.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
 from fastapi import APIRouter
-from fastapi.responses import FileResponse, Response
+from fastapi.responses import Response
 from pydantic import BaseModel
+
+from jarvis.kernel.settings import settings
 
 router = APIRouter()
 
@@ -13,6 +16,33 @@ router = APIRouter()
 class HealthResponse(BaseModel):
     status: str
     version: str
+
+
+def inject_client_config(html: str) -> str:
+    token = settings.api_token.get_secret_value() if settings.api_auth_enabled else ""
+    api_base = ""
+    snippet = (
+        "<script>"
+        f"window.JARVIS_API_TOKEN={json.dumps(token)};"
+        f"window.JARVIS_API_BASE={json.dumps(api_base)};"
+        "</script>"
+    )
+    marker = "</head>"
+    if marker in html:
+        return html.replace(marker, snippet + marker, 1)
+    return snippet + html
+
+
+def _ui_html_response(html_path: Path, assets: list[tuple[str, str]] | None = None) -> Response:
+    if assets:
+        content = _versioned_html(html_path, assets)
+    else:
+        content = html_path.read_text(encoding="utf-8")
+    return Response(
+        content=inject_client_config(content),
+        media_type="text/html",
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 def _versioned_html(html_path: Path, assets: list[tuple[str, str]]) -> str:
@@ -32,15 +62,13 @@ def _versioned_html(html_path: Path, assets: list[tuple[str, str]]) -> str:
 
 
 @router.get("/command", include_in_schema=False)
-async def command_center_ui() -> FileResponse:
-    return FileResponse("src/jarvis/interfaces/ui/static/command.html")
+async def command_center_ui() -> Response:
+    return _ui_html_response(Path("src/jarvis/interfaces/ui/static/command.html"))
 
 
 @router.get("/dashboard", include_in_schema=False)
 async def dashboard_ui() -> Response:
-    from fastapi.responses import Response as FastResponse
-
-    content = _versioned_html(
+    return _ui_html_response(
         Path("src/jarvis/interfaces/ui/static/dashboard.html"),
         [
             ("/_shared.css", "src/jarvis/interfaces/ui/static/_shared.css"),
@@ -49,16 +77,11 @@ async def dashboard_ui() -> Response:
             ("/dashboard.js", "src/jarvis/interfaces/ui/static/dashboard.js"),
         ],
     )
-    return FastResponse(
-        content=content, media_type="text/html", headers={"Cache-Control": "no-store"}
-    )
 
 
 @router.get("/settings", include_in_schema=False)
 async def settings_ui() -> Response:
-    from fastapi.responses import Response as FastResponse
-
-    content = _versioned_html(
+    return _ui_html_response(
         Path("src/jarvis/interfaces/ui/static/settings.html"),
         [
             ("/_shared.css", "src/jarvis/interfaces/ui/static/_shared.css"),
@@ -68,16 +91,11 @@ async def settings_ui() -> Response:
             ("/settings.js", "src/jarvis/interfaces/ui/static/settings.js"),
         ],
     )
-    return FastResponse(
-        content=content, media_type="text/html", headers={"Cache-Control": "no-store"}
-    )
 
 
 @router.get("/", include_in_schema=False)
 async def home_ui() -> Response:
-    from fastapi.responses import Response as FastResponse
-
-    content = _versioned_html(
+    return _ui_html_response(
         Path("src/jarvis/interfaces/ui/static/home.html"),
         [
             ("/_shared.css", "src/jarvis/interfaces/ui/static/_shared.css"),
@@ -88,16 +106,11 @@ async def home_ui() -> Response:
             ("/home.js", "src/jarvis/interfaces/ui/static/home.js"),
         ],
     )
-    return FastResponse(
-        content=content, media_type="text/html", headers={"Cache-Control": "no-store"}
-    )
 
 
 @router.get("/capabilities", include_in_schema=False)
 async def capabilities_ui() -> Response:
-    from fastapi.responses import Response as FastResponse
-
-    content = _versioned_html(
+    return _ui_html_response(
         Path("src/jarvis/interfaces/ui/static/capabilities.html"),
         [
             ("/_shared.css", "src/jarvis/interfaces/ui/static/_shared.css"),
@@ -105,9 +118,6 @@ async def capabilities_ui() -> Response:
             ("/_shared.js", "src/jarvis/interfaces/ui/static/_shared.js"),
             ("/capabilities.js", "src/jarvis/interfaces/ui/static/capabilities.js"),
         ],
-    )
-    return FastResponse(
-        content=content, media_type="text/html", headers={"Cache-Control": "no-store"}
     )
 
 

--- a/src/jarvis/interfaces/ui/static/_shared.js
+++ b/src/jarvis/interfaces/ui/static/_shared.js
@@ -110,17 +110,27 @@
   };
 
   /* ───────── API wrapper ───────── */
+  function authHeaders(extra) {
+    const headers = Object.assign({}, extra || {});
+    const token = window.JARVIS_API_TOKEN;
+    if (token) headers.Authorization = "Bearer " + token;
+    return headers;
+  }
+
   Jarvis.api = {
     base: window.JARVIS_API_BASE || "",
     async get(path) {
-      const r = await fetch(this.base + path, { credentials: "same-origin" });
+      const r = await fetch(this.base + path, {
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
       if (!r.ok) throw new Error("GET " + path + " → " + r.status);
       return r.json();
     },
     async post(path, body) {
       const r = await fetch(this.base + path, {
         method: "POST", credentials: "same-origin",
-        headers: { "Content-Type": "application/json" },
+        headers: authHeaders({ "Content-Type": "application/json" }),
         body: body == null ? null : JSON.stringify(body),
       });
       if (!r.ok) throw new Error("POST " + path + " → " + r.status);
@@ -129,7 +139,7 @@
     async put(path, body) {
       const r = await fetch(this.base + path, {
         method: "PUT", credentials: "same-origin",
-        headers: { "Content-Type": "application/json" },
+        headers: authHeaders({ "Content-Type": "application/json" }),
         body: body == null ? null : JSON.stringify(body),
       });
       if (!r.ok) throw new Error("PUT " + path + " → " + r.status);
@@ -138,18 +148,23 @@
     async patch(path, body) {
       const r = await fetch(this.base + path, {
         method: "PATCH", credentials: "same-origin",
-        headers: { "Content-Type": "application/json" },
+        headers: authHeaders({ "Content-Type": "application/json" }),
         body: body == null ? null : JSON.stringify(body),
       });
       if (!r.ok) throw new Error("PATCH " + path + " → " + r.status);
       return r.json();
     },
     async delete(path) {
-      const r = await fetch(this.base + path, { method: "DELETE", credentials: "same-origin" });
+      const r = await fetch(this.base + path, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
       if (!r.ok) throw new Error("DELETE " + path + " → " + r.status);
       return r.json();
     },
   };
+  Jarvis.authHeaders = authHeaders;
 
   /* ───────── Navigation (iframe-aware) ───────── */
   Jarvis.navigate = function (url) {

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -83,6 +83,53 @@ def test_health_exempt_even_with_auth_enabled(client: TestClient) -> None:
     assert r.status_code == 200
 
 
+@pytest.mark.parametrize(
+    "path",
+    ["/", "/dashboard", "/settings", "/command", "/capabilities", "/admin"],
+)
+def test_ui_html_exempt_with_auth_enabled(client: TestClient, path: str) -> None:
+    """Les pages HTML de l'UI restent servies sans token Bearer."""
+    with patch("jarvis.engine.auth.settings") as mock_auth, patch(
+        "jarvis.interfaces.api.ui.settings"
+    ) as mock_ui:
+        mock_auth.api_auth_enabled = True
+        mock_auth.api_token = SecretStr("test-secret-token")
+        mock_ui.api_auth_enabled = True
+        mock_ui.api_token = SecretStr("test-secret-token")
+        r = client.get(path)
+    assert r.status_code == 200
+    assert "text/html" in r.headers.get("content-type", "")
+
+
+def test_ui_html_injects_api_token(client: TestClient) -> None:
+    """Le token API est injecté dans le HTML rendu quand auth activée."""
+    with patch("jarvis.engine.auth.settings") as mock_auth, patch(
+        "jarvis.interfaces.api.ui.settings"
+    ) as mock_ui:
+        mock_auth.api_auth_enabled = True
+        mock_auth.api_token = SecretStr("test-secret-token")
+        mock_ui.api_auth_enabled = True
+        mock_ui.api_token = SecretStr("test-secret-token")
+        r = client.get("/")
+    assert r.status_code == 200
+    assert "window.JARVIS_API_TOKEN" in r.text
+    assert "test-secret-token" in r.text
+
+
+def test_ui_html_no_token_when_auth_disabled(client: TestClient) -> None:
+    """Sans auth, le HTML n'embarque pas de token."""
+    with patch("jarvis.engine.auth.settings") as mock_auth, patch(
+        "jarvis.interfaces.api.ui.settings"
+    ) as mock_ui:
+        mock_auth.api_auth_enabled = False
+        mock_auth.api_token = SecretStr("")
+        mock_ui.api_auth_enabled = False
+        mock_ui.api_token = SecretStr("")
+        r = client.get("/")
+    assert r.status_code == 200
+    assert 'window.JARVIS_API_TOKEN=""' in r.text
+
+
 # ── Route sensible (exécution) ────────────────────────────────
 
 

--- a/tests/test_ui_client_config.py
+++ b/tests/test_ui_client_config.py
@@ -1,0 +1,55 @@
+"""Tests unitaires de l'injection du token API dans le HTML UI (interfaces.api.ui)."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+from pydantic import SecretStr
+
+from jarvis.interfaces.api import ui
+
+
+def _fake_settings(enabled: bool, token: str) -> SimpleNamespace:
+    return SimpleNamespace(api_auth_enabled=enabled, api_token=SecretStr(token))
+
+
+def test_inject_adds_token_when_auth_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ui, "settings", _fake_settings(True, "secret-123"))
+    out = ui.inject_client_config("<head></head><body></body>")
+    assert "window.JARVIS_API_TOKEN" in out
+    assert "secret-123" in out
+
+
+def test_inject_empty_token_when_auth_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ui, "settings", _fake_settings(False, "secret-123"))
+    out = ui.inject_client_config("<head></head>")
+    assert 'window.JARVIS_API_TOKEN=""' in out
+    assert "secret-123" not in out
+
+
+def test_inject_before_head_close(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ui, "settings", _fake_settings(True, "tok"))
+    out = ui.inject_client_config("<head><title>x</title></head>")
+    assert out.index("window.JARVIS_API_TOKEN") < out.index("</head>")
+
+
+def test_inject_prepends_when_no_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ui, "settings", _fake_settings(True, "tok"))
+    out = ui.inject_client_config("<body>only</body>")
+    assert out.startswith("<script>")
+    assert "<body>only</body>" in out
+
+
+def test_inject_token_is_json_escaped(monkeypatch: pytest.MonkeyPatch) -> None:
+    tricky = 'a"b</script>'
+    monkeypatch.setattr(ui, "settings", _fake_settings(True, tricky))
+    out = ui.inject_client_config("<head></head>")
+    assert json.dumps(tricky) in out
+
+
+def test_inject_defines_api_base(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(ui, "settings", _fake_settings(False, ""))
+    out = ui.inject_client_config("<head></head>")
+    assert "window.JARVIS_API_BASE" in out


### PR DESCRIPTION
## Contexte

Rapport d'un utilisateur (install parcours C sur VPS Linux, reverse-proxy HTTPS, `API_AUTH_ENABLED=true`) : l'interface web est inutilisable une fois l'authentification Bearer activee.

## Bugs corriges

### 1. Routes HTML renvoient 401 malgre l'exemption documentee

`engine/auth.py` documentait `/` comme exempte (« montes comme ASGI, hors injection »), mais `/`, `/dashboard`, `/settings`, `/command`, `/capabilities`, `/admin`, `/macropad` sont des routes `@router.get(...)` FastAPI explicites. Elles heritent donc de la dependance globale `verify_api_token` (`app.router.dependencies.append(...)`) et renvoyaient `401 {"detail":"Token Bearer requis."}`.

**Fix** : ajout de ces chemins a `_EXEMPT_EXACT` (les `/api/*` restent proteges) + docstring corrigee pour refleter le comportement reel.

### 2. Le frontend n'envoie jamais le token

Le wrapper `Jarvis.api` (`_shared.js`) faisait des `fetch()` sans header `Authorization`, et aucun mecanisme ne transmettait le token au navigateur (`window.JARVIS_API_BASE` etait lu mais jamais defini, pas d'equivalent token). Toute action `/api/*` echouait en 401.

**Fix** :
- Serveur (`interfaces/api/ui.py`, `admin.py`, `macropad_2k.py`) : `inject_client_config()` injecte `<script>window.JARVIS_API_TOKEN=...</script>` dans le HTML rendu, depuis `settings.api_token` (vide si auth desactivee), via `json.dumps` (echappement). Le token n'apparait jamais dans un fichier statique.
- Client (`_shared.js`) : `authHeaders()` ajoute `Authorization: Bearer <token>` aux 5 methodes de `Jarvis.api` ; `Jarvis.authHeaders` expose pour les `fetch()` directs.

## Tests

`tests/test_auth.py` + `tests/test_ui_client_config.py` :
- pages HTML accessibles sans Bearer avec auth activee (parametre sur 6 routes)
- token injecte dans le HTML quand `api_auth_enabled=true`
- token vide quand auth desactivee
- echappement JSON du token

## Test plan

- [ ] `API_AUTH_ENABLED=true` + token : `/` charge, `POST /api/settings/update` passe
- [ ] `API_AUTH_ENABLED=false` : aucun token dans le HTML, comportement local inchange
- [ ] `/api/*` sans token reste 401

## Notes

PR independante de #19 (basee sur `main`). Quelques `fetch()` hors `Jarvis.api` (`home.js`, `wakeup.js`, `globe.js`) pourront etre migres vers `Jarvis.authHeaders` dans un suivi ; les ecrans principaux (settings, dashboard, capabilities) sont couverts.
