### PR TITLE
fix(docker): bind mount .env to persist UI settings changes across rebuilds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  jarvis:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: jarvis-os
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "127.0.0.1:8000:8000"
+    volumes:
+      # Données persistantes (mémoire, sessions, skills) — survivent aux rebuilds
+      - jarvis-data:/app/memory_data
+      - jarvis-skills:/app/skills_data
+      - jarvis-workspace:/app/workspace
+      # Modèle TTS Piper, téléchargé manuellement (hors image)
+      - ./models:/app/models:ro
+      - ./config:/app/config
+      - ./.env:/app/.env
+    networks:
+      - jarvis-net
+
+networks:
+  jarvis-net:
+    driver: bridge
+
+volumes:
+  jarvis-data:
+  jarvis-skills:
+  jarvis-workspace:


### PR DESCRIPTION
Sans bind mount sur .env, les changements sauvegardés depuis l'UI (TTS_PROVIDER, GEMINI_TTS_VOICE, GEMINI_TTS_MODEL, etc.) sont écrits dans /app/.env à l'intérieur du conteneur et perdus au prochain rebuild. Ajout de ./.env:/app/.env dans docker-compose.yml — même pattern que le fix /app/config (PR #30). Concerne principalement les installs non-locales où les rebuilds sont fréquents.