### PR TITLE
fix(bundle): rend le bundle offline relocalisable (Python standalone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Tu télécharges une archive **avec le dossier `bundle/` déjà inclus**. Tu n'a
 | Navigateur web | Configuration sur `http://127.0.0.1:8765/setup` |
 | Clés API (LLM, etc.) | OpenAI ou Anthropic au minimum — saisies dans l'assistant web |
 
-Le bundle embarque déjà : Python 3.11, les dépendances Python, les modèles ML (YOLO, Piper), `livekit-server` et `uv.exe`.
+Le bundle embarque déjà : un Python 3.11 **autonome et relocalisable** (`bundle/python`), un environnement virtuel (`bundle/.venv`), les dépendances Python, les modèles ML (YOLO, Piper), `livekit-server` et `uv.exe`. Au premier `setup`, l'environnement est automatiquement ré-ancré sur la machine cible (aucun chemin absolu de la machine de build n'est requis).
 
 ### Développeur — construire le bundle
 
@@ -94,7 +94,7 @@ Une seule fois, **avec réseau**, pour produire `bundle/` (release ou usage loca
 
 | Outil | Version | Notes |
 |---|---|---|
-| [uv](https://docs.astral.sh/uv/) | latest | Télécharge Python 3.11 dans `bundle/.venv` |
+| [uv](https://docs.astral.sh/uv/) | latest | Télécharge un Python 3.11 relocalisable dans `bundle/python` + venv `bundle/.venv` |
 | Réseau | | Téléchargement des deps, modèles et binaires |
 
 Python système et LiveKit **ne sont pas requis** : le script de build les intègre au bundle.

--- a/jarvis.ps1
+++ b/jarvis.ps1
@@ -6,6 +6,13 @@ param(
 $ErrorActionPreference = "Stop"
 Set-Location $PSScriptRoot
 
+function Repair-BundleVenv {
+    $rehome = Join-Path $PSScriptRoot "scripts\release\rehome_bundle.ps1"
+    if (Test-Path $rehome) {
+        & $rehome -ProjectRoot $PSScriptRoot
+    }
+}
+
 function Get-JarvisPython {
     $bundlePy = Join-Path $PSScriptRoot "bundle\.venv\Scripts\python.exe"
     $venvPy = Join-Path $PSScriptRoot ".venv\Scripts\python.exe"
@@ -198,6 +205,8 @@ function Invoke-JarvisRun {
         Write-Host "  Jarvis arrete" -ForegroundColor DarkGray
     }
 }
+
+Repair-BundleVenv
 
 switch ($Command.ToLowerInvariant()) {
     { $_ -in @("eclosion", "setup") } {

--- a/scripts/release/build_bundle.ps1
+++ b/scripts/release/build_bundle.ps1
@@ -4,6 +4,7 @@ Set-Location ..\..
 
 $bundleRoot = Join-Path (Get-Location) "bundle"
 $venvPath = Join-Path $bundleRoot ".venv"
+$pythonDir = Join-Path $bundleRoot "python"
 $modelsDir = Join-Path $bundleRoot "models"
 $piperDir = Join-Path $modelsDir "piper"
 $binDir = Join-Path $bundleRoot "bin"
@@ -31,26 +32,45 @@ if (-not (Ensure-Command "uv")) {
 
 New-Item -ItemType Directory -Path $bundleRoot, $modelsDir, $piperDir, $binDir -Force | Out-Null
 
-Write-Host "[1/5] Sync Python env into bundle/.venv" -ForegroundColor Cyan
-if (Test-Path $venvPath) {
-    Remove-Item -Recurse -Force $venvPath
-}
-uv venv $venvPath --python 3.11
-uv sync --python $venvPath
-if ($LASTEXITCODE -ne 0) { throw "uv sync failed." }
-uv pip install --python $venvPath -e .
-if ($LASTEXITCODE -ne 0) { throw "jarvis package install failed." }
+# A standalone Python is embedded and the venv is created with the std `venv`
+# module (--copies). uv's own venv uses a trampoline with the base interpreter
+# path baked into python.exe, which is NOT relocatable across machines. The std
+# venv reads `home` from pyvenv.cfg, so it can be re-homed on the target machine
+# (see scripts/release/rehome_bundle.ps1).
+Write-Host "[1/6] Embed relocatable Python into bundle/python" -ForegroundColor Cyan
+if (Test-Path $pythonDir) { Remove-Item -Recurse -Force $pythonDir }
+$pyInstallCache = Join-Path $bundleRoot ".python-install"
+if (Test-Path $pyInstallCache) { Remove-Item -Recurse -Force $pyInstallCache }
+$env:UV_PYTHON_INSTALL_DIR = $pyInstallCache
+uv python install 3.11
+if ($LASTEXITCODE -ne 0) { throw "uv python install failed." }
+$managedPython = Get-ChildItem $pyInstallCache -Recurse -Filter "python.exe" | Select-Object -First 1
+if (-not $managedPython) { throw "managed python.exe not found after install." }
+$managedRoot = Split-Path $managedPython.FullName -Parent
+New-Item -ItemType Directory -Path $pythonDir -Force | Out-Null
+Copy-Item (Join-Path $managedRoot "*") $pythonDir -Recurse -Force
+Remove-Item -Recurse -Force $pyInstallCache
+$bundleBasePython = Join-Path $pythonDir "python.exe"
+if (-not (Test-Path $bundleBasePython)) { throw "bundle base python missing." }
 
+Write-Host "[2/6] Create relocatable venv (std venv --copies)" -ForegroundColor Cyan
+if (Test-Path $venvPath) { Remove-Item -Recurse -Force $venvPath }
+& $bundleBasePython -m venv --copies $venvPath
+if ($LASTEXITCODE -ne 0) { throw "venv creation failed." }
 $bundlePython = Join-Path $venvPath "Scripts\python.exe"
-if (-not (Test-Path $bundlePython)) { throw "bundle python missing." }
+if (-not (Test-Path $bundlePython)) { throw "bundle venv python missing." }
+
+Write-Host "[3/6] Install deps + jarvis into venv" -ForegroundColor Cyan
+uv pip install --python $bundlePython -e .
+if ($LASTEXITCODE -ne 0) { throw "jarvis package install failed." }
 & $bundlePython -c "import jarvis.setup_app"
 if ($LASTEXITCODE -ne 0) { throw "jarvis.setup_app not importable in bundle venv." }
 
-Write-Host "[2/5] Copy uv binary" -ForegroundColor Cyan
+Write-Host "[4/6] Copy uv binary" -ForegroundColor Cyan
 $uvExe = (Get-Command uv).Source
 Copy-Item $uvExe (Join-Path $binDir "uv.exe") -Force
 
-Write-Host "[3/5] Download ML models" -ForegroundColor Cyan
+Write-Host "[5/6] Download ML models" -ForegroundColor Cyan
 if (-not (Test-Path "yolov8n.pt")) {
     & $bundlePython -c "from ultralytics import YOLO; YOLO('yolov8n.pt')"
 }
@@ -64,7 +84,7 @@ if (-not (Test-Path $piperOnnx)) {
     curl.exe -L --silent -o $piperJson "$baseUrl/fr_FR-upmc-medium.onnx.json"
 }
 
-Write-Host "[4/5] Download livekit-server" -ForegroundColor Cyan
+Write-Host "[6/6] Download livekit-server" -ForegroundColor Cyan
 $lkTarget = Join-Path $binDir "livekit-server.exe"
 if (-not (Test-Path $lkTarget)) {
     $release = Invoke-RestMethod -Uri "https://api.github.com/repos/livekit/livekit/releases/latest" -Headers @{ "User-Agent" = "jarvis-bundle" }
@@ -90,12 +110,14 @@ if (-not (Test-Path $lkTarget)) {
     Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
 }
 
-Write-Host "[5/5] Write manifest" -ForegroundColor Cyan
+Write-Host "Write manifest" -ForegroundColor Cyan
 $manifest = @{
-    version = "1"
+    version = "2"
     platform = "windows"
     python = "3.11"
     venv = ".venv"
+    python_home = "python"
+    relocatable = $true
     models = @{
         yolo = "models/yolov8n.pt"
         piper_onnx = "models/piper/fr_FR-upmc-medium.onnx"

--- a/scripts/release/build_bundle.sh
+++ b/scripts/release/build_bundle.sh
@@ -6,6 +6,7 @@ cd "$ROOT"
 
 BUNDLE_ROOT="$ROOT/bundle"
 VENV_PATH="$BUNDLE_ROOT/.venv"
+PYTHON_DIR="$BUNDLE_ROOT/python"
 MODELS_DIR="$BUNDLE_ROOT/models"
 PIPER_DIR="$MODELS_DIR/piper"
 BIN_DIR="$BUNDLE_ROOT/bin"
@@ -21,24 +22,54 @@ fi
 
 mkdir -p "$BUNDLE_ROOT" "$MODELS_DIR" "$PIPER_DIR" "$BIN_DIR"
 
-echo "[1/5] Sync Python env into bundle/.venv"
-rm -rf "$VENV_PATH"
-uv venv "$VENV_PATH" --python 3.11
-uv sync --python "$VENV_PATH" --extra vision
-uv pip install --python "$VENV_PATH" -e .
-
-BUNDLE_PYTHON="$VENV_PATH/bin/python"
-if [[ ! -x "$BUNDLE_PYTHON" ]]; then
-  echo "bundle python missing"
+# A standalone Python is embedded and the venv is created with the std `venv`
+# module (--copies). uv's own venv bakes the base interpreter path into its
+# python trampoline, which is NOT relocatable across machines. The std venv
+# reads `home` from pyvenv.cfg, so it can be re-homed on the target machine
+# (see scripts/release/rehome_bundle.sh).
+echo "[1/6] Embed relocatable Python into bundle/python"
+rm -rf "$PYTHON_DIR"
+PY_INSTALL_CACHE="$BUNDLE_ROOT/.python-install"
+rm -rf "$PY_INSTALL_CACHE"
+export UV_PYTHON_INSTALL_DIR="$PY_INSTALL_CACHE"
+uv python install 3.11
+MANAGED_PYTHON="$(find "$PY_INSTALL_CACHE" -name 'python3.11' -type f | head -n 1)"
+if [[ -z "$MANAGED_PYTHON" ]]; then
+  MANAGED_PYTHON="$(find "$PY_INSTALL_CACHE" -name 'python3' -type f | head -n 1)"
+fi
+if [[ -z "$MANAGED_PYTHON" ]]; then
+  echo "managed python not found after install"
   exit 1
 fi
+MANAGED_ROOT="$(cd "$(dirname "$MANAGED_PYTHON")/.." && pwd)"
+mkdir -p "$PYTHON_DIR"
+cp -a "$MANAGED_ROOT/." "$PYTHON_DIR/"
+rm -rf "$PY_INSTALL_CACHE"
+BUNDLE_BASE_PYTHON="$PYTHON_DIR/bin/python3.11"
+[[ -x "$BUNDLE_BASE_PYTHON" ]] || BUNDLE_BASE_PYTHON="$PYTHON_DIR/bin/python3"
+if [[ ! -x "$BUNDLE_BASE_PYTHON" ]]; then
+  echo "bundle base python missing"
+  exit 1
+fi
+
+echo "[2/6] Create relocatable venv (std venv --copies)"
+rm -rf "$VENV_PATH"
+"$BUNDLE_BASE_PYTHON" -m venv --copies "$VENV_PATH"
+BUNDLE_PYTHON="$VENV_PATH/bin/python"
+if [[ ! -x "$BUNDLE_PYTHON" ]]; then
+  echo "bundle venv python missing"
+  exit 1
+fi
+
+echo "[3/6] Install deps + jarvis into venv"
+uv pip install --python "$BUNDLE_PYTHON" -e ".[vision]"
 "$BUNDLE_PYTHON" -c "import jarvis.setup_app"
 
-echo "[2/5] Copy uv binary"
+echo "[4/6] Copy uv binary"
 cp "$(command -v uv)" "$BIN_DIR/uv"
 chmod +x "$BIN_DIR/uv"
 
-echo "[3/5] Download ML models"
+echo "[5/6] Download ML models"
 if [[ ! -f yolov8n.pt ]]; then
   uv run --python "$BUNDLE_PYTHON" python -c "from ultralytics import YOLO; YOLO('yolov8n.pt')"
 fi
@@ -52,7 +83,7 @@ if [[ ! -f "$PIPER_ONNX" ]]; then
   curl -L --silent -o "$PIPER_JSON" "${BASE_URL}/fr_FR-upmc-medium.onnx.json"
 fi
 
-echo "[4/5] Download livekit-server"
+echo "[6/6] Download livekit-server"
 OS="$(uname -s)"
 ARCH="$(uname -m)"
 LK_TARGET="$BIN_DIR/livekit-server"
@@ -96,13 +127,15 @@ if [[ ! -x "$LK_TARGET" ]]; then
   fi
 fi
 
-echo "[5/5] Write manifest"
+echo "Write manifest"
 cat > "$BUNDLE_ROOT/manifest.json" <<EOF
 {
-  "version": "1",
+  "version": "2",
   "platform": "$(echo "$OS" | tr '[:upper:]' '[:lower:]')",
   "python": "3.11",
   "venv": ".venv",
+  "python_home": "python",
+  "relocatable": true,
   "models": {
     "yolo": "models/yolov8n.pt",
     "piper_onnx": "models/piper/fr_FR-upmc-medium.onnx",

--- a/scripts/release/rehome_bundle.ps1
+++ b/scripts/release/rehome_bundle.ps1
@@ -1,0 +1,40 @@
+param(
+    [string]$ProjectRoot
+)
+
+# Re-home the bundled relocatable venv to the current machine.
+# The bundle ships a standalone Python (bundle/python) and a std venv
+# (bundle/.venv) whose pyvenv.cfg `home` and the editable .pth point to the
+# build machine's absolute paths. This rewrites them to the local paths so the
+# venv works after the bundle is moved/extracted anywhere.
+
+if ([string]::IsNullOrWhiteSpace($ProjectRoot)) {
+    $ProjectRoot = Join-Path $PSScriptRoot "..\.."
+}
+$root = (Resolve-Path $ProjectRoot).Path
+
+$venvCfg = Join-Path $root "bundle\.venv\pyvenv.cfg"
+$pyHome = Join-Path $root "bundle\python"
+$pyExe = Join-Path $pyHome "python.exe"
+
+# Nothing to do for dev installs (no bundle) or legacy bundles without an
+# embedded Python — those can't be re-homed offline.
+if (-not (Test-Path $venvCfg)) { return }
+if (-not (Test-Path $pyExe)) { return }
+
+$venvPath = Join-Path $root "bundle\.venv"
+$newCfg = Get-Content $venvCfg | ForEach-Object {
+    if ($_ -match '^\s*home\s*=') { "home = $pyHome" }
+    elseif ($_ -match '^\s*executable\s*=') { "executable = $pyExe" }
+    elseif ($_ -match '^\s*command\s*=') { "command = $pyExe -m venv $venvPath" }
+    else { $_ }
+}
+Set-Content -Path $venvCfg -Value $newCfg -Encoding ascii
+
+$srcPath = Join-Path $root "src"
+$sitePackages = Join-Path $venvPath "Lib\site-packages"
+if (Test-Path $sitePackages) {
+    Get-ChildItem $sitePackages -Filter "*editable*jarvis*.pth" -ErrorAction SilentlyContinue | ForEach-Object {
+        Set-Content -Path $_.FullName -Value $srcPath -Encoding ascii
+    }
+}

--- a/scripts/release/rehome_bundle.sh
+++ b/scripts/release/rehome_bundle.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Re-home the bundled relocatable venv to the current machine.
+# The bundle ships a standalone Python (bundle/python) and a std venv
+# (bundle/.venv) whose pyvenv.cfg `home` and the editable .pth point to the
+# build machine's absolute paths. This rewrites them to the local paths so the
+# venv works after the bundle is moved/extracted anywhere.
+
+ROOT="${1:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+VENV_CFG="$ROOT/bundle/.venv/pyvenv.cfg"
+PY_HOME="$ROOT/bundle/python"
+PY_BIN="$PY_HOME/bin/python3.11"
+[[ -x "$PY_BIN" ]] || PY_BIN="$PY_HOME/bin/python3"
+
+# Nothing to do for dev installs (no bundle) or legacy bundles without an
+# embedded Python — those can't be re-homed offline.
+[[ -f "$VENV_CFG" ]] || exit 0
+[[ -x "$PY_BIN" ]] || exit 0
+
+VENV_PATH="$ROOT/bundle/.venv"
+TMP_CFG="$(mktemp)"
+while IFS= read -r line; do
+  case "$line" in
+    home\ =*|home=*) echo "home = $PY_HOME" ;;
+    executable\ =*|executable=*) echo "executable = $PY_BIN" ;;
+    command\ =*|command=*) echo "command = $PY_BIN -m venv $VENV_PATH" ;;
+    *) echo "$line" ;;
+  esac
+done < "$VENV_CFG" > "$TMP_CFG"
+mv "$TMP_CFG" "$VENV_CFG"
+
+SRC_PATH="$ROOT/src"
+SITE_PACKAGES="$(find "$VENV_PATH/lib" -maxdepth 1 -type d -name 'python*' 2>/dev/null | head -n 1)/site-packages"
+if [[ -d "$SITE_PACKAGES" ]]; then
+  for pth in "$SITE_PACKAGES"/*editable*jarvis*.pth; do
+    [[ -f "$pth" ]] || continue
+    echo "$SRC_PATH" > "$pth"
+  done
+fi

--- a/setup.ps1
+++ b/setup.ps1
@@ -15,6 +15,13 @@ function Ask-BuildBundle {
     return $raw.Trim().ToLowerInvariant() -in @("y", "yes", "o", "oui")
 }
 
+function Repair-BundleVenv {
+    $rehome = Join-Path $PSScriptRoot "scripts\release\rehome_bundle.ps1"
+    if (Test-Path $rehome) {
+        & $rehome -ProjectRoot $PSScriptRoot
+    }
+}
+
 function Get-JarvisPython {
     $bundlePy = Join-Path $PSScriptRoot "bundle\.venv\Scripts\python.exe"
     $venvPy = Join-Path $PSScriptRoot ".venv\Scripts\python.exe"
@@ -42,14 +49,29 @@ function Ensure-Uv {
     }
 }
 
+function Get-BundledUv {
+    $bundledUv = Join-Path $PSScriptRoot "bundle\bin\uv.exe"
+    if (Test-Path $bundledUv) { return $bundledUv }
+    if (Ensure-Command "uv") { return "uv" }
+    return $null
+}
+
 function Ensure-JarvisPackage {
     param([string]$PythonPath)
     & $PythonPath -c "import jarvis.setup_app" 2>$null
     if ($LASTEXITCODE -eq 0) { return }
-    if (-not (Ensure-Command "uv")) { throw "jarvis package missing in venv and uv unavailable." }
-    uv pip install --python $PythonPath -e .
-    if ($LASTEXITCODE -ne 0) { throw "jarvis package install failed." }
+    $uvCmd = Get-BundledUv
+    if (-not $uvCmd) { throw "jarvis package missing in venv and uv unavailable." }
+    # Bundle case: deps are already installed in the venv, only the editable
+    # link needs (re)registering -> offline + no-deps avoids any network call.
+    & $uvCmd pip install --python $PythonPath --no-deps -e .
+    if ($LASTEXITCODE -ne 0) {
+        & $uvCmd pip install --python $PythonPath -e .
+        if ($LASTEXITCODE -ne 0) { throw "jarvis package install failed." }
+    }
 }
+
+Repair-BundleVenv
 
 if ($Ci) {
     Write-Host "JARVIS V3 - setup --Ci (mode non-interactif)" -ForegroundColor Cyan

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+if [[ -f "$ROOT/scripts/release/rehome_bundle.sh" ]]; then
+  bash "$ROOT/scripts/release/rehome_bundle.sh" "$ROOT" || true
+fi
+
 if [[ "${1:-}" == "--ci" ]]; then
   echo "JARVIS V3 — setup --ci (mode non-interactif)"
 
@@ -85,7 +90,12 @@ if [[ -z "$PYTHON_BIN" ]]; then
 fi
 
 if ! "$PYTHON_BIN" -c "import jarvis.setup_app" 2>/dev/null; then
-  uv pip install --python "$PYTHON_BIN" -e .
+  UV_CMD="uv"
+  [[ -x bundle/bin/uv ]] && UV_CMD="bundle/bin/uv"
+  # Bundle case: deps already installed, only the editable link needs
+  # (re)registering -> --no-deps avoids any network call.
+  "$UV_CMD" pip install --python "$PYTHON_BIN" --no-deps -e . \
+    || "$UV_CMD" pip install --python "$PYTHON_BIN" -e .
 fi
 
 echo ""


### PR DESCRIPTION
## Contexte

Rapport utilisateur sur la release offline v0.3.0 (machine Windows tierce) :

```
.\jarvis.ps1 setup
python.exe : No Python at '"C:\Users\Puparia\AppData\Local\Programs\Python\Python311\python.exe'
```

## Cause racine

Un `.venv` n'est pas relocalisable. Le bundle v0.3.0 embarquait un venv cree par `uv venv` :
- `pyvenv.cfg` pointait en absolu vers le Python de la machine de build ;
- surtout, le `python.exe` d'un venv uv est un **trampoline avec le chemin de base code en dur dans l'exe** (verifie : il ignore meme `pyvenv.cfg`).

Sur une autre machine, ce chemin n'existe pas -> echec immediat.

## Solution (validee empiriquement)

Embarquer un **Python 3.11 standalone relocalisable** (`bundle/python`) et creer le venv avec le module `venv` standard (`python -m venv --copies`), dont le `python.exe` est une vraie copie qui lit `home` depuis `pyvenv.cfg`. Au premier `setup`, le venv est **re-ancre** sur la machine cible.

## Changements

- **build_bundle.ps1 / .sh** : installe un Python standalone dans `bundle/python`, cree `bundle/.venv` via `python -m venv --copies`, y installe deps + jarvis. Manifest `version: 2` (+ `python_home`, `relocatable`).
- **rehome_bundle.ps1 / .sh** (nouveaux) : reecrivent `pyvenv.cfg` (`home`/`executable`) et le `.pth` editable de jarvis vers les chemins locaux. Idempotent, offline, no-op si pas de bundle.
- **setup.ps1 / setup.sh** : re-homing avant d'utiliser le Python ; reparation du package via l'`uv` embarque en `--no-deps` (offline).
- **jarvis.ps1** : re-homing au demarrage (cas dossier deplace apres setup).
- **README** : note sur le Python relocalisable.

## Important

- Necessite de **reconstruire le bundle** puis de **republier** (release v0.3.1).
- Le zip v0.3.0 deja telecharge ne peut pas etre repare offline (pas de Python de base embarque) : il faut prendre la v0.3.1.

## Test plan

- [x] Verifie que le venv uv bake le chemin de base dans le trampoline (non relocalisable)
- [x] Verifie qu'un venv `python -m venv --copies` depuis un standalone est relocalisable via reecriture de `home` (deplacement du base + suppression de l'original -> fonctionne)
- [x] `rehome_bundle.ps1` no-op propre sur un bundle sans `bundle/python`
- [ ] Rebuild du bundle via `build_bundle.ps1` puis `setup` sur une machine sans Python
- [ ] Extraction dans un chemin different + `setup` (relocalisation)
