### PR TITLE
fix(voice): add authHeaders to LiveKit token fetch

### DIFF
--- a/src/jarvis/interfaces/ui/static/voice_livekit.js
+++ b/src/jarvis/interfaces/ui/static/voice_livekit.js
@@ -43,7 +43,7 @@ class JarvisLiveKitClient {
 
     let tokenData;
     try {
-      tokenData = await fetch(tokenUrl).then((r) => r.json());
+      tokenData = await fetch(tokenUrl, { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} }).then((r) => r.json());
     } catch (e) {
       console.error("[LiveKit] Impossible de récupérer le token:", e);
       throw e;


### PR DESCRIPTION
Dans voice_livekit.js, le fetch vers /api/voice/token n'envoyait pas de header Authorization. Avec API_AUTH_ENABLED=true, cet appel retournait 401, le token LiveKit n'était jamais récupéré, et le micro restait silencieux sans erreur visible. Fix : ajout de Jarvis.authHeaders() sur le fetch, même pattern que les autres endpoints protégés.