### PR TITLE
test(unit): tests unitaires sur modules a logique pure

### DIFF
--- a/tests/test_audio_chunker.py
+++ b/tests/test_audio_chunker.py
@@ -1,0 +1,67 @@
+"""Tests unitaires de providers.audio.chunker (decoupage de phrases streaming)."""
+
+from __future__ import annotations
+
+from jarvis.providers.audio.chunker import (
+    MAX_TOKENS_WITHOUT_FLUSH,
+    StreamChunker,
+    split_sentences,
+)
+
+
+def test_split_sentences_basic() -> None:
+    assert split_sentences("Bonjour. Comment vas-tu ?") == ["Bonjour.", "Comment vas-tu ?"]
+
+
+def test_split_sentences_strips_and_drops_empty() -> None:
+    assert split_sentences("   ") == []
+
+
+def test_split_sentences_single_no_punctuation() -> None:
+    assert split_sentences("salut le monde") == ["salut le monde"]
+
+
+def test_split_sentences_multiple_terminators() -> None:
+    assert split_sentences("Ah ! Vraiment ? Oui.") == ["Ah !", "Vraiment ?", "Oui."]
+
+
+def test_chunker_yields_complete_sentence() -> None:
+    c = StreamChunker()
+    assert c.feed("Bonjour") == []
+    out = c.feed(". ")
+    assert out == ["Bonjour."]
+
+
+def test_chunker_accumulates_then_flushes_remainder() -> None:
+    c = StreamChunker()
+    c.feed("Une phrase sans fin")
+    assert c.flush() == "Une phrase sans fin"
+    assert c.flush() is None
+
+
+def test_chunker_flush_resets_buffer() -> None:
+    c = StreamChunker()
+    c.feed("Reste")
+    assert c.flush() == "Reste"
+    assert c.feed("Nouveau.") == ["Nouveau."]
+
+
+def test_chunker_force_flush_after_max_tokens() -> None:
+    c = StreamChunker()
+    out: list[str] = []
+    for _ in range(MAX_TOKENS_WITHOUT_FLUSH):
+        out += c.feed("mot ")
+    assert out
+    assert "mot" in out[-1]
+
+
+def test_chunker_multiple_sentences_in_one_feed() -> None:
+    c = StreamChunker()
+    out = c.feed("Un. Deux. ")
+    assert out == ["Un.", "Deux."]
+
+
+def test_chunker_empty_after_full_consume() -> None:
+    c = StreamChunker()
+    c.feed("Fini. ")
+    assert c.flush() is None

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,0 +1,125 @@
+"""Tests unitaires de kernel.bundle (resolution runtime / manifest offline)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from jarvis.kernel import bundle
+
+
+@pytest.fixture
+def fake_bundle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Reconfigure le module bundle pour pointer vers un faux bundle temporaire."""
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    monkeypatch.setattr(bundle, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(bundle, "BUNDLE_DIR", bundle_dir)
+    monkeypatch.setattr(bundle, "MANIFEST_PATH", bundle_dir / "manifest.json")
+    return bundle_dir
+
+
+def _venv_python(bundle_dir: Path) -> Path:
+    if sys.platform == "win32":
+        p = bundle_dir / ".venv" / "Scripts" / "python.exe"
+    else:
+        p = bundle_dir / ".venv" / "bin" / "python"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("", encoding="utf-8")
+    return p
+
+
+def test_load_manifest_missing_returns_empty(fake_bundle: Path) -> None:
+    assert bundle.load_manifest() == {}
+
+
+def test_load_manifest_reads_json(fake_bundle: Path) -> None:
+    (fake_bundle / "manifest.json").write_text(
+        json.dumps({"version": "1", "platform": "windows"}), encoding="utf-8"
+    )
+    assert bundle.load_manifest() == {"version": "1", "platform": "windows"}
+
+
+def test_load_manifest_tolerates_utf8_bom(fake_bundle: Path) -> None:
+    (fake_bundle / "manifest.json").write_text(
+        json.dumps({"version": "2"}), encoding="utf-8-sig"
+    )
+    assert bundle.load_manifest() == {"version": "2"}
+
+
+def test_bundle_available_false_without_manifest(fake_bundle: Path) -> None:
+    _venv_python(fake_bundle)
+    assert bundle.bundle_available() is False
+
+
+def test_bundle_available_false_without_python(fake_bundle: Path) -> None:
+    (fake_bundle / "manifest.json").write_text("{}", encoding="utf-8")
+    assert bundle.bundle_available() is False
+
+
+def test_bundle_available_true_when_complete(fake_bundle: Path) -> None:
+    (fake_bundle / "manifest.json").write_text("{}", encoding="utf-8")
+    _venv_python(fake_bundle)
+    assert bundle.bundle_available() is True
+
+
+def test_resolve_python_prefers_bundle(fake_bundle: Path) -> None:
+    (fake_bundle / "manifest.json").write_text("{}", encoding="utf-8")
+    expected = _venv_python(fake_bundle)
+    assert bundle.resolve_python() == expected
+
+
+def test_resolve_python_raises_when_nothing(fake_bundle: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        bundle.resolve_python()
+
+
+def test_resolve_uv_falls_back_to_path(fake_bundle: Path) -> None:
+    assert bundle.resolve_uv() == "uv"
+
+
+def test_resolve_uv_uses_bundled_binary(fake_bundle: Path) -> None:
+    bin_dir = fake_bundle / "bin"
+    bin_dir.mkdir()
+    name = "uv.exe" if sys.platform == "win32" else "uv"
+    bundled = bin_dir / name
+    bundled.write_text("", encoding="utf-8")
+    assert bundle.resolve_uv() == str(bundled)
+
+
+def test_resolve_livekit_binary_none_when_absent(fake_bundle: Path) -> None:
+    assert bundle.resolve_livekit_binary() is None
+
+
+def test_resolve_livekit_binary_from_manifest(fake_bundle: Path) -> None:
+    rel = "bin/livekit-server.exe" if sys.platform == "win32" else "bin/livekit-server"
+    target = fake_bundle / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("", encoding="utf-8")
+    (fake_bundle / "manifest.json").write_text(
+        json.dumps({"bin": {"livekit": rel}}), encoding="utf-8"
+    )
+    assert bundle.resolve_livekit_binary() == target
+
+
+def test_prerequisites_status_shape(fake_bundle: Path) -> None:
+    (fake_bundle / "manifest.json").write_text(
+        json.dumps({"version": "9"}), encoding="utf-8"
+    )
+    _venv_python(fake_bundle)
+    status = bundle.prerequisites_status()
+    assert status["bundle"] is True
+    assert status["bundle_version"] == "9"
+    assert status["python"] is True
+    assert status["yolo_model"] is False
+    assert status["piper_model"] is False
+    assert status["offline_ready"] is False
+    for key in ("platform", "python_path", "livekit_binary", "livekit_path"):
+        assert key in status
+
+
+def test_stage_models_noop_without_bundle(fake_bundle: Path) -> None:
+    assert bundle.stage_models_from_bundle() == []

--- a/tests/test_file_lock.py
+++ b/tests/test_file_lock.py
@@ -1,0 +1,48 @@
+"""Tests unitaires de kernel.file_lock (verrou exclusif cross-platform)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jarvis.kernel.file_lock import exclusive_file_lock
+
+
+def test_creates_lock_file(tmp_path: Path) -> None:
+    lock = tmp_path / "sub" / "dir" / "x.lock"
+    with exclusive_file_lock(lock):
+        assert lock.exists()
+
+
+def test_creates_parent_dirs(tmp_path: Path) -> None:
+    lock = tmp_path / "a" / "b" / "c.lock"
+    assert not lock.parent.exists()
+    with exclusive_file_lock(lock):
+        pass
+    assert lock.parent.exists()
+
+
+def test_sequential_reacquire(tmp_path: Path) -> None:
+    lock = tmp_path / "seq.lock"
+    with exclusive_file_lock(lock):
+        pass
+    with exclusive_file_lock(lock):
+        pass
+
+
+def test_yields_inside_critical_section(tmp_path: Path) -> None:
+    lock = tmp_path / "crit.lock"
+    entered = False
+    with exclusive_file_lock(lock):
+        entered = True
+    assert entered
+
+
+def test_releases_on_exception(tmp_path: Path) -> None:
+    lock = tmp_path / "exc.lock"
+    try:
+        with exclusive_file_lock(lock):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    with exclusive_file_lock(lock):
+        pass

--- a/tests/test_ihex.py
+++ b/tests/test_ihex.py
@@ -1,0 +1,80 @@
+"""Tests unitaires de hardware.macropad_2k.ihex (decodage Intel HEX)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jarvis.hardware.macropad_2k.ihex import ihex_to_bin_file, ihex_to_bytes
+
+
+def _checksum(data: bytes) -> int:
+    return (-sum(data)) & 0xFF
+
+
+def _record(count: int, addr: int, rectype: int, payload: bytes) -> str:
+    body = bytes([count, (addr >> 8) & 0xFF, addr & 0xFF, rectype]) + payload
+    return ":" + (body + bytes([_checksum(body)])).hex().upper()
+
+
+def _hex_file(tmp_path: Path, records: list[str]) -> Path:
+    p = tmp_path / "fw.hex"
+    p.write_text("\n".join(records) + "\n", encoding="ascii")
+    return p
+
+
+def test_ihex_simple_data(tmp_path: Path) -> None:
+    records = [
+        _record(4, 0x0000, 0x00, bytes([0xDE, 0xAD, 0xBE, 0xEF])),
+        _record(0, 0x0000, 0x01, b""),
+    ]
+    blob = ihex_to_bytes(_hex_file(tmp_path, records))
+    assert blob == bytes([0xDE, 0xAD, 0xBE, 0xEF])
+
+
+def test_ihex_fills_gaps_with_ff(tmp_path: Path) -> None:
+    records = [
+        _record(1, 0x0000, 0x00, bytes([0x01])),
+        _record(1, 0x0003, 0x00, bytes([0x02])),
+        _record(0, 0x0000, 0x01, b""),
+    ]
+    blob = ihex_to_bytes(_hex_file(tmp_path, records))
+    assert blob == bytes([0x01, 0xFF, 0xFF, 0x02])
+
+
+def test_ihex_stops_at_eof_record(tmp_path: Path) -> None:
+    records = [
+        _record(1, 0x0000, 0x00, bytes([0xAA])),
+        _record(0, 0x0000, 0x01, b""),
+        _record(1, 0x0001, 0x00, bytes([0xBB])),
+    ]
+    blob = ihex_to_bytes(_hex_file(tmp_path, records))
+    assert blob == bytes([0xAA])
+
+
+def test_ihex_ignores_non_colon_lines(tmp_path: Path) -> None:
+    p = tmp_path / "fw.hex"
+    p.write_text(
+        "; comment\n" + _record(1, 0x0000, 0x00, bytes([0x42])) + "\n",
+        encoding="ascii",
+    )
+    assert ihex_to_bytes(p) == bytes([0x42])
+
+
+def test_ihex_empty_raises(tmp_path: Path) -> None:
+    p = tmp_path / "empty.hex"
+    p.write_text("; nothing\n", encoding="ascii")
+    with pytest.raises(ValueError, match="empty intel hex"):
+        ihex_to_bytes(p)
+
+
+def test_ihex_to_bin_file(tmp_path: Path) -> None:
+    records = [
+        _record(2, 0x0000, 0x00, bytes([0x12, 0x34])),
+        _record(0, 0x0000, 0x01, b""),
+    ]
+    hex_path = _hex_file(tmp_path, records)
+    bin_path = tmp_path / "out.bin"
+    ihex_to_bin_file(hex_path, bin_path)
+    assert bin_path.read_bytes() == bytes([0x12, 0x34])

--- a/tests/test_macropad_paths.py
+++ b/tests/test_macropad_paths.py
@@ -1,0 +1,64 @@
+"""Tests unitaires de hardware.macropad_2k.paths (resolution de chemins)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from jarvis.hardware.macropad_2k import paths
+
+
+def test_sketch_dir_uses_workspace(tmp_path: Path) -> None:
+    assert paths.sketch_dir(tmp_path) == tmp_path / "CH552_HID_Keyboard"
+
+
+def test_sketch_dir_defaults_to_firmware_root() -> None:
+    assert paths.sketch_dir(None) == paths.firmware_root() / "CH552_HID_Keyboard"
+
+
+def test_sketch_ino_path(tmp_path: Path) -> None:
+    expected = tmp_path / "CH552_HID_Keyboard" / "CH552_HID_Keyboard.ino"
+    assert paths.sketch_ino(tmp_path) == expected
+
+
+def test_generated_dir(tmp_path: Path) -> None:
+    assert paths.generated_dir(tmp_path) == tmp_path / "CH552_HID_Keyboard" / "generated"
+
+
+def test_usb_hid_dir(tmp_path: Path) -> None:
+    expected = tmp_path / "CH552_HID_Keyboard" / "src" / "userUsbHidKeyboard"
+    assert paths.usb_hid_dir(tmp_path) == expected
+
+
+def test_profile_path(tmp_path: Path) -> None:
+    assert paths.profile_path(tmp_path) == tmp_path / "keypad-studio-profile.json"
+
+
+def test_firmware_root_under_keypad_root() -> None:
+    assert paths.firmware_root() == paths.keypad_root() / "firmware"
+
+
+def test_arduino_cli_executable_extension() -> None:
+    exe = paths.arduino_cli_executable()
+    if sys.platform.startswith("win"):
+        assert exe.name == "arduino-cli.exe"
+    else:
+        assert exe.name == "arduino-cli"
+
+
+def test_is_valid_workspace_false_when_no_ino(tmp_path: Path) -> None:
+    assert paths.is_valid_workspace(tmp_path) is False
+
+
+def test_is_valid_workspace_true_with_ino(tmp_path: Path) -> None:
+    ino = paths.sketch_ino(tmp_path)
+    ino.parent.mkdir(parents=True, exist_ok=True)
+    ino.write_text("// sketch", encoding="utf-8")
+    assert paths.is_valid_workspace(tmp_path) is True
+
+
+def test_is_valid_workspace_accepts_str(tmp_path: Path) -> None:
+    ino = paths.sketch_ino(tmp_path)
+    ino.parent.mkdir(parents=True, exist_ok=True)
+    ino.write_text("// sketch", encoding="utf-8")
+    assert paths.is_valid_workspace(str(tmp_path)) is True

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,50 @@
+"""Tests unitaires de kernel.permissions (PermissionStore runtime)."""
+
+from __future__ import annotations
+
+from jarvis.kernel.permissions import PermissionStore
+
+
+def test_defaults() -> None:
+    store = PermissionStore()
+    assert store.get("microphone") is True
+    assert store.get("screen") is False
+    assert store.get("camera") is False
+    assert store.get("files") is False
+
+
+def test_set_known_key() -> None:
+    store = PermissionStore()
+    store.set("camera", True)
+    assert store.get("camera") is True
+
+
+def test_set_unknown_key_ignored() -> None:
+    store = PermissionStore()
+    store.set("unknown_perm", True)
+    assert store.get("unknown_perm") is True
+    assert "unknown_perm" not in store.all()
+
+
+def test_get_unknown_defaults_true() -> None:
+    store = PermissionStore()
+    assert store.get("not_tracked") is True
+
+
+def test_all_returns_copy() -> None:
+    store = PermissionStore()
+    snapshot = store.all()
+    snapshot["microphone"] = False
+    assert store.get("microphone") is True
+
+
+def test_all_contains_all_known_keys() -> None:
+    store = PermissionStore()
+    assert set(store.all()) == {"microphone", "screen", "camera", "files"}
+
+
+def test_toggle_persists_on_instance() -> None:
+    store = PermissionStore()
+    store.set("screen", True)
+    store.set("screen", False)
+    assert store.get("screen") is False

--- a/tests/test_pricing_schemas.py
+++ b/tests/test_pricing_schemas.py
@@ -1,0 +1,98 @@
+"""Tests unitaires des helpers purs de kernel.schemas (pricing + validation)."""
+
+from __future__ import annotations
+
+import pytest
+
+from jarvis.kernel.schemas import (
+    Initiative,
+    Step,
+    calculate_cost,
+    needs_human_validation,
+    validate_step,
+)
+from jarvis.kernel.vocab import AutonomyLevel
+
+
+def test_calculate_cost_anthropic_tokens() -> None:
+    cost = calculate_cost(
+        "anthropic", "claude-sonnet-4-6", input_tokens=1_000_000, output_tokens=1_000_000
+    )
+    assert cost == pytest.approx(18.0)
+
+
+def test_calculate_cost_openai_with_images() -> None:
+    cost = calculate_cost("openai", "gpt-4o", input_tokens=0, output_tokens=0, images=10)
+    assert cost == pytest.approx(0.02)
+
+
+def test_calculate_cost_elevenlabs_chars() -> None:
+    cost = calculate_cost("elevenlabs", "eleven_turbo_v2_5", characters=1000)
+    assert cost == pytest.approx(0.18)
+
+
+def test_calculate_cost_deepgram_minutes() -> None:
+    cost = calculate_cost("deepgram", "nova-2", audio_minutes=10)
+    assert cost == pytest.approx(0.059)
+
+
+def test_calculate_cost_unknown_provider_is_zero() -> None:
+    assert calculate_cost("nope", "model", input_tokens=1000) == 0.0
+
+
+def test_calculate_cost_unknown_model_is_zero() -> None:
+    assert calculate_cost("anthropic", "totally-unknown-model-xyz", input_tokens=1000) == 0.0
+
+
+def test_calculate_cost_prefix_match() -> None:
+    cost = calculate_cost(
+        "anthropic", "claude-haiku-4-5-20251001", input_tokens=1_000_000
+    )
+    assert cost == pytest.approx(0.25)
+
+
+def test_calculate_cost_no_kwargs_is_zero() -> None:
+    assert calculate_cost("anthropic", "claude-sonnet-4-6") == 0.0
+
+
+def test_validate_step_ok() -> None:
+    step = Step(id="s1", title="t", description="d", success_criterion="le fichier existe")
+    validate_step(step)
+
+
+def test_validate_step_rejects_empty_criterion() -> None:
+    step = Step(id="s1", title="t", description="d", success_criterion="   ")
+    with pytest.raises(ValueError, match="success_criterion"):
+        validate_step(step)
+
+
+def _initiative(level: AutonomyLevel, requires: bool = False) -> Initiative:
+    from jarvis.kernel.schemas import ExecutionMode, InitiativeType, Priority
+
+    return Initiative(
+        id="i1",
+        type=InitiativeType.SUGGESTION,
+        title="t",
+        context="c",
+        reasoning="r",
+        action="a",
+        priority=Priority.LOW,
+        execution_mode=ExecutionMode.NOTIFY,
+        autonomy_level=level,
+        requires_validation=requires,
+    )
+
+
+def test_needs_human_validation_external_always_true() -> None:
+    init = _initiative(AutonomyLevel.EXTERNAL_ACTION, requires=False)
+    assert needs_human_validation(init) is True
+
+
+def test_needs_human_validation_respects_flag() -> None:
+    init = _initiative(AutonomyLevel.SUGGEST, requires=True)
+    assert needs_human_validation(init) is True
+
+
+def test_needs_human_validation_default_false() -> None:
+    init = _initiative(AutonomyLevel.SUGGEST, requires=False)
+    assert needs_human_validation(init) is False

--- a/tests/test_setup_layout.py
+++ b/tests/test_setup_layout.py
@@ -1,0 +1,92 @@
+"""Tests unitaires de kernel.setup_layout (lecture .env + detection setup)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jarvis.kernel.setup_layout import is_setup_complete, read_env_file
+
+
+def _write(path: Path, content: str, encoding: str = "utf-8") -> None:
+    path.write_text(content, encoding=encoding)
+
+
+def test_read_env_file_missing_returns_empty(tmp_path: Path) -> None:
+    assert read_env_file(tmp_path / "absent.env") == {}
+
+
+def test_read_env_file_parses_key_values(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "FOO=bar\nBAZ=qux\n")
+    result = read_env_file(env)
+    assert result == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_read_env_file_skips_comments_and_blanks(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "# comment\n\nFOO=bar\n   \n# another\nBAZ=qux\n")
+    assert read_env_file(env) == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_read_env_file_ignores_lines_without_equals(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "FOO=bar\nNOT_A_PAIR\nBAZ=qux\n")
+    assert read_env_file(env) == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_read_env_file_strips_whitespace(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "  FOO = bar  \n")
+    assert read_env_file(env) == {"FOO": "bar"}
+
+
+def test_read_env_file_handles_utf8_bom(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "FOO=bar\n", encoding="utf-8-sig")
+    assert read_env_file(env) == {"FOO": "bar"}
+
+
+def test_read_env_file_keeps_equals_in_value(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "TOKEN=a=b=c\n")
+    assert read_env_file(env) == {"TOKEN": "a=b=c"}
+
+
+def test_is_setup_complete_false_when_no_firstname(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "API_BACKEND=openai\nOPENAI_API_KEY=sk-test\n")
+    assert is_setup_complete(env) is False
+
+
+def test_is_setup_complete_openai_requires_openai_key(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "USER_FIRSTNAME=Max\nAPI_BACKEND=openai\nOPENAI_API_KEY=\n")
+    assert is_setup_complete(env) is False
+
+
+def test_is_setup_complete_openai_ok(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "USER_FIRSTNAME=Max\nAPI_BACKEND=openai\nOPENAI_API_KEY=sk-test\n")
+    assert is_setup_complete(env) is True
+
+
+def test_is_setup_complete_anthropic_requires_anthropic_key(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "USER_FIRSTNAME=Max\nAPI_BACKEND=anthropic\nANTHROPIC_API_KEY=\n")
+    assert is_setup_complete(env) is False
+
+
+def test_is_setup_complete_anthropic_ok(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "USER_FIRSTNAME=Max\nAPI_BACKEND=anthropic\nANTHROPIC_API_KEY=sk-ant\n")
+    assert is_setup_complete(env) is True
+
+
+def test_is_setup_complete_defaults_to_anthropic_backend(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    _write(env, "USER_FIRSTNAME=Max\nANTHROPIC_API_KEY=sk-ant\n")
+    assert is_setup_complete(env) is True
+
+
+def test_is_setup_complete_missing_file(tmp_path: Path) -> None:
+    assert is_setup_complete(tmp_path / "absent.env") is False

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -1,0 +1,110 @@
+"""Tests unitaires de capabilities.skills._loader (parsing SKILL.md)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jarvis.capabilities.skills._loader import (
+    _check_requirements,
+    _parse_skill_md,
+    load_skills,
+)
+
+_VALID = """---
+name: demo
+description: Une skill de demonstration
+---
+Voici les instructions.
+Multi-lignes.
+"""
+
+
+def _make_skill(root: Path, folder: str, content: str) -> Path:
+    d = root / folder
+    d.mkdir(parents=True, exist_ok=True)
+    md = d / "SKILL.md"
+    md.write_text(content, encoding="utf-8")
+    return md
+
+
+def test_parse_valid_skill(tmp_path: Path) -> None:
+    md = _make_skill(tmp_path, "demo", _VALID)
+    parsed = _parse_skill_md(md)
+    assert parsed is not None
+    assert parsed["name"] == "demo"
+    assert parsed["description"] == "Une skill de demonstration"
+    assert "instructions" in parsed["instructions"].lower() or parsed["instructions"]
+    assert parsed["instructions"].startswith("Voici les instructions.")
+
+
+def test_parse_missing_file_returns_none(tmp_path: Path) -> None:
+    assert _parse_skill_md(tmp_path / "nope" / "SKILL.md") is None
+
+
+def test_parse_without_frontmatter_returns_none(tmp_path: Path) -> None:
+    md = _make_skill(tmp_path, "raw", "Pas de frontmatter ici.")
+    assert _parse_skill_md(md) is None
+
+
+def test_parse_invalid_yaml_returns_none(tmp_path: Path) -> None:
+    bad = "---\nname: [unclosed\n---\nbody\n"
+    md = _make_skill(tmp_path, "bad", bad)
+    assert _parse_skill_md(md) is None
+
+
+def test_parse_name_defaults_to_folder(tmp_path: Path) -> None:
+    content = "---\ndescription: sans nom\n---\nbody\n"
+    md = _make_skill(tmp_path, "myfolder", content)
+    parsed = _parse_skill_md(md)
+    assert parsed is not None
+    assert parsed["name"] == "myfolder"
+
+
+def test_check_requirements_no_openclaw_block() -> None:
+    ok, reason = _check_requirements({})
+    assert ok is True
+    assert reason == ""
+
+
+def test_check_requirements_os_filter_rejects() -> None:
+    meta = {"metadata": {"openclaw": {"os": ["nonexistent-os"]}}}
+    ok, reason = _check_requirements(meta)
+    assert ok is False
+    assert "non support" in reason.lower()
+
+
+def test_check_requirements_missing_binary() -> None:
+    meta = {"metadata": {"openclaw": {"requires": {"bins": ["definitely-not-a-real-bin-xyz"]}}}}
+    ok, reason = _check_requirements(meta)
+    assert ok is False
+    assert "manquant" in reason.lower()
+
+
+def test_check_requirements_missing_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SOME_REQUIRED_KEY_XYZ", raising=False)
+    meta = {"metadata": {"openclaw": {"requires": {"config": ["SOME_REQUIRED_KEY_XYZ"]}}}}
+    ok, reason = _check_requirements(meta)
+    assert ok is False
+    assert "env" in reason.lower()
+
+
+def test_load_skills_empty_dir(tmp_path: Path) -> None:
+    assert load_skills(tmp_path / "absent") == []
+
+
+def test_load_skills_collects_valid(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "demo", _VALID)
+    skills = load_skills(tmp_path)
+    assert len(skills) == 1
+    assert skills[0]["name"] == "demo"
+
+
+def test_load_skills_ignores_underscore_folders(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "demo", _VALID)
+    _make_skill(tmp_path, "_internal", _VALID)
+    skills = load_skills(tmp_path)
+    names = {s["name"] for s in skills}
+    assert "demo" in names
+    assert all(not s["dir"].name.startswith("_") for s in skills)

--- a/tests/test_skill_mapping.py
+++ b/tests/test_skill_mapping.py
@@ -1,0 +1,41 @@
+"""Tests unitaires de capabilities.skills._mapping (mapping outils OpenClaw)."""
+
+from __future__ import annotations
+
+import pytest
+
+from jarvis.capabilities.skills._mapping import TOOL_MAP, UNSUPPORTED, resolve_tool
+
+
+@pytest.mark.parametrize(
+    ("openclaw", "expected"),
+    [
+        ("exec", "run_script"),
+        ("cli", "run_script"),
+        ("web_search", "browser"),
+        ("browser", "browser"),
+        ("read_file", "filesystem"),
+        ("calendar", "calendar_list"),
+        ("notion", "notion_tasks"),
+        ("weather", "weather"),
+    ],
+)
+def test_resolve_known_tools(openclaw: str, expected: str) -> None:
+    assert resolve_tool(openclaw) == expected
+
+
+@pytest.mark.parametrize("tool", sorted(UNSUPPORTED))
+def test_resolve_unsupported_returns_none(tool: str) -> None:
+    assert resolve_tool(tool) is None
+
+
+def test_resolve_unknown_returns_none() -> None:
+    assert resolve_tool("totally_unknown_tool") is None
+
+
+def test_tool_map_values_are_strings() -> None:
+    assert all(isinstance(v, str) and v for v in TOOL_MAP.values())
+
+
+def test_unsupported_and_map_are_disjoint() -> None:
+    assert UNSUPPORTED.isdisjoint(TOOL_MAP.keys())


### PR DESCRIPTION
## Contexte

Ajout de tests unitaires sur des modules a logique pure jusqu'ici non couverts. Aucun mock reseau / LLM / audio / hardware : uniquement parsing, validation, math de pricing, resolution de chemins.

## Contenu — 10 fichiers, 108 tests

| Fichier | Module cible | Couvre |
|---|---|---|
| `test_setup_layout.py` | `kernel/setup_layout.py` | lecture `.env` (BOM, commentaires, `=` dans valeur), `is_setup_complete` |
| `test_bundle.py` | `kernel/bundle.py` | manifest (BOM), resolution python/uv/livekit, `prerequisites_status` |
| `test_permissions.py` | `kernel/permissions.py` | defaults, cles inconnues, copie defensive |
| `test_pricing_schemas.py` | `kernel/schemas.py` | `calculate_cost`, `validate_step`, `needs_human_validation` |
| `test_file_lock.py` | `kernel/file_lock.py` | verrou exclusif, creation parents, release sur exception |
| `test_audio_chunker.py` | `providers/audio/chunker.py` | decoupage phrases, flush streaming, force-flush |
| `test_skill_loader.py` | `capabilities/skills/_loader.py` | parsing SKILL.md, requirements OS/bins/env |
| `test_skill_mapping.py` | `capabilities/skills/_mapping.py` | mapping outils OpenClaw, non supportes |
| `test_ihex.py` | `hardware/macropad_2k/ihex.py` | decodage Intel HEX (gaps FF, EOF, vide) |
| `test_macropad_paths.py` | `hardware/macropad_2k/paths.py` | resolution chemins, `is_valid_workspace` |

## Validation

- 108 tests passent (~0.6s)
- ruff clair sur tous les fichiers

## Notes

Basee sur `feat/offline-setup-wizard` (#19) car `test_bundle.py` et `test_setup_layout.py` couvrent `kernel/bundle.py` et `kernel/setup_layout.py`, modules introduits par cette PR. A merger apres #19.
