### PR TITLE
fix(run): l'API ne démarrait jamais (quoting cmd) + sortie UTF-8

### DIFF
--- a/jarvis.ps1
+++ b/jarvis.ps1
@@ -6,6 +6,13 @@ param(
 $ErrorActionPreference = "Stop"
 Set-Location $PSScriptRoot
 
+# Force UTF-8 for every child Python process. When stdout/stderr are redirected to
+# a log file (run command), Python otherwise falls back to the legacy ANSI code page
+# (cp1252) with strict error handling, so any non-cp1252 char in a log line (e.g. the
+# arrow glyph) raises UnicodeEncodeError, kills the process and leaves an empty log.
+$env:PYTHONUTF8 = "1"
+$env:PYTHONIOENCODING = "utf-8"
+
 function Repair-BundleVenv {
     $rehome = Join-Path $PSScriptRoot "scripts\release\rehome_bundle.ps1"
     if (Test-Path $rehome) {
@@ -103,7 +110,11 @@ function Start-BackgroundProcess {
         [string]$CommandLine,
         [string]$LogPath
     )
-    $wrapped = "$CommandLine > `"$LogPath`" 2>&1"
+    # Wrap the whole command in an outer quote pair. `cmd /c` strips that outer pair
+    # before executing; without it, a CommandLine that starts with a quoted path (e.g.
+    # "C:\...\python.exe") triggers cmd's quote-stripping rule, mangles the command and
+    # it silently never runs — leaving an empty log and an API that never binds.
+    $wrapped = "`"$CommandLine > `"$LogPath`" 2>&1`""
     return Start-Process -FilePath "cmd.exe" `
         -ArgumentList @("/c", $wrapped) `
         -WorkingDirectory $PSScriptRoot `

--- a/src/jarvis/app.py
+++ b/src/jarvis/app.py
@@ -1,7 +1,19 @@
 from __future__ import annotations
 
-import asyncio
 import sys
+
+# Force UTF-8 on stdout/stderr before anything logs. When the process is launched
+# with its streams redirected to a file (e.g. jarvis.ps1 run), Python defaults to the
+# legacy ANSI code page (cp1252 on FR Windows) with strict errors, so a single log
+# line carrying a non-cp1252 glyph raises UnicodeEncodeError and crashes startup with
+# an empty log. backslashreplace guarantees logging never raises again.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="backslashreplace")  # type: ignore[union-attr]
+    except (AttributeError, ValueError, OSError):
+        pass
+
+import asyncio
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path


### PR DESCRIPTION
## Contexte

Un collaborateur signale `API timeout` au lancement de `.\jarvis.ps1 run` (bundle offline v0.3.1), avec un `api.log` totalement vide. LiveKit démarre, l'API non.

## Cause racine

`Start-BackgroundProcess` lançait l'API ainsi :

```
cmd /c "C:\...\python.exe" -m jarvis.app > "...\api.log" 2>&1
```

Quand la chaîne passée à `cmd /c` commence par un guillemet (le chemin python quoté), `cmd.exe` applique sa règle de suppression de guillemets et la commande échoue silencieusement : python n'est jamais lancé. Le `api.log` pré-créé reste vide et l'API ne bind jamais, d'où le timeout. LiveKit n'était pas touché car sa commande commence par un chemin non quoté.

Bug latent associé : une fois la redirection réparée, Python écrit dans le log avec l'encodage hérité cp1252 strict. Le code logue des caractères hors cp1252 (`→`, `✓`...), ce qui déclenche `UnicodeEncodeError` et un crash au démarrage.

## Correctifs

- `jarvis.ps1` : `Start-BackgroundProcess` entoure toute la commande d'une paire de guillemets externes que `cmd /c` retire proprement (guillemets internes préservés : chemin python, clés LiveKit, `&&`).
- `jarvis.ps1` : `PYTHONUTF8=1` / `PYTHONIOENCODING=utf-8` pour tous les process Python enfants.
- `src/jarvis/app.py` : reconfigure `stdout`/`stderr` en UTF-8 (`errors=backslashreplace`) avant tout log, en défense en profondeur pour les autres modes de lancement.

Aucun rebuild du bundle ni release : fichiers texte uniquement. Le bundle utilise une install éditable pointant vers `src/`, donc remplacer ces 2 fichiers dans un dossier déjà extrait suffit.

## Validation

- Bug isolé de façon déterministe : commande `cmd /c` à guillemet en tête -> fichier jamais créé / python jamais lancé ; commande ré-entourée de guillemets -> OK.
- Encodage : `→` (U+2192) redirigé en cp1252 -> `UnicodeEncodeError` ; avec `PYTHONUTF8=1` -> OK.
- Après correctif : `/health` répond `200 {"status":"ok","version":"0.1.0"}` en ~2s et `api.log` se remplit normalement.

## Test plan

- [ ] `.\jarvis.ps1 run` démarre l'API sans timeout, `api.log` non vide
- [ ] LiveKit et le pipeline vocal démarrent toujours (commandes compatibles)
- [ ] `.\jarvis.ps1 api` (foreground) inchangé
