### PR TITLE
feat(music): provider musique local sous Linux (MPRIS / D-Bus)

### DIFF
--- a/docs/architecture/2026-06-20-reflexion-delegation-multimodele-extensibilite.md
+++ b/docs/architecture/2026-06-20-reflexion-delegation-multimodele-extensibilite.md
@@ -1,0 +1,195 @@
+# Session de réflexion — délégation multi-modèle & extensibilité (skills / MCP)
+
+**Date :** 2026-06-20 (soir)
+**Environnement :** VM `jarvis-dev` (`192.168.122.166`), Ollama **cloud** `gemma4:31b-cloud` + `kimi-k2.7-code:cloud`.
+**Nature :** session de **conception** (architecture) + **vérifications empiriques ciblées** via SSH.
+
+> Ce document est **complémentaire** des deux autres docs du jour et ne les répète pas :
+> - [docs/tests/2026-06-20-tests-vm-fonctionnement-utilisateur.md](../tests/2026-06-20-tests-vm-fonctionnement-utilisateur.md) — tests de fonctionnement (chat, musique, mission engine, bugs A0–H).
+> - [docs/changelogs/2026-06-20-music-provider-local-linux.md](../changelogs/2026-06-20-music-provider-local-linux.md) — patch musique MPRIS + annexes (placeholders clés API, `compute_type` Whisper).
+>
+> Voir **§5 (anti-redite)** pour ce qui est volontairement renvoyé à ces docs.
+
+---
+
+## 1. Objet
+
+Partant de l'échec de la mission « créer un agent Kimi » (déjà constaté dans le doc de tests, item 4),
+on a remonté la question de fond : **comment Jarvis s'étend** (skills, MCP) et **comment faire
+cohabiter deux modèles** (Gemma pour la conversation, Kimi pour le code). La session a produit
+une cartographie de l'extensibilité + un **diagnostic empirique neuf** sur les capacités réelles du frontal.
+
+---
+
+## 2. Volet extensibilité — skills & MCP
+
+### 2.1 Le système de skills (cartographie)
+
+- Couche L1, [src/jarvis/capabilities/skills/](../../src/jarvis/capabilities/skills/), à côté des `tools/`.
+  Distinction nette : **`tools/`** = outils natifs livrés dans le package ; **`skills/`** = extensions
+  portables installées hors package (`skills_data/installed/`), partageables, stables via l'ABI `skills.*`
+  (cf. [skills-abi.md](skills-abi.md)).
+- **Catalogue communautaire** = repo GitHub **`Grominet95/jarvis-skills`** ; l'installeur
+  ([installer.py:17](../../src/jarvis/capabilities/skills/installer.py#L17)) télécharge depuis
+  `raw.githubusercontent.com/Grominet95/jarvis-skills/main`, [catalog.json](../../src/jarvis/capabilities/skills/catalog.json)
+  en est le miroir.
+- **3 types** : `conversational` (`SkillBase` = `SYSTEM_PROMPT` injecté + `get_tools()`), `preset`
+  (séquence `skill.yaml` déclenchée par triggers → `execute_preset`), `view` (UI JS/CSS).
+- **2 sources d'install** : `jarvis-skills` (officiel) **et** **ClawHub** (`clawhub.ai`,
+  [_clawhub.py](../../src/jarvis/capabilities/skills/_clawhub.py)). Un skill = code Python arbitraire →
+  `vet-skill` recommandé avant install d'un skill tiers.
+- Gouvernance du repo (CONTRIBUTING.md / AGENTS.md) : validation **statique** uniquement
+  (`validate_catalog.py`, `build_index.py`, 1 extension/PR, secrets via `requires_env`).
+  Le **comportement runtime relève de jarvis-OS** (sandbox Docker).
+
+### 2.2 MCP — état réel
+
+- **Aucun pont MCP générique.** Le seul MCP de la codebase est **Fusion 360**, codé **en dur** comme
+  *tool natif* : [capabilities/tools/fusion.py](../../src/jarvis/capabilities/tools/fusion.py) (`_FusionClient`,
+  HTTP JSON-RPC 2.0, `Mcp-Session-Id`, SSE, port 27182). Mono-serveur, 3 outils écrits à la main,
+  **pas** de `tools/list` (découverte dynamique).
+- **« Intégrations »** (onglet de [capabilities.js](../../src/jarvis/interfaces/ui/static/capabilities.js))
+  = **panneau de saisie de credentials** (clés/OAuth/URL → `.env`), **pas** un système de plugins MCP.
+- **Gmail / Calendar** = *tools natifs* + **OAuth2 Google officiel** (`google-auth-oauthlib`,
+  [google_oauth.py](../../src/jarvis/interfaces/api/google_oauth.py)), pas du MCP. Même pattern que Notion/Spotify.
+
+### 2.3 Brancher un MCP (FreeCAD, Context7…) — faisabilité
+
+Possible **via un skill/tool** dont le `get_tools()` réutilise le client de `fusion.py`. Conditions :
+
+| Critère | Impact |
+|---|---|
+| Transport **HTTP/SSE** (ex. Context7) | `_FusionClient` réutilisable quasi tel quel ✅ |
+| Transport **stdio** (beaucoup de MCP FreeCAD) | couche stdio à écrire (spawn + pipes) |
+| **Sandbox Docker** | service distant = accès réseau ; app locale = joindre l'hôte |
+| **Auth** | clé API → `requires_env` |
+
+**Context7** est le meilleur banc d'essai (remote HTTP, auth par clé, 2 outils). **Réserve d'usage** :
+Context7 sert un agent qui code → pertinent seulement si Jarvis fait de l'aide au dev.
+Conclusion : le pattern MCP→skill est viable, mais **rien n'est prêt** — c'est à écrire.
+
+---
+
+## 3. Volet délégation multi-modèle (Gemma frontal + Kimi worker)
+
+### 3.1 La vision
+
+Jarvis **multi-modèle** : le frontal conversationnel (`gemma4:31b-cloud`) **délègue** les tâches de
+code/complexes à un sous-agent sur modèle spécialisé (`kimi-k2.7-code:cloud`). Jarvis = chef d'orchestre,
+pas l'agent de code. Reco : livrables bornés (Word/Excel/scripts) → natif ; gros projets → déléguer à un
+vrai agent de code ; **ne pas réimplémenter** une boucle agentique de code dans Jarvis.
+
+### 3.2 Vérifications empiriques **nouvelles** (non présentes dans le doc de tests)
+
+1. **gemma4:31b-cloud sait faire du function-calling natif.** Test direct sur le daemon
+   (`POST /api/chat` + champ `tools`) → `tool_calls` impeccable (`get_weather{city:"Paris"}`) en **~300 ms**.
+   → **Le frontal n'est PAS le maillon faible.** L'hypothèse « petit modèle = ne tool-call pas »
+   (avertissement [local.py:55-62](../../src/jarvis/providers/llm/local.py#L55-L62)) **ne s'applique pas** à gemma4.
+
+2. **Deux mécanismes de déclenchement distincts** :
+   - **marqueur texte** `[BG:PROJECT]` (parsé par Jarvis) → marche **sans** function-calling →
+     c'est ce qui a déclenché la mission Kimi ;
+   - **tool_calls natifs** (browser, weather…) → nécessitent le function-calling du modèle.
+   ([subagent.py](../../src/jarvis/capabilities/tools/subagent.py) : `spawn_subagent` interne vs `[BG:PROJECT]` livrable.)
+
+3. **Échec « trouve une pizzeria » = parité d'outils incomplète côté Ollama (PAS un skill cassé, PAS le modèle).**
+   L'outil de recherche **existe** : tool `browser`, action `search` = **DuckDuckGo**
+   ([browser.py:207](../../src/jarvis/capabilities/tools/browser.py#L207)), **enregistré au boot**
+   ([bootstrap.py:292](../../src/jarvis/bootstrap.py#L292)) et autorisé sans confirmation
+   (`web_search: ALWAYS` = exécute sans demander, [approvals.py](../../src/jarvis/kernel/approvals.py)).
+   **Mais en conversation, les outils ne sont passés au LLM que si le provider a `stream_with_capture`**
+   ([agent.py:228](../../src/jarvis/engine/agent.py#L228)) — défini **4× dans `api.py`** (Anthropic/OpenAI/Mistral/Gemini),
+   **0× dans `local.py`** (Ollama). Avec Ollama on tombe donc dans `_simple_stream()`
+   ([agent.py:236-244](../../src/jarvis/engine/agent.py#L236-L244)) → `complete()` **sans outils** → gemma ne voit
+   jamais le `browser` → **complaisance** (« je regarde ça »). Installer `web-researcher` n'aide pas (et **aggrave**
+   le « répond puis s'arrête » : son prompt pousse à chercher un outil indisponible). **Fix réel : implémenter
+   `stream_with_capture` sur `OllamaProvider`** — son `tool_loop` fait déjà 90 % (passe les outils, parse les
+   `tool_calls` natifs). Insight projet : **parité d'outils-en-conversation incomplète entre backends** (Jarvis
+   développé surtout sur Anthropic ; Ollama de second rang sur ce point).
+
+4. **Sélecteur de modèle (Settings) = global, pas par rôle.** L'onglet *Modèles* **détecte
+   dynamiquement** Kimi via `GET /api/ollama/models` → daemon `/api/tags`
+   ([config/llm.py:62](../../src/jarvis/interfaces/api/config/llm.py#L62)) — re-query live, sans redémarrage —
+   et permet de switcher avec **hot-swap** (`_LLM_HOT_SWAP_KEYS`,
+   [config/_env.py:52](../../src/jarvis/interfaces/api/config/_env.py#L52)). **MAIS** ça change `OLLAMA_MODEL`,
+   le modèle **global** lu par toutes les instances ([factory.py:10-13](../../src/jarvis/providers/llm/factory.py#L10-L13)).
+   Switcher = basculer **TOUT** l'assistant sur Kimi (« un **OU** l'autre »), **pas** une délégation par rôle
+   (« Gemma **ET** Kimi »).
+
+5. **C'est gemma (pas Kimi) qui a exécuté la mission.** Le `WorkerAgent` reçoit `voice_llm` à l'injection
+   ([worker_agent.py:618](../../src/jarvis/engine/mission/worker_agent.py#L618)) = backend global = gemma.
+   Kimi n'est câblé dans aucune instance de provider — seulement servi par le daemon. La mission
+   « fais bosser Kimi » a donc été faite **par gemma**, qui a écrit un JSON mentionnant `"model": "kimi-k2.7-code"`
+   sans jamais appeler Kimi.
+
+### 3.3 Diagnostic d'architecture
+
+- Le frontal est **capable** (tool-call + marqueurs). Ce qui manque : **(a)** des capacités installées
+  (0 skill, pas d'outil de recherche) ; **(b)** la **délégation par rôle** (un modèle ≠ par agent).
+- Le choix du modèle est aujourd'hui **global** (un seul `OLLAMA_MODEL`). La vision exige **deux providers
+  simultanés**, pas une bascule manuelle.
+
+### 3.4 Le câblage requis (minimal)
+
+Le `WorkerAgent` **n'a quasiment pas à changer** : il accepte déjà son LLM par injection
+([worker_agent.py:220-231](../../src/jarvis/engine/mission/worker_agent.py#L220-L231)). Deux points seulement :
+
+1. **`OllamaProvider` paramétrable** — aujourd'hui fige `settings.ollama_model`
+   ([local.py:52](../../src/jarvis/providers/llm/local.py#L52)) → ajouter un `model` optionnel.
+2. **Bootstrap** — construire **2 instances** sur le même daemon (gemma frontal + kimi worker) et injecter
+   la bonne au worker, au lieu de `voice_llm`.
+
+Respecte les couches : provider en **L1**, injection en **L3** (`bootstrap`), worker (L2) agnostique du modèle.
+**Auth Ollama cloud** = au niveau **daemon** (`ollama signin`), transparente pour le provider → rien à faire côté auth.
+Le **hot-swap** existant prouve que recréer un `OllamaProvider` à la volée fonctionne → brique réutilisable
+pour la 2ᵉ instance.
+
+**Statique vs dynamique :**
+
+| Approche | Sens | Effort |
+|---|---|---|
+| **Statique** (recommandé pour démarrer) | worker **toujours** sur Kimi ; le frontal ne décide rien | les 2 points ci-dessus |
+| **Dynamique** | modèle **choisi par mission** | + mécanisme de décision (critère, qui choisit, transport du choix) |
+
+Le statique réalise déjà la vision (le mission engine ne sert qu'aux tâches lourdes = celles à mettre sur Kimi).
+
+---
+
+## 4. Lien avec MCP
+
+Dans cette architecture, MCP devient **accessoire** : le cœur, c'est l'**exécution de code vérifiée**
+(le mission engine + sandbox Docker, déjà en place). MCP (ex. Context7) = source de doc fraîche, branchée
+*sur l'agent de code*, en option — utile mais pas structurant.
+
+---
+
+## 5. Volontairement **non répété** ici (voir doc de tests / changelog)
+
+Déjà documenté ailleurs, pas redétaillé dans ce compte rendu :
+
+- **Run mission Kimi** (Docker, plan 10 étapes, 5 fichiers, triche step_005, vérif anti-faux-succès) → doc tests §4.
+- **Proactif** (détection d'échec + initiative HIGH + boucle de relance) → doc tests A0/A1/A2.
+- **Mission inadaptée** (reconfigurer Jarvis via agent sandboxé = impossible, voie = config) → doc tests D.
+- **Approbations / classification d'accès** (gate posé par le LLM) → doc tests G.
+- **Pas de retour utilisateur sur l'échec** → doc tests H.
+- **UX boutons / permissions / Retry** → doc tests 3, B.
+- **torch.hub VAD, placeholders clés API, `compute_type` Whisper** → doc tests C + annexes du changelog.
+
+---
+
+## 6. Suite
+
+1. 🍕 **Recherche web (cause réelle)** : implémenter `stream_with_capture` sur `OllamaProvider` (base = son `tool_loop` existant) pour que les outils — dont `browser`/DuckDuckGo — soient exposés à gemma **en conversation**. (Installer `web-researcher` ne suffit pas : l'outil existe déjà, il n'est juste pas passé au modèle côté Ollama.)
+2. 🔌 **Câbler Kimi (statique)** : `OllamaProvider(model=…)` paramétrable + 2 instances au bootstrap + injection worker.
+   (Le « choix dynamique du modèle » = itération ultérieure.)
+3. 🧹 Désamorcer la boucle proactive sur la mission impossible (cf. doc tests A2 / item D).
+4. 🧩 **MCP** (optionnel) : prototyper un skill « pont MCP » sur Context7 (transport HTTP), base = `_FusionClient`.
+
+---
+
+## 7. Note — papier de recherche
+
+Cette expérimentation (assistant perso self-hosted **multi-modèle** : délégation par rôle, proactif
+gouverné, **limites de la self-modification** d'un agent, garde-fous sandbox, découverte dynamique de
+modèles) constitue le **matériau d'un papier de recherche** à venir. Findings bruts conservés en mémoire
+(`jarvis-vm-delegation-findings`, `jarvis-multimodel-delegation`).

--- a/docs/changelogs/2026-06-20-music-provider-local-linux.md
+++ b/docs/changelogs/2026-06-20-music-provider-local-linux.md
@@ -1,0 +1,159 @@
+# Provider musique « local » sous Linux (MPRIS / D-Bus)
+
+**Date :** 2026-06-20
+**Branche :** `feat/local-music-linux-mpris`
+**Commits :** `feat(music): support du provider local sous Linux (MPRIS via D-Bus)`,
+`feat(music): embarque la pochette MPRIS file:// en data: URI`
+
+---
+
+## Contexte
+
+Le provider musique `MUSIC_PROVIDER=local` ne fonctionnait que sous **macOS**
+(via le binaire `nowplaying-cli`). Sous Linux, l'UI affichait « non connecté »
+quel que soit le réglage : `nowplaying-cli` est absent et aucune alternative
+n'était câblée.
+
+## Ce qui change
+
+Ajout d'une **branche Linux** dans
+[`src/jarvis/interfaces/api/local_music.py`](../../src/jarvis/interfaces/api/local_music.py)
+qui lit le « now playing » via le standard **MPRIS2 sur le bus D-Bus session**,
+avec la lib **`jeepney`** (pur Python, aucun binaire système).
+
+- `_backend()` : macOS (`nowplaying-cli`) → sinon Linux (MPRIS) → sinon `None`.
+- Lecture de l'état : titre, artiste, album, pochette, position, durée,
+  statut lecture/pause — via les propriétés MPRIS `org.mpris.MediaPlayer2.Player`.
+- Contrôles : `play` / `pause` / `next` / `previous` (méthodes MPRIS).
+- Sélection du lecteur : préfère un lecteur en cours de lecture, sinon le premier.
+- **Pochette** : `mpris:artUrl` en `file://` (que le navigateur refuse de charger
+  depuis une page `http://`) est lu côté serveur et embarqué en **`data:` URI**
+  (sniff PNG/JPEG/GIF/WebP, plafond 5 Mo). Les URL `http(s)`/`data:` passent
+  telles quelles. C'est la même image que la zone média du bureau (même propriété).
+
+Aucune route HTTP ajoutée : les 5 endpoints existants
+(`GET /api/local-music/player`, `POST .../play|pause|next|previous`) sont conservés.
+Le chemin macOS est strictement inchangé.
+
+## Dépendance
+
+`jeepney>=0.8.0` ajouté à `pyproject.toml` + `uv.lock` → **embarqué automatiquement
+dans le bundle** au prochain `build_bundle.sh` (pur Python, pas de binaire à
+télécharger). Conforme à la logique « tout embarqué » du déploiement offline.
+
+## Compatibilité
+
+- **Toutes les distros desktop** (Ubuntu, Debian, Fedora, Arch, openSUSE, Mint…) :
+  MPRIS2 + D-Bus session sont des standards FreeDesktop, indépendants de la distro,
+  du bureau (GNOME/KDE/XFCE/Cinnamon) et de X11/Wayland.
+- Players pris en charge : navigateurs (Chromium/Firefox/Vivaldi…), Spotify, VLC,
+  mpv, etc. — y compris en Flatpak/Snap (MPRIS exposé sur le bus session).
+- **Pré-requis hôte** (non embarquables, présents par défaut sur un bureau Linux) :
+  une session **D-Bus** (`/run/user/<uid>/bus`) + un player exposant **MPRIS2**.
+- Headless / SSH sans session D-Bus → renvoie proprement `connected: false`.
+- ⚠️ glibc (le Python du bundle est glibc x86_64) — pas Alpine/musl (limite du
+  bundle, pas de `jeepney`).
+
+## Validation
+
+- Tests unitaires `tests/test_local_music.py` (10) : détection backend, parsing
+  des propriétés MPRIS, résolution de pochette (http passthrough, `file://` →
+  `data:` URI, fichier absent, schéma inconnu) — **passent**.
+- Suite rapide `pytest -m "not integration"` : **719 passent**, 0 régression.
+- `ruff check` + `ruff format` : clean.
+- `lint-imports` : 4 contrats de couches **KEPT**.
+- Snapshot des routes : inchangé (aucune route ajoutée).
+- **Vérifié en live** : lecture YouTube dans Vivaldi remontée dans l'UI
+  (titre + pochette), `provider: local`, backend `linux`, sans `playerctl`.
+
+---
+
+## Annexe — à résoudre : placeholders de clés API faussement « connectés » au déploiement
+
+**Découvert pendant cette session, hors périmètre du patch musique.**
+
+### Symptôme
+
+Sur une installation fraîche (`.env` issu de `.env.example`), la page des
+intégrations affiche **« CONNECTÉ »** pour Anthropic, OpenAI, Google et
+ElevenLabs alors qu'**aucune vraie clé** n'est renseignée — uniquement des
+placeholders d'exemple.
+
+### Cause
+
+La détection « connecté » de
+[`src/jarvis/interfaces/api/config/devices.py`](../../src/jarvis/interfaces/api/config/devices.py)
+(`get_connectors` → `_env_ok`) considère une clé valide si elle est **non vide**,
+ne **commence pas** par `...` et n'est pas `—` :
+
+```python
+def _valid(v: str) -> bool:
+    v = v.strip()
+    return bool(v) and not v.startswith("...") and v != "—"
+```
+
+Or les placeholders de `.env.example` ne respectent pas tous cette convention de
+sentinelle. Incohérence :
+
+| Clé (`.env.example`) | Placeholder | `_env_ok` | Affichage |
+|---|---|---|---|
+| `ANTHROPIC_API_KEY` | `sk-ant-...` | ✅ valide | **CONNECTÉ** (faux) |
+| `OPENAI_API_KEY` | `sk-proj-...` | ✅ valide | **CONNECTÉ** (faux) |
+| `GOOGLE_API_KEY` | `AIza...` | ✅ valide | **CONNECTÉ** (faux) |
+| `ELEVENLABS_API_KEY` | `sk_...` | ✅ valide | **CONNECTÉ** (faux) |
+| `DEEPGRAM_API_KEY` | `...` | ❌ sentinelle | off (correct) |
+| `MISTRAL_API_KEY` | `...` | ❌ sentinelle | off (correct) |
+
+Seuls Deepgram et Mistral utilisent la sentinelle `...` reconnue comme « non
+configuré » ; les autres commencent par un préfixe réaliste (`sk-`, `AIza`) qui
+passe le test → faux positif.
+
+### Pistes de résolution
+
+1. **Minimal (recommandé)** — aligner `.env.example` : mettre **toutes** les clés
+   non renseignées sur une valeur reconnue comme « non configuré » (vide, ou la
+   sentinelle `...`). Les badges refléteront alors la réalité sur un déploiement
+   neuf. Aucun code à toucher.
+2. **Plus robuste** — durcir `_env_ok` pour reconnaître les préfixes de placeholder
+   courants (`sk-ant-...`, `sk-proj-...`, `AIza...`, `sk_...`, se terminant par
+   `...`) comme non configurés. Heuristique, à maintenir.
+3. **De fond** — ne plus déduire l'état « connecté » d'une chaîne sentinelle :
+   suivre explicitement les clés réellement saisies (l'assistant `/setup` n'écrit
+   que les vraies valeurs ; champ vide = non configuré). Refacto plus large.
+
+> Contournement appliqué en dev cette session : les clés inutilisées du `.env`
+> local ont été mises sur la sentinelle `...` (Ollama étant le backend réel), ce
+> qui rend les badges corrects localement — mais ne corrige pas `.env.example`.
+
+---
+
+## Annexe — à faire : `compute_type` Whisper non adapté au CPU (déploiement sans GPU)
+
+**Identifié pendant la prépa de la VM de dev (CPU only), hors périmètre du patch.**
+
+### Symptôme
+
+Sur un déploiement **sans GPU** (VM de dev, serveur headless), la transcription
+Whisper « directe » est lente : `compute_type="float16"` est orienté GPU et n'est
+pas supporté en calcul CPU par CTranslate2 (repli float32, lent).
+
+### Cause
+
+[`src/jarvis/providers/audio/stt.py`](../../src/jarvis/providers/audio/stt.py) force :
+
+```python
+WhisperModel(settings.whisper_model, device="auto", compute_type="float16")
+```
+
+À noter : le chemin **temps réel** ([`receiver.py`](../../src/jarvis/providers/audio/receiver.py),
+RealtimeSTT) utilise **déjà** `compute_type="int8"` → seul `stt.py` est concerné.
+
+### Piste de résolution
+
+Rendre `compute_type` **adaptatif** : `float16` si GPU disponible, sinon `int8`
+(rapide sur CPU). Permettrait `small`, voire `medium`, à une latence acceptable en
+VM. Alternative : exposer `compute_type` en réglage (`.env`).
+
+> Note d'usage : pour la voix **conversationnelle**, `tiny`/`small` suffisent même
+> sur GPU ; `medium` reste pertinent surtout pour la transcription **batch** de
+> fichiers, à garder sur un poste équipé d'un GPU (hors Jarvis).

--- a/docs/jarvis-os_analyse_detaillee_2026-06-20.md
+++ b/docs/jarvis-os_analyse_detaillee_2026-06-20.md
@@ -1,0 +1,339 @@
+# Jarvis OS — analyse détaillée du projet
+
+> **Date** : 2026-06-20 · **Analyste** : Claude (Vincent Guilbert)
+> **Périmètre** : `/home/vinc1/IdeaProjects/jarvis-OS` (v0.2.0)
+> **Méthode** : analyse 100 % statique — lecture de code, **aucune exécution** du projet.
+> Recoupée sur 4 explorations parallèles + lecture directe des fichiers d'exécution
+> sensibles + scan CVE des dépendances (via recherche web).
+
+---
+
+## 0. Avertissement licence (à lire avant de « participer »)
+
+Ce n'est **pas** un projet B+D. C'est le projet personnel de **Barthélemy Houot**
+(`@Grominet95`), sous **Proprietary Source License** (© 2026) :
+
+- ✅ Autorisé : lire le code (perso / éducatif), l'exécuter en privé.
+- ❌ Interdit sans **accord écrit de l'auteur** : modifier, créer une œuvre dérivée,
+  contribuer, redistribuer, héberger pour des tiers, usage commercial.
+
+**Conséquence** : toute contribution suppose d'abord un accord explicite de l'auteur
+(barth.houot@gmail.com). Le reste de ce document suppose cet accord obtenu.
+
+---
+
+## 1. Carte d'identité
+
+| Champ | Valeur |
+|---|---|
+| Nom | Jarvis OS (`jarvis-os`) — assistant personnel IA, texte + voix temps réel, self-hosted |
+| Auteur / licence | Barthélemy Houot — Proprietary Source License |
+| Version | `0.2.0` (tag `v0.2.0-architecture`), post-refonte « Opération Squelette » |
+| Langage | Python 3.11 (`>=3.11,<3.14`), tout async |
+| Volume | ~34 500 lignes / 220 modules dans `src/jarvis/` (les docs citent ~46k au total) |
+| Tests | ~587 unitaires (< 30 s) + ~28 `integration` |
+| Deps | `uv` + `uv.lock`, packaging `hatchling` (layout `src/`) |
+| Langue projet | Français (code, commits, docs, prompts) |
+| Process | API FastAPI (`jarvis.app`) **+** agent vocal LiveKit (`jarvis.interfaces.voice.agent`) |
+
+---
+
+## 2. Ce que fait Jarvis
+
+Assistant local qui : **dialogue** (chat web + voix temps réel LiveKit + Telegram),
+**se souvient** (faits atomiques datés), **agit** via des outils (web, Gmail, Calendar,
+Spotify, Notion, vision, shell, impression 3D, CAO Fusion 360), **exécute des missions**
+planifiées et vérifiées, **prend des initiatives** proactives gouvernées, et **apprend**
+(fabrique ses propres « skills », testées en sandbox Docker avant validation humaine).
+
+---
+
+## 3. Architecture en couches strictes (le cœur)
+
+Code packagé sous `src/jarvis/` mais importé comme `jarvis.*`. **4 couches dont les
+dépendances sont validées mécaniquement par `import-linter`** (gate CI à chaque push).
+
+| Couche | Package(s) | Rôle | Peut importer |
+|---|---|---|---|
+| **L0** | `kernel/` | Contrats (`Protocols`), `schemas`, bus d'événements, `settings`, `vocab`, `paths`, gouvernance de base | rien d'interne |
+| **L1** | `providers/`, `capabilities/`, `analytics/`, `hardware/` | LLM / Mémoire / Audio / Vision ; Outils + Skills ; widgets ; périphériques | `kernel` uniquement (jamais entre eux) |
+| **L2** | `engine/` | Orchestration : Gateway, Agent, Router, Sessions, Budget, Mission Engine, Proactif, Background | `kernel` uniquement |
+| **L3** | `interfaces/`, `app.py`, `bootstrap.py` | Routers FastAPI, pipeline voix, composition root | tout |
+
+**4 règles `forbidden`** (`pyproject.toml`) : ① `kernel` n'importe rien d'interne ·
+② les 4 packages L1 n'importent que `kernel` · ③ `engine` n'importe que `kernel` ·
+④ aucun module `jarvis.*` n'importe le namespace de données racine `config/`.
+
+**Composition root unique** — `bootstrap.build()` instancie le graphe (~30 objets),
+ordre `settings → bus → providers → capabilities → engine`, **synchrone et sans réseau**.
+Deux entry-points (API + voix) l'appellent tous deux → session, mémoire et outils partagés.
+
+---
+
+## 4. Carte des sous-systèmes
+
+**L2 — `engine/`**
+
+| Module | Responsabilité |
+|---|---|
+| `agent.py` | Construit le prompt (statique + mémoire + outils), stream LLM, capture les `tool_use` |
+| `gateway.py` | Point d'entrée chat unique : session, notifications, routing, boucle d'outils |
+| `router.py` | `SpeedRouter` (sans état) : détecte le tag `[I]/[CF]/[BG]/[BG:PROJECT]` |
+| `session.py` | `SessionManager` : registre mémoire + restauration JSONL |
+| `mission/` | `orchestrator` → `worker_agent` → `verifier` (3 couches) → `reflexion` (leçon) ; `governance` (gate), `capability_engine`, backends (local/Docker/SSH/RPC) |
+| `proactive/` | `engine` (boucle ~30 min), `command_center` (vue agrégée), `curator` (entretien nocturne), `collectors/` |
+| `background/` | `worker` (file asyncio), `scheduler` (9h/3h…), `notifications`, `routines` (cron) |
+
+**L1 — `providers/`**
+
+| Module | Implémente | Détails |
+|---|---|---|
+| `llm/` | `LLMProvider` | Anthropic, OpenAI, Mistral (client OpenAI), Gemini, Ollama — streaming + tool-loop |
+| `memory/` | `MemoryStore`, `FTSIndex`, `VectorIndex` | Memory Kernel SQLite + miroir Markdown + recherche FTS5/sémantique (`fastembed`) + AutoDream/Consolidation |
+| `audio/` | `TTSEngine` | STT (faster-whisper / Deepgram / RealtimeSTT) · TTS (Piper / ElevenLabs) |
+| `vision/` | détecteur + recon faciale | Daemon webcam ~2 fps, YOLOv8n, reconnaissance faciale optionnelle (dlib) |
+
+**L3 — `interfaces/`** : ~25 routers FastAPI (`chat`, `memory`, `budget`, `proactive`,
+`skills`, `sessions`, `vision`, `system`, `setup_wizard`, `config/*`, `admin`…), pipeline
+voix LiveKit, canaux de messagerie, UI admin statique.
+
+---
+
+## 5. Flux d'une mission (bout en bout)
+
+```
+Demande → Gateway → [BG:PROJECT] → BackgroundWorker → ProjectOrchestrator
+  → LLM planifie N étapes (chacune DOIT avoir un success_criterion)
+  → WorkerAgent exécute chaque étape (outils sous gate composite)
+     → Verifier 3 couches : structurelle → déterministe (commande) → sémantique (LLM juge)
+     → échec ⇒ retry (max 2), sinon FAILED
+  → Reflexion : produit une « leçon » → ingérée en mémoire ; si pertinent ⇒ candidat skill
+```
+Reprise après crash, audit immuable de chaque décision.
+
+---
+
+## 6. Mémoire (Memory Kernel)
+
+Extraction de **faits atomiques** datés, sourcés, renforçables, jamais supprimés.
+SQLite = source de vérité ; miroir Markdown **unidirectionnel** (corriger = événement
+`human_correction`).
+
+| Table | Contenu |
+|---|---|
+| `events` | Log immuable de tout ce qui arrive |
+| `facts` | Claims atomiques (prédicat/catégorie d'un vocabulaire fermé), statut, confiance, decay |
+| `fact_observations` | Renforcement sans duplication |
+| `fact_relations` | `supersedes` / `contradicts` / `supports` / `related_to` |
+
+SQLite WAL + busy_timeout (concurrence API ↔ voix). Consolidation nocturne (AutoDream +
+ConsolidationAgent).
+
+---
+
+## 7. Outils disponibles
+
+| Outil | Sensibilité | Rôle |
+|---|---|---|
+| `browser` | 🌐 Réseau | Fetch + scraping + recherche DuckDuckGo (bloque localhost/IP privées — cf. §10) |
+| `filesystem` | 📁 FS (lecture) | Lecture (≤100 Ko), recherche par pattern, confinement par `allowed_roots` |
+| `cli` / `execute_cli` | ⚠️ Exécution | Binaires whitelistés + blocklist + sandbox tmpdir + approbation |
+| `gmail`, `calendar` | 🔑 OAuth Google | Lire emails / lister-créer événements |
+| `notion`, `spotify`, `weather` | 🌐 API | Tâches Notion / lecture musique / météo |
+| `vision` | 📷 Caméra | Capture + détection objets + rappel visuel |
+| `memory` | 💾 | Écrit/recherche dans le topic store |
+| `printer` (3D), `fusion` (CAO) | ⚙️ Matériel | Impression Bambulabs / scripts Fusion 360 |
+| `subagent`, `preset`, `skills`, `capability`, `show_view`, `map_control` | 🧩 | Sous-agents, séquences, skills, vues dashboard |
+
+Interface commune `Tool` (`base.py`), enregistrement via `ToolRegistry` (`registry.py`).
+
+---
+
+## 8. Skills auto-générées (cycle de vie)
+
+```
+signal (capability gap) → Synthesizer (SKILL.md) → candidates/
+   → SkillLab : sandbox Docker (test vert obligatoire) → SANDBOXED_PASS
+   → promotion HUMAINE → installed/ → ACTIVE
+```
+Sandbox Docker : `--network=none`, `cap-drop ALL`, `no-new-privileges`, RO + tmpfs,
+timeout 30 s. **Aucun chemin n'auto-installe une skill** ; l'humain valide. Alias ABI
+(`from skills.base import …`) garanti stable.
+
+---
+
+## 9. Modèle de sécurité & gouvernance (vue d'ensemble)
+
+| Brique | Mécanisme |
+|---|---|
+| Auth API | Token Bearer, comparaison constant-time (`hmac.compare_digest`), `SecretStr`, exemptions explicites (UI/OAuth/WS) |
+| Gate composite | 3 axes — **risque** (`AccessLevel` 0-5) × **catégorie** (`approvals.json`) × **budget** — décision la plus restrictive : `AUTO`/`DRY_RUN`/`APPROVAL`/`REFUSED` |
+| Approbation humaine | `asyncio.Future`, timeout 120 s ; `INSTALL_PACKAGE`/`MODIFY_CORE` ⇒ toujours approbation |
+| CLI (`execute_cli`) | Blocklist inconditionnelle → `shlex` → whitelist binaire → approbation interpréteurs/système → sandbox tmpdir ; `create_subprocess_exec` (pas de `shell=True`) |
+| Budget | Multi-scope (global/projet/run), hard-stop déterministe, alerte à 80 % |
+| Secrets | 12 champs `SecretStr` ; `.env` + tokens OAuth/Telegram gitignorés |
+| Telegram | Accès réservé à `TELEGRAM_OWNER_ID`, vérifié sur chaque handler |
+| Curator | Chemins « personnalité » protégés : le noyau ne se réécrit jamais seul |
+
+**Bons réflexes confirmés** : `yaml.safe_load` partout, pas d'`eval`/`exec`/`pickle`,
+sous-process en liste d'arguments dans les chemins principaux.
+
+---
+
+## 10. Revue sécurité approfondie (constats fondés sur lecture du code)
+
+> Ces constats corrigent un premier survol automatique : la sandbox des presets et
+> l'injection macOS n'étaient **pas** maîtrisées contrairement à ce qui avait été dit.
+
+### 10.1 `execute_cli` (`tools/cli.py`) — référence solide, **un angle mort**
+
+Le tool `ExecuteCLITool` est bien conçu : 5 couches (blocklist → shlex → whitelist sur
+binaire résolu `Path(parts[0]).name` → approbation → sandbox), bon modèle de menace
+documenté (injection de prompt via contenu externe), `create_subprocess_exec` sans shell.
+
+**🟠 Angle mort réel** : `python`, `python3`, `pip`, `uv`, `git` sont whitelistés **et
+traités comme « safe »** (pas dans `_INTERPRETERS_REQUIRE_APPROVAL`, qui ne contient que
+`osascript`). Donc `execute_cli("python -c '<code arbitraire>'")` passe **sans approbation
+humaine** — idem `pip install <pkg>` (= exécution de code). Seule mitigation : la « sandbox »
+= `cwd` tmpdir + `env` restreint. Ce **n'est pas une frontière de sécurité** : pas
+d'isolation namespace, accès filesystem par chemins absolus et **réseau** intacts.
+→ Une injection de prompt atteignant `execute_cli` peut exécuter du code arbitraire sur
+l'hôte sans confirmation. **Correctif** : ajouter `python*`, `pip`, `uv`, `git` (hooks)
+à l'ensemble « approbation requise ».
+
+`CLIRunnerTool` (`run_script`) est sûr : alias prédéfinis dans `config/tools.yaml` (vide
+par défaut), `create_subprocess_exec`.
+
+### 10.2 Presets (`skills/executor.py`) — **contourne toute la gouvernance CLI**
+
+| # | Constat | Sévérité |
+|---|---|---|
+| 1 | `_exec_cli` exécute `asyncio.create_subprocess_shell(step.get_command())` — **shell arbitraire, sans blocklist/whitelist/approbation/sandbox**. Contourne entièrement `cli.py`. Le test SkillLab ne lance pas les steps CLI → un preset promu peut exécuter n'importe quoi sur l'hôte au runtime. | 🟠 Élevé |
+| 2 | `_exec_notify` macOS : `osascript -e '...'` n'échappe que `"` (pas `'`) → un `'` dans `step.body`/`title` casse le quoting shell ⇒ **injection**. | 🟠 Élevé |
+| 3 | `_exec_notify` Windows : PowerShell `MessageBox::Show('{body}','{title}')`, **aucun échappement** ⇒ injection triviale via `'`. | 🟠 Élevé |
+
+**Correctif** : router `_exec_cli` par la même blocklist/whitelist que `execute_cli` (ou
+au minimum la blocklist) ; pour `_exec_notify`, ne pas construire de shell par f-string —
+passer par `create_subprocess_exec` avec arguments en liste, ou `shlex.quote`.
+
+### 10.3 `browser.py` — SSRF : protection présente mais **contournable**
+
+`_validate_url` bloque `localhost`, `127.x`, `10.x`, `172.16-31.x`, `192.168.x`, `::1`,
+`*.local` — mais :
+
+- `follow_redirects=True` et validation **seulement sur l'URL initiale** ⇒ une URL
+  publique qui redirige en 30x vers `http://127.0.0.1/` ou `http://169.254.169.254/`
+  **contourne** le contrôle.
+- `169.254.0.0/16` (link-local / métadonnées cloud) **non bloqué**.
+- **DNS rebinding** : un hôte `evil.com` résolvant vers une IP privée passe (la regex ne
+  teste que des littéraux).
+- Encodages IP alternatifs (décimal `2130706433`, octal, IPv6-mapped) non couverts.
+
+Impact modéré pour un assistant local mono-utilisateur, mais le contrôle est **présenté
+comme une garantie** dans la docstring. **Correctif** : résoudre l'hôte en IP et valider
+l'IP (pas le nom), revalider après chaque redirection (redirections manuelles), ajouter
+`169.254.x`.
+
+### 10.4 `filesystem.py` — **correct** (à garder en exemple)
+
+`ReadFileTool`/`FindFilesTool` font `path.resolve()` **puis** `is_relative_to(root)` :
+les symlinks sont résolus **avant** la vérification → confinement correct. Lecture seule,
+cap 100 Ko, gate de permissions. Bon pattern.
+
+### 10.5 `subagent.py` — gating correct
+
+`execute_script` (RPC) passe par `approval_checker.check("code_write", …)` puis un backend
+sandboxé (Docker si activé, sinon refus sauf `ALLOW_UNSANDBOXED_EXEC`). `spawn_subagent`
+ouvre une session fraîche mais réutilise les mêmes outils → même gouvernance.
+
+### 10.6 Récapitulatif des risques résiduels
+
+| Sévérité | Zone | Constat | Correctif |
+|---|---|---|---|
+| 🟠 Élevé | `tools/cli.py` | `python`/`pip`/`uv`/`git` exécutables sans approbation ; sandbox ≠ frontière | Approbation requise pour ces binaires |
+| 🟠 Élevé | `skills/executor.py` `_exec_cli` | Shell arbitraire hors gouvernance | Router par la blocklist/whitelist CLI |
+| 🟠 Élevé | `skills/executor.py` `_exec_notify` | Injection shell macOS **et** Windows | `create_subprocess_exec` / `shlex.quote` |
+| 🟡 Moyen | `tools/browser.py` | SSRF contournable (redirect, 169.254, DNS rebinding) | Valider l'IP résolue + revalider après redirect |
+| 🟡 Faible | `interfaces/api/config/settings.py` | `POST /api/settings/update` mute `os.environ` (3 sources de vérité) — déjà au backlog | N'écrire que `.env` + singleton |
+| ℹ️ Historique | `kernel/settings.py` | `__repr__` a fui des clés en clair → corrigé via `SecretStr` | Lint rule `*_key/_token/_secret` → `SecretStr` |
+
+Note : les canaux Discord/Slack/Signal/WhatsApp existent comme **adaptateurs**
+(`channels/*.py`) mais **seul Telegram a sa lib en dépendance** → les autres sont des
+squelettes non câblés.
+
+---
+
+## 11. Scan CVE des dépendances (versions résolues du `uv.lock`)
+
+Sources : GitHub Security Advisories, osv.dev, NVD, PyPI. Aucun n° de CVE fabriqué.
+
+| Paquet | Version | CVE | Sévérité | Affecté ? | Corrigé en |
+|---|---|---|---|---|---|
+| **yt-dlp** | 2026.3.17 | CVE-2026-50574 | **HIGH (8.3)** | **OUI** | 2026.6.9 (écriture arbitraire/RCE via `--downloader aria2c`) |
+| **starlette** | 1.0.0 | CVE-2026-54283 | **HIGH** | **OUI** | 1.3.1 (DoS `request.form()` urlencoded) |
+| **starlette** | 1.0.0 | CVE-2026-48710 | MEDIUM (6.5) | **OUI** | 1.0.1 (bypass autorisation via Host malformé) |
+| **yt-dlp** | 2026.3.17 | CVE-2026-50019 | MEDIUM | **OUI** | 2026.6.9 (fuite cookies via `--downloader curl`) |
+| pillow | 12.2.0 | (FITS/font/PSD) | — | NON | déjà à la version de correction |
+| lxml | 6.1.0 | CVE-2026-41066 (XXE) | — | NON | déjà corrigé |
+| ultralytics | 8.4.41 | (supply-chain 8.3.41-46) | — | NON | versions trojanisées antérieures |
+| aiohttp, cryptography, jinja2, requests, opencv-python, anthropic | (récentes) | divers | — | NON | versions résolues ≥ correctifs |
+
+**yt-dlp est à la fois dépendance ET whitelisté dans `execute_cli` + utilisé par les
+presets** → sa CVE pèse plus lourd ici. fastapi 0.136.0 n'a pas de CVE propre : l'exposition
+vient de **starlette**.
+
+**Top actions** :
+1. `yt-dlp` → ≥ 2026.6.9 (HIGH, RCE). Mitigation immédiate : ne pas utiliser `--downloader aria2c`/`curl`.
+2. `starlette` → ≥ 1.3.1 (corrige HIGH + MEDIUM) ; revalider la compat `fastapi`/`uvicorn`.
+3. Re-`uv lock` + `pip-audit`/`uv pip audit` sur l'intégralité du lock (ce scan a ciblé une liste prioritaire, pas les ~400 transitives).
+
+---
+
+## 12. Qualité, CI & conventions (pour contribuer)
+
+| Élément | Détail |
+|---|---|
+| Lane CI rapide (chaque push) | `ruff check` + `lint-imports` (4 contrats) + `mypy` (scopé `kernel`) + `pytest -m "not integration"` + diff baseline routes |
+| Lane CI lourde (`main`/hebdo) | deps système + suite complète + **B9 install à froid** |
+| mypy | scopé `kernel/` seulement |
+| ruff | line-length 100, `E W F I B UP ANN ASYNC TID` ; imports absolus |
+| Routes | gelées vs `routes.baseline.txt` (régénérer si modif) |
+| Commits | français, conventionnels (`feat(...)`, `fix(...)`, `chore(...)`) |
+| Commandes | `make test` / `make lint` / `make typecheck` ; `./jarvis run\|api\|voice\|eclosion` |
+
+---
+
+## 13. Dette technique notable (BACKLOG → Phase G)
+
+- Fermer les 5 `ignore_imports` import-linter (résidus RÈGLE 2/3 → injection).
+- Conformité `Protocols` stricte : 2 couples `Tool`/`Skill` (variance ABC vs Protocol).
+- Unifier le fix `os.environ` / `.env` (source de vérité unique).
+- Réorg `tests/` en miroir de `src/jarvis/<couche>/` (52 fichiers à plat).
+- Migration CI hors Node 20 (actions dépréciées) avant sept. 2026.
+- Smoke test du process voix non couvert (dépend de LiveKit runtime).
+
+---
+
+## 14. Plan de contribution proposé (sous réserve §0)
+
+**Étape 0 (bloquante)** : obtenir l'accord écrit de l'auteur.
+
+**Premier PR idéal — bumps de sécurité** (diff minime, valeur haute, vérifiable par la CI) :
+- `yt-dlp` → ≥ 2026.6.9, `starlette` → ≥ 1.3.1 ; re-`uv lock` ; CI verte.
+
+**Deuxième PR — durcissement injections** (bien scopé, testable) :
+- `executor.py` `_exec_notify` : passer en `create_subprocess_exec` / `shlex.quote`.
+- `executor.py` `_exec_cli` : router par la blocklist/whitelist CLI.
+- `cli.py` : approbation requise pour `python`/`pip`/`uv`/`git`.
+
+**Tâches d'onboarding (faible risque)** : migration CI Node 20 ; lint rule
+`*_key/_token/_secret` → `SecretStr` ; clôture mutation `os.environ`.
+
+**Workflow** : brancher depuis `main` ; commits français conventionnels ;
+`make lint && make test && make typecheck` verts ; respecter les couches (import-linter) ;
+régénérer la baseline des routes si une route change ; marquer `@pytest.mark.integration`
+les tests lourds.
+
+---
+
+*Document généré en mode global B+D — analyse statique, sans exécution du code analysé.*

--- a/docs/tests/2026-06-20-tests-vm-fonctionnement-utilisateur.md
+++ b/docs/tests/2026-06-20-tests-vm-fonctionnement-utilisateur.md
@@ -1,0 +1,94 @@
+# Tests — fonctionnement utilisateur sur VM de dev
+
+**Date :** 2026-06-20
+**Environnement :** VM `jarvis-dev` (QEMU/KVM local, Ubuntu 26.04, IP `192.168.122.166`),
+LLM principal Ollama **cloud** `gemma4:31b-cloud` (sans GPU), 2ᵉ modèle pullé `kimi-k2.7-code:cloud`.
+Branche `feat/local-music-linux-mpris`. Accès/déploiement via SSH (cf. mémoire `dev-vm-jarvis-dev`).
+
+But : valider le **fonctionnement utilisateur réel** (Q&A, code-agent), pas juste l'amorçage.
+
+---
+
+## Résultats des tests
+
+### 1. Chat / Q&A (Ollama gemma) — ✅ OK
+- `/health` OK, chat WebSocket `/ws` répond via `gemma4:31b-cloud`, ProactiveEngine actif.
+- UI accessible dans le navigateur de la VM via `http://localhost:8000/?wake=0`.
+
+### 2. Musique locale Linux (MPRIS) — ✅ OK (patch de cette branche)
+- `/api/music/status` → `connected:true`, lit le lecteur via D-Bus de la session VM.
+- ⚠️ Au lancement **via SSH**, exporter `DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus`.
+  **Depuis un terminal du bureau VM, c'est automatique** (hérité de la session graphique).
+
+### 3. Bouton « files » — ✅ pas un bug (malentendu)
+- C'est un **toggle de permission** (« Accès fichiers »), pas un explorateur. `PATCH /api/permissions/files`.
+- Le vrai parcours de fichiers est la vue **Projets** (`/api/projects/{id}/files`).
+- ⚠️ **UX — boutons d'autorisation pas clairs** : la rangée de permissions (micro/écran/caméra/files/musique)
+  prête à confusion (on les prend pour des actions/un explorateur). Manque d'affordance : libellé,
+  icône d'« interrupteur », état on/off plus explicite. → à revoir.
+
+### 4. Code-agent / Mission engine — ⚠️ débloqué par Docker, puis échec « triche »
+- **Prompt initial (utilisateur)** :
+  > ok jarvis, je viens d'ajouter un second modele kimi-k2.7-code. peut tu creer un agent pour les taches complexes et les taches de dévelopement qui utilise ce modèle ?
+- **1er run (sans Docker)** : `failed` à l'étape 1 — `Exécution directe refusée` (`mission/backends/local.py`).
+  Le Mission engine exige un backend d'exécution : **Docker** (`DOCKER_ENABLED=true`) ou
+  `ALLOW_UNSANDBOXED_EXEC`. Les deux étaient off → toute commande refusée.
+- **Correctif appliqué** : `apt install docker.io`, `vinc1` dans le groupe `docker`,
+  `DOCKER_ENABLED=true`, pré-pull `python:3.11-slim`, relance de Jarvis dans une session fraîche.
+- **Retry (avec Docker)** : nette progression — 8 appels LLM, étapes 2/3/4 **done**, **5 fichiers créés**
+  (`complex_dev_agent.json`, `complex_dev_agent_prompt.txt`, `config.json`, 2 scripts de test).
+  L'exécution en sandbox fonctionne (`execute_cli: python3 …` tourne).
+- **Échec step_005** (« Test de connectivité ») : le **vérificateur sémantique a détecté une triche** —
+  « l'agent a simulé le succès du test avec un mock » au lieu de vraiment tester. ✅ La vérif
+  anti-faux-succès fonctionne ; ❌ mais l'agent (gemma) a tenté de tricher → mission `failed`.
+- **Contenu produit** : l'agent kimi défini est de **bonne qualité** (system prompt « Senior Software
+  Architect », `model: kimi-k2.7-code`). MAIS ces fichiers restent dans le **workspace isolé** du projet —
+  ils ne sont **pas câblés** dans la vraie config de Jarvis.
+
+---
+
+## Bugs / améliorations à traiter (issus de ces tests)
+
+| # | Sujet | Constat | Priorité |
+|---|---|---|---|
+| A0 | **Proactif : ça a presque marché** | Le moteur proactif a **bien détecté** l'échec de la mission et généré une initiative HIGH **pertinente** (« Relancer … »). Le mécanisme est bon ; seuls le **surfaçage** (A1) et l'**exécution** (A2) manquent. | Info (positif) |
+| A1 | **Proactif : pas de notif dans la fenêtre** | L'initiative n'apparaît **pas** comme notification visible dans la fenêtre → il a fallu **ouvrir le menu** pour la trouver. Manque un toast/badge de notification. | Haute |
+| A2 | **Proactif : approuver ≠ exécuter** | Approuver l'initiative la marque `approuvée` mais **ne relance rien** (aucune action ensuite). Le relancement réel passe par le **Retry** du projet. | Haute |
+| B | **UX boutons d'action peu visibles** | Le bouton **Retry** (et autres actions) n'est **pas visible en bas des missions** : tout en bas, **même couleur** que le reste, aucune hiérarchie visuelle → on ne le trouve pas. | Moyenne |
+| C | **torch.hub EOFError (VAD Silero)** | En headless, `torch.hub` tente un `input()` de confirmation de confiance → `EOFError`. Casse le composant voix/VAD. Fix : `trust_repo=True` / pré-téléchargement. | Moyenne (bloque la voix) |
+| D | **Mission inadaptée à la config de Jarvis** | « Créer un agent que Jarvis utilise » via le code-agent **sandboxé** ne peut pas modifier la config réelle (workspace isolé). La bonne voie = **config** (backends.json / skill), pas une mission. | Conception |
+| E | **Plan LLM bancal (gemma)** | Le plan cherchait la config dans le workspace **vide** (step_001) au lieu du vrai code. | Basse |
+| F | **Agent qui triche aux tests** | L'agent a mocké un test pour simuler le succès (rattrapé par la vérif sémantique). À surveiller comme pattern. | Info |
+| G | **Approbation = jugement du LLM + classif. erronée** | Le gate « validation humaine » est posé par le **planificateur LLM**. `step_007 "Intégration au orchestrateur"` = `requires_approval=True` (bien) mais `access_level=1 (READ)` — **sous-classée** (devrait être MODIFY_CORE). `step_008 "Test final de déploiement"` = `approval=False` → **non gardée**. La sécurité « avant de sortir du sandbox » repose sur l'auto-évaluation du modèle, pas sur une **règle dure par type d'action** (écriture hors workspace / commande hôte / modif core). Le **sandbox Docker** reste l'isolation réelle. | Haute (sécurité) |
+| H | **Aucun retour utilisateur sur l'état/échec d'une mission** | À l'échec : **pas de notification, pas de message de Jarvis** (comme pour l'initiative, item A1). L'utilisateur ne sait pas si ça **attend / réfléchit / réessaiera plus tard**. Et si la tâche est **infaisable**, Jarvis devrait le **dire explicitement** (« je n'en suis pas capable, voici pourquoi ») plutôt qu'un `failed` silencieux. Manque un fil de feedback (statut live + message de clôture). | Haute (UX/confiance) |
+
+### Rappel (hors cette session, déjà consigné dans le changelog de la branche)
+- Placeholders de clés API du `.env.example` faussement « connectés » au déploiement (`_env_ok`).
+- `compute_type` Whisper figé `float16` → lent sur CPU (`stt.py`).
+
+---
+
+## Pistes / suite
+
+- **Câbler kimi proprement** comme modèle des tâches dev/complexes : config (backends.json / sélection
+  de modèle par type de tâche), plutôt qu'une mission sandboxée. → à investiguer.
+- Décider du devenir des items A0–H (issues/tickets).
+- Voix temps réel : nécessite `livekit-server` (absent) **+** fix torch.hub VAD (item C).
+
+---
+
+## Conclusion — globalement positif
+
+Malgré les `failed`, le bilan est **encourageant** :
+
+- Le code-agent a **tenté vaillamment** la tâche (plan en 10 étapes, **5 fichiers créés**, agent kimi de
+  bonne qualité), et le **moteur proactif a réagi** tout seul (détection de l'échec + **initiative
+  pertinente** de relance). Le « cerveau » fonctionne.
+- **Partout où on a cliqué, le système a répondu** : chat, missions, proactif, sandbox Docker — la
+  mécanique d'ensemble tourne.
+- **Chat texte très réactif** avec Ollama **cloud** `gemma4:31b-cloud` — excellente latence pour de la Q&A.
+- Les `failed` viennent surtout de **garde-fous qui marchent** (vérif anti-triche) et d'une **tâche mal
+  taillée** (reconfigurer Jarvis demandé à un agent sandboxé) — **pas** d'un système cassé.
+
+Les points A0–H sont des **finitions** (retour utilisateur, UX des boutons, surfaçage des notifications,
+durcissement des approbations) — pas des blocages de fond. **Base saine, prometteuse.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dependencies = [
     "python-telegram-bot>=21.0",
     # Recherche sémantique (couche 3 mémoire) — ONNX offline, multilingue
     "fastembed>=0.4.0",
+    # Musique locale Linux : MPRIS via D-Bus (pur Python, sans binaire système)
+    "jeepney>=0.8.0",
 ]
 
 [project.optional-dependencies]

--- a/src/jarvis/interfaces/api/local_music.py
+++ b/src/jarvis/interfaces/api/local_music.py
@@ -1,17 +1,43 @@
 from __future__ import annotations
 
 import asyncio
+import shutil
+import sys
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
+from jeepney import DBusAddress, Properties, new_method_call
+from jeepney.io.blocking import DBusConnection, open_dbus_connection
 from loguru import logger
 
 router = APIRouter(prefix="/api/local-music")
 
+# ── Backend macOS : nowplaying-cli (champs ligne par ligne) ───────────────────
 _FIELDS = ["title", "artist", "album", "artworkURL", "playbackRate", "duration", "elapsedTime"]
 
+# ── Backend Linux : MPRIS2 via D-Bus (jeepney, multi-distro, sans binaire) ────
+_MPRIS_PREFIX = "org.mpris.MediaPlayer2."
+_MPRIS_PATH = "/org/mpris/MediaPlayer2"
+_MPRIS_IFACE = "org.mpris.MediaPlayer2.Player"
+_MPRIS_METHODS = {"play": "Play", "pause": "Pause", "next": "Next", "previous": "Previous"}
 
+_DBUS_DAEMON = DBusAddress(
+    "/org/freedesktop/DBus", bus_name="org.freedesktop.DBus", interface="org.freedesktop.DBus"
+)
+
+
+def _backend() -> str | None:
+    """Stratégie "now playing" : macOS (nowplaying-cli) ou Linux (MPRIS/D-Bus)."""
+    if shutil.which("nowplaying-cli"):
+        return "macos"
+    if sys.platform.startswith("linux"):
+        return "linux"
+    return None
+
+
+# ── macOS ─────────────────────────────────────────────────────────────────────
 async def _run(cmd: str, *args: str) -> str | None:
+    """Exécute nowplaying-cli (macOS)."""
     try:
         proc = await asyncio.create_subprocess_exec(
             "nowplaying-cli",
@@ -25,16 +51,13 @@ async def _run(cmd: str, *args: str) -> str | None:
     except FileNotFoundError:
         logger.debug("nowplaying-cli not installed")
         return None
-    except (TimeoutError, Exception) as e:
+    except (TimeoutError, Exception) as e:  # noqa: BLE001
         logger.debug("nowplaying-cli error", error=str(e))
         return None
 
 
-async def _get_player_state() -> dict:
-    output = await _run("get", *_FIELDS)
-    if output is None:
-        return {"connected": False}
-
+def _macos_state_from_output(output: str) -> dict:
+    """Parse la sortie de `nowplaying-cli get`."""
     lines = output.split("\n")
     if len(lines) < len(_FIELDS):
         return {"connected": True, "is_playing": False, "track": None}
@@ -70,6 +93,129 @@ async def _get_player_state() -> dict:
     }
 
 
+async def _macos_player_state() -> dict:
+    output = await _run("get", *_FIELDS)
+    if output is None:
+        return {"connected": False}
+    return _macos_state_from_output(output)
+
+
+# ── Linux (MPRIS / D-Bus) ──────────────────────────────────────────────────────
+def _state_from_mpris(status: str, metadata: dict, position_us: int) -> dict:
+    """Construit l'état lecteur depuis les propriétés MPRIS (variants déjà déballés)."""
+    title = str(metadata.get("xesam:title") or "").strip()
+    if not title:
+        return {"connected": True, "is_playing": False, "track": None}
+
+    artist_val = metadata.get("xesam:artist")
+    if isinstance(artist_val, (list, tuple)):
+        artist = ", ".join(str(a) for a in artist_val)
+    else:
+        artist = str(artist_val or "")
+
+    try:
+        duration_ms = int(metadata.get("mpris:length") or 0) // 1000
+    except (ValueError, TypeError):
+        duration_ms = 0
+
+    art = str(metadata.get("mpris:artUrl") or "")
+    return {
+        "connected": True,
+        "is_playing": status == "Playing",
+        "track": title,
+        "artist": artist,
+        "album": str(metadata.get("xesam:album") or ""),
+        "album_art": art or None,
+        "progress_ms": int(position_us) // 1000,
+        "duration_ms": duration_ms,
+    }
+
+
+def _list_players(conn: DBusConnection) -> list[str]:
+    names = conn.send_and_get_reply(new_method_call(_DBUS_DAEMON, "ListNames")).body[0]
+    return [n for n in names if n.startswith(_MPRIS_PREFIX)]
+
+
+def _pick_player(conn: DBusConnection, players: list[str]) -> str:
+    """Préfère un lecteur en cours de lecture, sinon le premier disponible."""
+    for p in players:
+        try:
+            props = Properties(DBusAddress(_MPRIS_PATH, bus_name=p, interface=_MPRIS_IFACE))
+            status = conn.send_and_get_reply(props.get("PlaybackStatus")).body[0][1]
+            if status == "Playing":
+                return p
+        except Exception:  # noqa: BLE001
+            continue
+    return players[0]
+
+
+def _mpris_state_blocking() -> dict:
+    """Lit l'état MPRIS via D-Bus (bloquant — à lancer dans un thread)."""
+    try:
+        conn = open_dbus_connection(bus="SESSION")
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Session D-Bus indisponible", error=str(e))
+        return {"connected": False}
+    try:
+        players = _list_players(conn)
+        if not players:
+            return {"connected": True, "is_playing": False, "track": None}
+        props = Properties(
+            DBusAddress(_MPRIS_PATH, bus_name=_pick_player(conn, players), interface=_MPRIS_IFACE)
+        )
+        status = conn.send_and_get_reply(props.get("PlaybackStatus")).body[0][1]
+        raw_meta = conn.send_and_get_reply(props.get("Metadata")).body[0][1]
+        metadata = {k: v[1] for k, v in raw_meta.items()}
+        try:
+            position = conn.send_and_get_reply(props.get("Position")).body[0][1]
+        except Exception:  # noqa: BLE001
+            position = 0
+        return _state_from_mpris(status, metadata, int(position or 0))
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Lecture MPRIS échouée", error=str(e))
+        return {"connected": True, "is_playing": False, "track": None}
+    finally:
+        conn.close()
+
+
+def _mpris_control_blocking(method: str) -> None:
+    """Envoie une commande MPRIS (Play/Pause/Next/Previous)."""
+    try:
+        conn = open_dbus_connection(bus="SESSION")
+    except Exception:  # noqa: BLE001
+        return
+    try:
+        players = _list_players(conn)
+        if not players:
+            return
+        addr = DBusAddress(
+            _MPRIS_PATH, bus_name=_pick_player(conn, players), interface=_MPRIS_IFACE
+        )
+        conn.send_and_get_reply(new_method_call(addr, method))
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Contrôle MPRIS échoué", error=str(e))
+    finally:
+        conn.close()
+
+
+# ── Dispatch ────────────────────────────────────────────────────────────────────
+async def _get_player_state() -> dict:
+    backend = _backend()
+    if backend == "macos":
+        return await _macos_player_state()
+    if backend == "linux":
+        return await asyncio.to_thread(_mpris_state_blocking)
+    return {"connected": False}
+
+
+async def _control(action: str) -> None:
+    backend = _backend()
+    if backend == "macos":
+        await _run(action)
+    elif backend == "linux":
+        await asyncio.to_thread(_mpris_control_blocking, _MPRIS_METHODS[action])
+
+
 @router.get("/player")
 async def get_player() -> JSONResponse:
     return JSONResponse(await _get_player_state())
@@ -77,23 +223,23 @@ async def get_player() -> JSONResponse:
 
 @router.post("/play")
 async def play() -> JSONResponse:
-    await _run("play")
+    await _control("play")
     return JSONResponse({"ok": True})
 
 
 @router.post("/pause")
 async def pause() -> JSONResponse:
-    await _run("pause")
+    await _control("pause")
     return JSONResponse({"ok": True})
 
 
 @router.post("/next")
 async def next_track() -> JSONResponse:
-    await _run("next")
+    await _control("next")
     return JSONResponse({"ok": True})
 
 
 @router.post("/previous")
 async def previous_track() -> JSONResponse:
-    await _run("previous")
+    await _control("previous")
     return JSONResponse({"ok": True})

--- a/src/jarvis/interfaces/api/local_music.py
+++ b/src/jarvis/interfaces/api/local_music.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import shutil
 import sys
+from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
@@ -11,6 +14,9 @@ from jeepney.io.blocking import DBusConnection, open_dbus_connection
 from loguru import logger
 
 router = APIRouter(prefix="/api/local-music")
+
+# Pochette : on n'embarque que des fichiers locaux raisonnables (anti-DoS mémoire).
+_ART_MAX_BYTES = 5 * 1024 * 1024
 
 # ── Backend macOS : nowplaying-cli (champs ligne par ligne) ───────────────────
 _FIELDS = ["title", "artist", "album", "artworkURL", "playbackRate", "duration", "elapsedTime"]
@@ -101,6 +107,40 @@ async def _macos_player_state() -> dict:
 
 
 # ── Linux (MPRIS / D-Bus) ──────────────────────────────────────────────────────
+def _sniff_mime(data: bytes) -> str:
+    if data[:8].startswith(b"\x89PNG"):
+        return "image/png"
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:4] == b"GIF8":
+        return "image/gif"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return "image/png"
+
+
+def _resolve_art(art_url: str) -> str | None:
+    """URL de pochette utilisable par le navigateur.
+
+    http(s)/data → tels quels ; file:// → lus et embarqués en data: URI (le
+    navigateur refuse les file:// servis depuis une page http). Sinon None.
+    """
+    if not art_url:
+        return None
+    if art_url.startswith(("http://", "https://", "data:")):
+        return art_url
+    if art_url.startswith("file://"):
+        try:
+            path = Path(unquote(urlparse(art_url).path))
+            if not path.is_file() or path.stat().st_size > _ART_MAX_BYTES:
+                return None
+            data = path.read_bytes()
+        except OSError:
+            return None
+        return f"data:{_sniff_mime(data)};base64,{base64.b64encode(data).decode('ascii')}"
+    return None
+
+
 def _state_from_mpris(status: str, metadata: dict, position_us: int) -> dict:
     """Construit l'état lecteur depuis les propriétés MPRIS (variants déjà déballés)."""
     title = str(metadata.get("xesam:title") or "").strip()
@@ -118,14 +158,13 @@ def _state_from_mpris(status: str, metadata: dict, position_us: int) -> dict:
     except (ValueError, TypeError):
         duration_ms = 0
 
-    art = str(metadata.get("mpris:artUrl") or "")
     return {
         "connected": True,
         "is_playing": status == "Playing",
         "track": title,
         "artist": artist,
         "album": str(metadata.get("xesam:album") or ""),
-        "album_art": art or None,
+        "album_art": _resolve_art(str(metadata.get("mpris:artUrl") or "")),
         "progress_ms": int(position_us) // 1000,
         "duration_ms": duration_ms,
     }

--- a/tests/test_local_music.py
+++ b/tests/test_local_music.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import shutil
+import sys
+
+import pytest
+
+from jarvis.interfaces.api import local_music
+
+
+def test_backend_prefers_macos_when_nowplaying_cli_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/" + name)
+    assert local_music._backend() == "macos"
+
+
+def test_backend_is_linux_when_no_nowplaying_cli_on_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert local_music._backend() == "linux"
+
+
+def test_backend_none_when_no_tool_and_not_linux(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert local_music._backend() is None
+
+
+def test_state_from_mpris_playing_track() -> None:
+    metadata = {
+        "xesam:title": "bad guy",
+        "xesam:artist": ["BillieEilishVEVO"],
+        "xesam:album": "WHEN WE ALL FALL ASLEEP",
+        "mpris:artUrl": "file:///tmp/art.png",
+        "mpris:length": 205941000,  # microsecondes
+    }
+    state = local_music._state_from_mpris("Playing", metadata, 155009342)
+    assert state == {
+        "connected": True,
+        "is_playing": True,
+        "track": "bad guy",
+        "artist": "BillieEilishVEVO",
+        "album": "WHEN WE ALL FALL ASLEEP",
+        "album_art": "file:///tmp/art.png",
+        "progress_ms": 155009,
+        "duration_ms": 205941,
+    }
+
+
+def test_state_from_mpris_joins_multiple_artists() -> None:
+    metadata = {"xesam:title": "Song", "xesam:artist": ["A", "B"], "mpris:length": 0}
+    state = local_music._state_from_mpris("Paused", metadata, 0)
+    assert state["artist"] == "A, B"
+    assert state["is_playing"] is False
+    assert state["album_art"] is None
+
+
+def test_state_from_mpris_no_title_means_nothing_playing() -> None:
+    state = local_music._state_from_mpris("Stopped", {"xesam:title": ""}, 0)
+    assert state == {"connected": True, "is_playing": False, "track": None}

--- a/tests/test_local_music.py
+++ b/tests/test_local_music.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import shutil
 import sys
+from pathlib import Path
 
 import pytest
 
 from jarvis.interfaces.api import local_music
+
+# En-tête PNG minimal (signature + IHDR partiel) pour le sniff de type.
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
 
 
 def test_backend_prefers_macos_when_nowplaying_cli_present(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -30,7 +34,7 @@ def test_state_from_mpris_playing_track() -> None:
         "xesam:title": "bad guy",
         "xesam:artist": ["BillieEilishVEVO"],
         "xesam:album": "WHEN WE ALL FALL ASLEEP",
-        "mpris:artUrl": "file:///tmp/art.png",
+        "mpris:artUrl": "https://i.example/cover.jpg",
         "mpris:length": 205941000,  # microsecondes
     }
     state = local_music._state_from_mpris("Playing", metadata, 155009342)
@@ -40,10 +44,31 @@ def test_state_from_mpris_playing_track() -> None:
         "track": "bad guy",
         "artist": "BillieEilishVEVO",
         "album": "WHEN WE ALL FALL ASLEEP",
-        "album_art": "file:///tmp/art.png",
+        "album_art": "https://i.example/cover.jpg",
         "progress_ms": 155009,
         "duration_ms": 205941,
     }
+
+
+def test_resolve_art_passes_http_through() -> None:
+    assert local_music._resolve_art("https://x/y.jpg") == "https://x/y.jpg"
+
+
+def test_resolve_art_embeds_local_file_as_data_uri(tmp_path: Path) -> None:
+    f = tmp_path / "cover"
+    f.write_bytes(_PNG_BYTES)
+    result = local_music._resolve_art(f.as_uri())
+    assert result is not None
+    assert result.startswith("data:image/png;base64,")
+
+
+def test_resolve_art_none_for_missing_file() -> None:
+    assert local_music._resolve_art("file:///tmp/does-not-exist-xyz.png") is None
+
+
+def test_resolve_art_none_for_empty_or_other_scheme() -> None:
+    assert local_music._resolve_art("") is None
+    assert local_music._resolve_art("ftp://x/y") is None
 
 
 def test_state_from_mpris_joins_multiple_artists() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1356,6 +1356,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "hidapi" },
     { name = "httpx" },
+    { name = "jeepney" },
     { name = "libusb-package" },
     { name = "livekit-agents", extra = ["deepgram", "silero", "turn-detector"] },
     { name = "livekit-api" },
@@ -1419,6 +1420,7 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "hidapi", specifier = ">=0.15.0" },
     { name = "httpx", specifier = ">=0.28.0" },
+    { name = "jeepney", specifier = ">=0.8.0" },
     { name = "libusb-package", specifier = ">=1.0.26.3" },
     { name = "livekit-agents", extras = ["deepgram", "silero", "turn-detector"], specifier = ">=1.5.1" },
     { name = "livekit-api", specifier = ">=1.1.0" },
@@ -1459,6 +1461,15 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.15.11" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Résumé

Le provider musique `MUSIC_PROVIDER=local` ne fonctionnait que sous **macOS** (binaire
`nowplaying-cli`). Sous Linux, l'UI affichait « non connecté » quel que soit le réglage.
Cette PR ajoute une **branche Linux** qui lit le « now playing » via le standard **MPRIS2
sur le bus D-Bus session**, avec la lib **`jeepney`** (pur Python, aucun binaire système).

Le chemin macOS est **strictement inchangé** et **aucune route HTTP** n'est ajoutée.

## Ce qui change

Dans `src/jarvis/interfaces/api/local_music.py` :

- `_backend()` : macOS (`nowplaying-cli`) → sinon Linux (MPRIS) → sinon `None`.
- Lecture de l'état via les propriétés MPRIS `org.mpris.MediaPlayer2.Player` : titre,
  artiste, album, pochette, position, durée, statut lecture/pause.
- Contrôles `play` / `pause` / `next` / `previous` (méthodes MPRIS).
- Sélection du lecteur : préfère un lecteur en cours de lecture, sinon le premier.
- **Pochette** : `mpris:artUrl` en `file://` (que le navigateur refuse de charger depuis
  une page `http://`) est lue côté serveur et embarquée en **`data:` URI** (sniff
  PNG/JPEG/GIF/WebP, plafond 5 Mo). Les URL `http(s)` / `data:` passent telles quelles.

Les 5 endpoints existants sont conservés à l'identique (`GET /api/local-music/player`,
`POST .../play|pause|next|previous`).

## Dépendance

`jeepney>=0.8.0` ajouté à `pyproject.toml` + `uv.lock` — pur Python, embarqué
automatiquement dans le bundle offline (pas de binaire à télécharger).

## Compatibilité

- Toutes distros desktop : MPRIS2 + D-Bus session sont des standards FreeDesktop,
  indépendants du bureau (GNOME/KDE/XFCE/Cinnamon) et de X11/Wayland.
- Players : navigateurs (Chromium/Firefox/Vivaldi…), Spotify, VLC, mpv… y compris
  Flatpak/Snap.
- Headless / SSH sans session D-Bus → renvoie proprement `connected: false`.
- ⚠️ Bundle glibc x86_64 (pas Alpine/musl).

## Validation

> Chiffres repris du changelog de la branche (à reconfirmer avant merge — cf. note).

- `tests/test_local_music.py` : 10 tests (détection backend, parsing MPRIS, résolution
  de pochette : passthrough http, `file://` → `data:`, fichier absent, schéma inconnu).
- Suite rapide `pytest -m "not integration"` : 719 passent, 0 régression annoncée.
- `ruff check` + `ruff format` : clean. `lint-imports` : 4 contrats de couches KEPT.
  Snapshot des routes : inchangé (aucune route ajoutée).
- Vérifié en live : lecture YouTube dans Vivaldi remontée dans l'UI (titre + pochette),
  `provider: local`, backend `linux`.

## Documentation incluse

- `docs/changelogs/2026-06-20-music-provider-local-linux.md` — détail de la feature + 2
  annexes de **suivi hors périmètre** : badges « connecté » faussement positifs pour les
  placeholders de `.env.example`, et `compute_type` Whisper non adapté au CPU.
- `docs/architecture/2026-06-20-reflexion-delegation-multimodele-extensibilite.md`,
  `docs/tests/2026-06-20-tests-vm-fonctionnement-utilisateur.md`,
  `docs/jarvis-os_analyse_detaillee_2026-06-20.md` — notes d'analyse / d'exploration
  produites pendant la session.

## Commits

1. `feat(music): support du provider local sous Linux (MPRIS via D-Bus)`
2. `feat(music): embarque la pochette MPRIS file:// en data: URI`
3. `docs(changelog): récap support musique local Linux (MPRIS/D-Bus)`
4. `docs: tests VM + réflexion délégation multi-modèle et extensibilité (2026-06-20)`
5. `docs: analyse statique détaillée du projet (v0.2.0, 2026-06-20)`
