### PR TITLE
fix(auth): exempt /api/spotify/ from Bearer auth like /api/google/

### DIFF
--- a/src/jarvis/engine/auth.py
+++ b/src/jarvis/engine/auth.py
@@ -31,6 +31,7 @@ _EXEMPT_EXACT: frozenset[str] = frozenset({
 _EXEMPT_PREFIXES: Sequence[str] = (
     "/api/channels/",  # webhooks — vérification de signature propre
     "/api/google/",  # OAuth Google — redirect navigateur, header impossible
+    "/api/spotify/",  # OAuth Spotify — redirect navigateur, header impossible
 )
 
 


### PR DESCRIPTION
/api/spotify/auth et /api/spotify/callback font des redirects navigateur — impossible d'y ajouter un header Bearer. Même pattern que /api/google/ qui est déjà exempté. Sans ce fix, le bouton 'Connecter mon compte' Spotify retourne 401 quand API_AUTH_ENABLED=true.