### PR TITLE
fix(oauth): force https redirect_uri when behind reverse proxy

### DIFF
--- a/src/jarvis/interfaces/api/google_oauth.py
+++ b/src/jarvis/interfaces/api/google_oauth.py
@@ -38,6 +38,8 @@ _pending: dict[str, dict] = {}
 
 def _redirect_uri(request: Request, service: str) -> str:
     base = str(request.base_url).rstrip("/")
+    if not base.startswith("https://") and "127.0.0.1" not in base and "localhost" not in base:
+        base = base.replace("http://", "https://", 1)
     return f"{base}/api/google/callback/{service}"
 
 


### PR DESCRIPTION
Quand Jarvis est derrière un reverse proxy qui termine le TLS (Tailscale, Nginx, Traefik), request.base_url retourne http:// même si l'accès est en https. Google rejette le redirect_uri avec une erreur 400. Fix : forcer https:// si le host n'est pas localhost/127.0.0.1.