### PR TITLE
fix(gmail): restrict UNREAD filter to INBOX to exclude Promotions/Social

### DIFF
--- a/src/jarvis/capabilities/tools/gmail.py
+++ b/src/jarvis/capabilities/tools/gmail.py
@@ -91,7 +91,7 @@ class GmailListTool(Tool):
         except Exception as e:
             return ToolResult(content=f"Erreur credentials Gmail : {e}", is_error=True)
 
-        label_ids = "UNREAD" if unread_only else "INBOX"
+        label_ids = ["UNREAD", "INBOX"] if unread_only else ["INBOX"]
         params = {"labelIds": label_ids, "maxResults": max_results}
 
         try:


### PR DESCRIPTION
labelIds=UNREAD sans INBOX retourne tous les non-lus toutes catégories confondues (Promotions, Social, Updates). L'agent annonce un nombre de non-lus supérieur à ce que l'utilisateur perçoit dans sa boîte principale. Fix : labelIds=[UNREAD, INBOX].