### PR TITLE
feat(ui): Mission Control v2 + système de thème complet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ tools/arduino-cli/*
 !tools/arduino-cli/.gitkeep
 
 keypad/firmware/Object File1/
+src/jarvis/interfaces/ui/static/*.bak-*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM python:3.11-slim
+
+# Deps système minimales : portaudio19-dev pour pyaudio (transitif RealtimeSTT,
+# pas de wheel linux, compile depuis sdist). python3-dev requis pour la compilation.
+# opencv-python et dlib (vision, non installé ici) ont des wheels linux x86_64
+# prêtes — pas besoin de cmake/openblas/libgl1 (cf. lane CI minimum du repo).
+RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+    portaudio19-dev \
+    gcc \
+    python3-dev \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# uv installé en standalone (pas de dépendance à un paquet apt)
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
+# Copie du lockfile + pyproject d'abord pour profiter du cache Docker
+# sur les layers de dépendances (ne re-sync que si ces fichiers changent)
+COPY pyproject.toml uv.lock ./
+
+# Sync des deps de base uniquement (pas vision, pas dev) — cf. décision
+# "API texte + vocal Cloud" : pas de face-recognition pour l'instant
+RUN uv sync --frozen --no-install-project
+
+# Copie du reste du code applicatif
+COPY . .
+
+# Sync final pour installer le package jarvis lui-même
+RUN uv sync --frozen --no-extra vision --no-group dev
+
+# Arborescence attendue par l'app (cf. setup.sh --ci)
+RUN mkdir -p memory_data/sessions \
+             memory_data/topics \
+             memory_data/conso \
+             memory_data/initiatives \
+             memory_data/curator_reports \
+             skills_data/installed \
+             skills_data/candidates \
+             workspace/projects
+
+EXPOSE 8000
+
+# API + voice agent (LiveKit Cloud, pas de serveur LiveKit local lancé ici —
+# cf. décision : jarvis run lance livekit-server --dev inconditionnellement,
+# on ne veut pas ça puisqu'on utilise LiveKit Cloud)
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml.bak-1782160656
+++ b/docker-compose.yml.bak-1782160656
@@ -1,0 +1,29 @@
+services:
+  jarvis:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: jarvis-os
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "127.0.0.1:8000:8000"
+    volumes:
+      # Données persistantes (mémoire, sessions, skills) — survivent aux rebuilds
+      - jarvis-data:/app/memory_data
+      - jarvis-skills:/app/skills_data
+      - jarvis-workspace:/app/workspace
+      # Modèle TTS Piper, téléchargé manuellement (hors image)
+      - ./models:/app/models:ro
+    networks:
+      - jarvis-net
+
+networks:
+  jarvis-net:
+    driver: bridge
+
+volumes:
+  jarvis-data:
+  jarvis-skills:
+  jarvis-workspace:

--- a/docker-compose.yml.bak-1782170629
+++ b/docker-compose.yml.bak-1782170629
@@ -1,0 +1,30 @@
+services:
+  jarvis:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: jarvis-os
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "127.0.0.1:8000:8000"
+    volumes:
+      # Données persistantes (mémoire, sessions, skills) — survivent aux rebuilds
+      - jarvis-data:/app/memory_data
+      - jarvis-skills:/app/skills_data
+      - jarvis-workspace:/app/workspace
+      # Modèle TTS Piper, téléchargé manuellement (hors image)
+      - ./models:/app/models:ro
+      - ./config:/app/config
+    networks:
+      - jarvis-net
+
+networks:
+  jarvis-net:
+    driver: bridge
+
+volumes:
+  jarvis-data:
+  jarvis-skills:
+  jarvis-workspace:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "── Jarvis-OS (conteneur) ──────────────────────────"
+echo "API + voice agent — LiveKit Cloud (pas de serveur local)"
+echo "────────────────────────────────────────────────────"
+
+cleanup() {
+  echo "Arrêt en cours..."
+  kill $(jobs -p) 2>/dev/null || true
+  wait
+}
+trap cleanup INT TERM
+
+# API (port 8000)
+uv run python -m jarvis.app &
+
+# Laisse l'API démarrer avant de lancer le voice agent
+sleep 4
+
+# Voice agent — se connecte à LiveKit Cloud via LIVEKIT_URL/.env
+uv run python -m jarvis.interfaces.voice.agent dev &
+
+wait

--- a/src/jarvis/capabilities/tools/gmail.py.bak-1782162227
+++ b/src/jarvis/capabilities/tools/gmail.py.bak-1782162227
@@ -1,0 +1,215 @@
+# Copyright (C) 2026 Barthélemy Houot
+# This file is part of Jarvis OS, licensed under the GNU AGPL-3.0-or-later.
+# See the LICENSE file or <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from email.mime.text import MIMEText
+from pathlib import Path
+
+import httpx
+from loguru import logger
+
+from jarvis.capabilities.tools.base import Tool, ToolResult
+
+_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+]
+_GMAIL_BASE = "https://gmail.googleapis.com/gmail/v1/users/me"
+
+try:
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+    from google_auth_oauthlib.flow import InstalledAppFlow
+
+    _HAS_GOOGLE = True
+except ImportError:
+    _HAS_GOOGLE = False
+
+
+def _load_gmail_creds(credentials_path: Path, token_path: Path) -> Credentials:
+    """Charge et rafraîchit les credentials Gmail OAuth2 (bloquant)."""
+    if not _HAS_GOOGLE:
+        raise RuntimeError("google-api-python-client non installé.")
+
+    creds = None
+    if token_path.exists():
+        creds = Credentials.from_authorized_user_file(str(token_path), _SCOPES)
+
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            if not credentials_path.exists():
+                raise FileNotFoundError(f"Credentials Google manquants : {credentials_path}.")
+            flow = InstalledAppFlow.from_client_secrets_file(str(credentials_path), _SCOPES)
+            creds = flow.run_local_server(port=0)
+        token_path.write_text(creds.to_json())
+
+    return creds
+
+
+class GmailListTool(Tool):
+    """Liste les emails Gmail non lus ou récents."""
+
+    name = "list_emails"
+    description = (
+        "Liste les emails Gmail de l'utilisateur. "
+        "Utilise cet outil quand l'utilisateur demande ses mails, sa boîte mail, "
+        "ses messages non lus."
+    )
+    input_schema = {
+        "type": "object",
+        "properties": {
+            "max_results": {
+                "type": "integer",
+                "description": "Nombre d'emails à retourner (défaut : 10)",
+            },
+            "unread_only": {
+                "type": "boolean",
+                "description": "Si true, retourne uniquement les non lus (défaut : true)",
+            },
+        },
+        "required": [],
+    }
+
+    def __init__(self, credentials_path: Path, token_path: Path) -> None:
+        self._creds = credentials_path
+        self._token = token_path
+
+    async def execute(
+        self, max_results: int = 10, unread_only: bool = True, **_: object
+    ) -> ToolResult:
+        if not _HAS_GOOGLE:
+            return ToolResult(content="google-api-python-client non installé.", is_error=True)
+
+        try:
+            creds = await asyncio.to_thread(_load_gmail_creds, self._creds, self._token)
+        except Exception as e:
+            return ToolResult(content=f"Erreur credentials Gmail : {e}", is_error=True)
+
+        label_ids = "UNREAD" if unread_only else "INBOX"
+        params = {"labelIds": label_ids, "maxResults": max_results}
+
+        try:
+            async with httpx.AsyncClient(timeout=60.0) as client:
+                headers = {"Authorization": f"Bearer {creds.token}"}
+
+                # 1. Lister les IDs
+                r = await client.get(f"{_GMAIL_BASE}/messages", headers=headers, params=params)
+                r.raise_for_status()
+                messages = r.json().get("messages", [])
+
+                if not messages:
+                    label = "non lus" if unread_only else "récents"
+                    return ToolResult(content=f"Aucun email {label}.")
+
+                # 2. Fetch metadata en parallèle
+                async def fetch_meta(msg_id: str) -> dict:
+                    resp = await client.get(
+                        f"{_GMAIL_BASE}/messages/{msg_id}",
+                        headers=headers,
+                        params=[
+                            ("format", "metadata"),
+                            ("metadataHeaders", "From"),
+                            ("metadataHeaders", "Subject"),
+                            ("metadataHeaders", "Date"),
+                        ],
+                    )
+                    resp.raise_for_status()
+                    return resp.json()
+
+                metas = await asyncio.gather(*[fetch_meta(m["id"]) for m in messages])
+
+            lines = []
+            for msg in metas:
+                hdrs = {h["name"]: h["value"] for h in msg.get("payload", {}).get("headers", [])}
+                sender = hdrs.get("From", "?")
+                subject = hdrs.get("Subject", "(sans sujet)")
+                snippet = msg.get("snippet", "")[:120]
+                lines.append(f"De : {sender}\nSujet : {subject}\nAperçu : {snippet}")
+
+            content = "\n\n---\n\n".join(lines)
+            logger.debug("Gmail emails listed", count=len(lines))
+            return ToolResult(content=content)
+
+        except Exception as e:
+            logger.error(f"Gmail list error: {type(e).__name__}: {e}")
+            return ToolResult(content=f"Erreur Gmail : {e}", is_error=True)
+
+
+# ── Send email ────────────────────────────────────────────────────────────────
+
+
+def _load_gmail_send_creds(credentials_path: Path, token_path: Path):  # noqa: ANN202
+    """Réutilise le même token unifié (readonly + send) que _load_gmail_creds."""
+    return _load_gmail_creds(credentials_path, token_path)
+
+
+def _parse_draft(draft_content: str) -> tuple[str, str, str | None, str]:
+    """Parse le format de brouillon structuré.
+
+    Retourne (to, subject, thread_id, body).
+    """
+    lines = draft_content.strip().splitlines()
+    headers: dict[str, str] = {}
+    thread_id: str | None = None
+    body_lines: list[str] = []
+    in_body = False
+
+    for line in lines:
+        if in_body:
+            body_lines.append(line)
+            continue
+        if line.strip() == "---":
+            in_body = True
+            continue
+        if line.startswith("[THREAD_ID:"):
+            thread_id = line[len("[THREAD_ID:") :].rstrip("]").strip()
+            continue
+        if ":" in line:
+            key, _, val = line.partition(":")
+            headers[key.strip().lower()] = val.strip()
+
+    to = headers.get("à", headers.get("to", ""))
+    subject = headers.get("sujet", headers.get("subject", ""))
+    body = "\n".join(body_lines).strip()
+    return to, subject, thread_id, body
+
+
+async def send_gmail_draft(
+    draft_content: str,
+    credentials_path: Path,
+    token_path: Path,
+) -> str:
+    """Parse draft_content et envoie via Gmail REST API. Retourne l'id du message envoyé."""
+    to, subject, thread_id, body = _parse_draft(draft_content)
+    if not to:
+        raise ValueError("Destinataire (À:) introuvable dans le brouillon")
+
+    creds = await asyncio.to_thread(_load_gmail_send_creds, credentials_path, token_path)
+
+    msg = MIMEText(body, "plain", "utf-8")
+    msg["To"] = to
+    msg["Subject"] = subject
+    msg["From"] = "me"
+
+    raw = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
+    payload: dict = {"raw": raw}
+    if thread_id:
+        payload["threadId"] = thread_id
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            "https://gmail.googleapis.com/gmail/v1/users/me/messages/send",
+            headers={"Authorization": f"Bearer {creds.token}"},
+            json=payload,
+        )
+        resp.raise_for_status()
+
+    sent_id: str = resp.json().get("id", "")
+    logger.info("Gmail message sent", to=to, subject=subject, message_id=sent_id)
+    return sent_id

--- a/src/jarvis/engine/auth.py
+++ b/src/jarvis/engine/auth.py
@@ -27,6 +27,7 @@ _EXEMPT_EXACT: frozenset[str] = frozenset({
     "/capabilities",
     "/admin",
     "/macropad",
+    "/mc",
     # OAuth Spotify : seuls le lancement (lien <a href>) et le callback (redirect
     # navigateur) ne peuvent pas porter de header Bearer. On exempte UNIQUEMENT
     # ces 2 routes — surtout PAS tout /api/spotify/ (qui contient /token, /play,

--- a/src/jarvis/engine/auth.py.bak-1782165671
+++ b/src/jarvis/engine/auth.py.bak-1782165671
@@ -1,0 +1,88 @@
+# Copyright (C) 2026 Barthélemy Houot
+# This file is part of Jarvis OS, licensed under the GNU AGPL-3.0-or-later.
+# See the LICENSE file or <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+"""Garde-fou réseau — authentification Bearer pour l'API Jarvis."""
+
+from __future__ import annotations
+
+import hmac
+from collections.abc import Sequence
+
+from fastapi import HTTPException
+from loguru import logger
+from starlette.requests import HTTPConnection
+
+from jarvis.kernel.settings import settings
+
+# Chemins exemptés de l'authentification Bearer.
+# Un préfixe couvre toutes ses sous-routes.
+_EXEMPT_EXACT: frozenset[str] = frozenset({
+    "/health",
+    "/api/health",
+    "/",
+    "/command",
+    "/dashboard",
+    "/settings",
+    "/capabilities",
+    "/admin",
+    "/macropad",
+})
+_EXEMPT_PREFIXES: Sequence[str] = (
+    "/api/channels/",  # webhooks — vérification de signature propre
+    "/api/google/",  # OAuth Google — redirect navigateur, header impossible
+)
+
+
+async def verify_api_token(request: HTTPConnection) -> None:
+    """Dépendance FastAPI globale — vérification du token Bearer.
+
+    No-op si ``api_auth_enabled=False`` (usage local inchangé).
+    Quand activée : exige ``Authorization: Bearer <token>`` sauf pour les
+    endpoints exemptés (health, webhooks canaux, OAuth Google) et les
+    connexions WebSocket (l'API browser ne supporte pas les headers d'upgrade).
+
+    Périmètre non protégé intentionnellement :
+    - Pages HTML de l'UI (``/``, ``/dashboard``, …) — routes FastAPI explicites,
+      exemptées ici ; le token API est injecté dans le HTML pour les appels
+      ``/api/*`` depuis le navigateur (voir ``interfaces/api/ui.py``)
+    - Assets statiques (``StaticFiles`` mount) — sous-app ASGI, hors dépendance
+    - Connexions WebSocket (``/ws/*``) — navigateur sans header Authorization
+    - Callbacks OAuth (``/api/google/``) — redirect tiers, token impossible
+    - Webhooks canaux (``/api/channels/``) — signature propre (HMAC/Token)
+    """
+    if not settings.api_auth_enabled:
+        return
+
+    # WebSocket : le navigateur ne peut pas envoyer Authorization à l'upgrade
+    if request.scope.get("type") == "websocket":
+        return
+
+    path: str = request.url.path
+    if path in _EXEMPT_EXACT:
+        return
+    for prefix in _EXEMPT_PREFIXES:
+        if path.startswith(prefix):
+            return
+
+    auth_header: str = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        logger.warning(
+            "Auth: token manquant",
+            path=path,
+            client=request.client.host if request.client else "?",
+        )
+        raise HTTPException(status_code=401, detail="Token Bearer requis.")
+
+    token = auth_header[len("Bearer ") :]
+    expected = settings.api_token.get_secret_value()
+    if not expected or not hmac.compare_digest(
+        token.encode("utf-8"),
+        expected.encode("utf-8"),
+    ):
+        logger.warning(
+            "Auth: token invalide",
+            path=path,
+            client=request.client.host if request.client else "?",
+        )
+        raise HTTPException(status_code=401, detail="Token invalide.")

--- a/src/jarvis/interfaces/api/google_oauth.py.bak-1782158405
+++ b/src/jarvis/interfaces/api/google_oauth.py.bak-1782158405
@@ -1,0 +1,179 @@
+# Copyright (C) 2026 Barthélemy Houot
+# This file is part of Jarvis OS, licensed under the GNU AGPL-3.0-or-later.
+# See the LICENSE file or <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+"""Google OAuth2 web flow — Gmail + Calendar."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse
+from loguru import logger
+
+from jarvis.kernel.settings import settings
+
+router = APIRouter(prefix="/api/google")
+
+_SCOPES_GMAIL = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+]
+_SCOPES_CALENDAR = ["https://www.googleapis.com/auth/calendar"]
+
+# Endpoints OAuth2 Google — constants, communs à toutes les apps.
+_GOOGLE_AUTH_URI = "https://accounts.google.com/o/oauth2/auth"
+_GOOGLE_TOKEN_URI = "https://oauth2.googleapis.com/token"
+_GOOGLE_CERT_URI = "https://www.googleapis.com/oauth2/v1/certs"
+
+# In-memory state store (single-user JARVIS)
+_pending: dict[str, dict] = {}
+
+
+def _redirect_uri(request: Request, service: str) -> str:
+    base = str(request.base_url).rstrip("/")
+    return f"{base}/api/google/callback/{service}"
+
+
+def _credentials_path() -> Path:
+    return Path(settings.google_credentials_path)
+
+
+def _maybe_write_credentials_from_env(request: Request) -> None:
+    """Régénère google_credentials.json à partir de GOOGLE_CLIENT_ID/SECRET.
+
+    Permet de configurer Google depuis l'UI/.env (comme Spotify/Deezer) sans
+    déposer le fichier JSON à la main : les champs variables sont client_id +
+    client_secret, le reste (auth_uri/token_uri/cert) est constant et les
+    redirect_uris se déduisent du host courant.
+
+    Ne fait rien si les credentials .env sont absents → un fichier déjà présent
+    (install historique) continue d'être utilisé tel quel, zéro régression.
+    """
+    client_id = settings.google_client_id
+    client_secret = settings.google_client_secret.get_secret_value()
+    if not client_id or not client_secret:
+        return
+
+    config = {
+        "web": {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "auth_uri": _GOOGLE_AUTH_URI,
+            "token_uri": _GOOGLE_TOKEN_URI,
+            "auth_provider_x509_cert_url": _GOOGLE_CERT_URI,
+            "redirect_uris": [
+                _redirect_uri(request, "gmail"),
+                _redirect_uri(request, "calendar"),
+            ],
+        }
+    }
+    path = _credentials_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2))
+
+
+def _token_path(service: str) -> Path:
+    base = Path(settings.google_token_path)
+    if service == "gmail":
+        return base.parent / "google_gmail_token.json"
+    return base  # calendar uses google_token.json
+
+
+@router.get("/auth/{service}")
+async def google_auth(service: str, request: Request) -> RedirectResponse:
+    if service not in ("gmail", "calendar"):
+        return RedirectResponse("/capabilities?error=unknown_service")
+
+    # Si les credentials sont fournis en .env (UI), (re)génère le fichier JSON
+    # que le reste du flux (et les consommateurs gmail/calendar) attendent.
+    _maybe_write_credentials_from_env(request)
+
+    creds_path = _credentials_path()
+    if not creds_path.exists():
+        logger.error("Google credentials file missing", path=str(creds_path))
+        return RedirectResponse("/capabilities?google_error=no_credentials")
+
+    try:
+        from google_auth_oauthlib.flow import Flow  # type: ignore
+
+        scopes = _SCOPES_GMAIL if service == "gmail" else _SCOPES_CALENDAR
+        redirect_uri = _redirect_uri(request, service)
+
+        flow = Flow.from_client_secrets_file(str(creds_path), scopes=scopes)
+        flow.redirect_uri = redirect_uri
+
+        state = secrets.token_urlsafe(16)
+        code_verifier = base64.urlsafe_b64encode(os.urandom(32)).decode().rstrip("=")
+        code_challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(code_verifier.encode()).digest())
+            .decode()
+            .rstrip("=")
+        )
+
+        auth_url, _ = flow.authorization_url(
+            access_type="offline",
+            prompt="consent",
+            state=state,
+            code_challenge=code_challenge,
+            code_challenge_method="S256",
+        )
+
+        _pending[state] = {
+            "service": service,
+            "redirect_uri": redirect_uri,
+            "code_verifier": code_verifier,
+        }
+        return RedirectResponse(auth_url)
+
+    except ImportError:
+        logger.error("google-auth-oauthlib non installé")
+        return RedirectResponse("/capabilities?google_error=missing_lib")
+    except Exception as exc:
+        logger.exception("Google auth error", error=str(exc))
+        return RedirectResponse("/capabilities?google_error=1")
+
+
+@router.get("/callback/{service}")
+async def google_callback(
+    service: str,
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
+) -> RedirectResponse:
+    if error or not code:
+        logger.error("Google OAuth error", service=service, error=error)
+        return RedirectResponse("/capabilities?google_error=1")
+
+    pending = _pending.pop(state, None) if state else None
+    if not pending or pending.get("service") != service:
+        logger.warning("Google OAuth state mismatch", state=state)
+        return RedirectResponse("/capabilities?google_error=state_mismatch")
+
+    try:
+        from google_auth_oauthlib.flow import Flow  # type: ignore
+
+        creds_path = _credentials_path()
+        scopes = _SCOPES_GMAIL if service == "gmail" else _SCOPES_CALENDAR
+
+        flow = Flow.from_client_secrets_file(str(creds_path), scopes=scopes, state=state)
+        flow.redirect_uri = pending["redirect_uri"]
+        flow.fetch_token(code=code, code_verifier=pending["code_verifier"])
+
+        token_path = _token_path(service)
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        token_path.write_text(flow.credentials.to_json())
+        logger.info("Google token saved", service=service, path=str(token_path))
+
+        return RedirectResponse("/capabilities?google_ok=" + service)
+
+    except Exception as exc:
+        logger.exception("Google callback error", service=service, error=str(exc))
+        return RedirectResponse("/capabilities?google_error=1")

--- a/src/jarvis/interfaces/api/ui.py
+++ b/src/jarvis/interfaces/api/ui.py
@@ -126,6 +126,20 @@ async def capabilities_ui() -> Response:
     )
 
 
+@router.get("/mc", include_in_schema=False)
+async def mc_ui() -> Response:
+    return _ui_html_response(
+        Path("src/jarvis/interfaces/ui/static/mc.html"),
+        [
+            ("/_shared.css",         "src/jarvis/interfaces/ui/static/_shared.css"),
+            ("/mission_control.css", "src/jarvis/interfaces/ui/static/mission_control.css"),
+            ("/mc.css",              "src/jarvis/interfaces/ui/static/mc.css"),
+            ("/_shared.js",          "src/jarvis/interfaces/ui/static/_shared.js"),
+            ("/mission_control.js",  "src/jarvis/interfaces/ui/static/mission_control.js"),
+            ("/mc.js",               "src/jarvis/interfaces/ui/static/mc.js"),
+            ("/jarvis-color-picker.js", "src/jarvis/interfaces/ui/static/jarvis-color-picker.js"),
+        ],
+    )
 @router.get("/health", response_model=HealthResponse)
 async def health() -> HealthResponse:
     """Point de contrôle — vérifie que le serveur est up."""

--- a/src/jarvis/interfaces/channels/gateway.py
+++ b/src/jarvis/interfaces/channels/gateway.py
@@ -88,7 +88,7 @@ class MessagingGateway:
         )
 
         # Persiste le session_id (nouveau ou restauré)
-        self._session_map[msg.session_key] = session.id
+        self._session_map[msg.session_key] = str(session.id)
         self._save_session_map()
 
         adapter = self._adapters.get(msg.platform.value)

--- a/src/jarvis/interfaces/channels/gateway.py.bak-1782245014
+++ b/src/jarvis/interfaces/channels/gateway.py.bak-1782245014
@@ -1,0 +1,124 @@
+# Copyright (C) 2026 Barthélemy Houot
+# This file is part of Jarvis OS, licensed under the GNU AGPL-3.0-or-later.
+# See the LICENSE file or <https://www.gnu.org/licenses/agpl-3.0.html>.
+
+"""Gateway de messagerie unifié Jarvis.
+
+MessagingGateway orchestre N ChannelAdapters, assure la continuité de session
+cross-plateforme en persistant un mapping (platform:user_id → session_id) sur
+disque, et route chaque message entrant vers le core.Gateway Jarvis.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from loguru import logger
+
+from jarvis.engine.gateway import Gateway as JarvisGateway
+from jarvis.interfaces.channels.base import ChannelAdapter, IncomingMessage, MessageTarget
+
+_SESSION_MAP_FILE = Path("memory/messaging_sessions.json")
+
+
+class MessagingGateway:
+    """Orchestre plusieurs ChannelAdapters avec continuité de session.
+
+    Usage::
+
+        gw = MessagingGateway(jarvis_gateway=app.state.gateway)
+        gw.register(TelegramChannel(...))
+        gw.register(DiscordChannel(...))
+        await gw.start_all()
+        # ...
+        await gw.stop_all()
+    """
+
+    def __init__(
+        self,
+        jarvis_gateway: JarvisGateway,
+        session_map_path: Path = _SESSION_MAP_FILE,
+    ) -> None:
+        self._jarvis = jarvis_gateway
+        self._adapters: dict[str, ChannelAdapter] = {}
+        self._session_map_path = session_map_path
+        self._session_map: dict[str, str] = self._load_session_map()
+
+    # ── Gestion des adaptateurs ───────────────────────────────────────────────
+
+    def register(self, adapter: ChannelAdapter) -> None:
+        """Enregistre un adaptateur et lui injecte le callback de dispatch."""
+        adapter.set_dispatch(self.dispatch)
+        self._adapters[adapter.platform.value] = adapter
+        logger.info("Canal enregistré", platform=adapter.platform.value)
+
+    async def start_all(self) -> None:
+        """Démarre tous les adaptateurs enregistrés."""
+        for adapter in self._adapters.values():
+            await adapter.start()
+
+    async def stop_all(self) -> None:
+        """Arrête proprement tous les adaptateurs."""
+        for adapter in self._adapters.values():
+            await adapter.stop()
+
+    # ── Dispatch ─────────────────────────────────────────────────────────────
+
+    async def dispatch(self, msg: IncomingMessage) -> None:
+        """Route un message entrant vers Jarvis et renvoie la réponse au bon canal.
+
+        La session est restaurée depuis le mapping persisté si elle existe,
+        ou créée à la volée par le core.Gateway.
+        """
+        session_id = self._session_map.get(msg.session_key)
+
+        logger.debug(
+            "Dispatch message",
+            platform=msg.platform.value,
+            user_id=msg.user_id,
+            session_id=session_id,
+            text=msg.text[:60],
+        )
+
+        session, _route, response = await self._jarvis.handle(
+            msg.text,
+            session_id=session_id,
+            stream=False,
+        )
+
+        # Persiste le session_id (nouveau ou restauré)
+        self._session_map[msg.session_key] = session.id
+        self._save_session_map()
+
+        adapter = self._adapters.get(msg.platform.value)
+        if adapter is None:
+            logger.warning("Adaptateur introuvable pour la réponse", platform=msg.platform.value)
+            return
+
+        target = MessageTarget(
+            platform=msg.platform,
+            user_id=msg.user_id,
+            channel_id=msg.channel_id,
+        )
+        await adapter.send(str(response), target)
+
+    # ── Persistance session map ───────────────────────────────────────────────
+
+    def _load_session_map(self) -> dict[str, str]:
+        if self._session_map_path.exists():
+            try:
+                return json.loads(self._session_map_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Impossible de charger messaging_sessions.json", error=str(exc))
+        return {}
+
+    def _save_session_map(self) -> None:
+        try:
+            self._session_map_path.parent.mkdir(parents=True, exist_ok=True)
+            self._session_map_path.write_text(
+                json.dumps(self._session_map, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.warning("Impossible de sauvegarder messaging_sessions.json", error=str(exc))

--- a/src/jarvis/interfaces/ui/static/_shared.css
+++ b/src/jarvis/interfaces/ui/static/_shared.css
@@ -13,32 +13,40 @@
    ───────────────────────────────────────────────────────────────────── */
 
 :root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
   /* Base palette */
   --bg-0:        #06080D;
   --bg-1:        #0A0E16;
   --bg-2:        #0F141F;
   --bg-3:        #161C2A;
-  --line-1:      rgba(220, 232, 255, 0.06);
-  --line-2:      rgba(220, 232, 255, 0.10);
-  --line-3:      rgba(220, 232, 255, 0.16);
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
 
   /* Foreground */
   --fg-0:        #DCE8FF;
-  --fg-1:        rgba(220, 232, 255, 0.78);
-  --fg-2:        rgba(220, 232, 255, 0.55);
-  --fg-3:        rgba(220, 232, 255, 0.36);
-  --fg-4:        rgba(220, 232, 255, 0.20);
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
 
   /* Semantic */
   --accent:      #4A9EFF;
-  --accent-soft: rgba(74, 158, 255, 0.14);
-  --accent-line: rgba(74, 158, 255, 0.32);
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --accent-icon: color-mix(in srgb, var(--accent) 40%, white 60%);
+  --accent-icon: color-mix(in srgb, var(--accent) 40%, white 60%);
   --gold:        #B8963E;
-  --gold-soft:   rgba(184, 150, 62, 0.12);
+  --gold-soft:   rgba(var(--c-gold), 0.12);
   --green:       #36D399;
-  --green-soft:  rgba(54, 211, 153, 0.12);
+  --green-soft:  rgba(var(--c-green), 0.12);
   --red:         #E5484D;
-  --red-soft:    rgba(229, 72, 77, 0.10);
+  --red-soft:    rgba(var(--c-red), 0.10);
 
   /* Type */
   --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
@@ -64,7 +72,7 @@
 html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
 body {
   font-family: var(--sans);
-  font-size: 13px;
+  font-size: 0.8125rem;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -86,28 +94,28 @@ body {
 }
 .atmo--aurora {
   background:
-    radial-gradient(80vw 60vh at 12% 8%, rgba(74,158,255,.06), transparent 60%),
-    radial-gradient(60vw 50vh at 92% 96%, rgba(184,150,62,.04), transparent 60%);
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
 }
 
 /* ───────── Type primitives ───────── */
 .t-eyebrow {
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 0.625rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--fg-3);
   font-weight: 400;
 }
 .t-label {
-  font-family: var(--mono); font-size: 10.5px;
+  font-family: var(--mono); font-size: 0.6562rem;
   letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
 }
 .t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
 .t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
 
-.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
-.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 3.75rem; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 2rem; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
 
 /* ───────── App shell ───────── */
 .app {
@@ -124,7 +132,7 @@ body {
   border-right: 1px solid var(--line-1);
   display: flex; flex-direction: column;
   padding: 22px 0 18px;
-  background: linear-gradient(180deg, rgba(74,158,255,0.02), transparent 200px);
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
   position: relative;
   z-index: 5;
 }
@@ -134,9 +142,9 @@ body {
   border-bottom: 1px solid var(--line-1);
 }
 .sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
-.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 1rem; letter-spacing: -0.005em; }
 .sb-brand-status {
-  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3);
   letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
   display: flex; align-items: center; gap: 5px;
 }
@@ -148,7 +156,7 @@ body {
 
 .sb-section-eyebrow {
   padding: 22px 22px 6px;
-  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.18em;
   color: var(--fg-3); text-transform: uppercase;
   display: flex; justify-content: space-between; align-items: center;
 }
@@ -160,14 +168,14 @@ body {
   align-items: center; gap: 10px;
   padding: 8px 12px; border-radius: 8px;
   cursor: pointer; color: var(--fg-1);
-  font-size: 12.5px; letter-spacing: 0.005em;
+  font-size: 0.7812rem; letter-spacing: 0.005em;
   border: 0; background: none; text-align: left; width: 100%;
   font-family: inherit;
   transition: background .15s ease, color .15s ease;
 }
-.sb-item:hover { background: rgba(220,232,255,0.04); color: var(--fg-0); }
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
 .sb-item.is-on {
-  background: linear-gradient(90deg, rgba(74,158,255,0.10), rgba(74,158,255,0.02));
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
   color: var(--fg-0);
 }
 .sb-item.is-on::before {
@@ -178,14 +186,14 @@ body {
 }
 .sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
 .sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
-.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); font-variant-numeric: tabular-nums; }
 .sb-item.is-on .sb-meta { color: var(--fg-1); }
 
 .sb-spark-wrap { padding: 20px 22px 0; }
 .sb-spark { display: block; height: 32px; width: 100%; }
 .sb-spark-meta {
   display: flex; justify-content: space-between; margin-top: 4px;
-  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3); letter-spacing: 0.06em;
 }
 
 .sb-foot {
@@ -196,7 +204,7 @@ body {
 }
 .sb-foot-row {
   display: flex; justify-content: space-between; align-items: center;
-  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3);
   letter-spacing: 0.06em; text-transform: uppercase;
 }
 .sb-foot-row > span:last-child { color: var(--fg-1); }
@@ -226,14 +234,14 @@ body {
   position: relative;
   overflow-y: auto; overflow-x: hidden;
   background:
-    radial-gradient(60vw 40vh at 100% 0%, rgba(74,158,255,.025), transparent 60%),
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
     var(--bg-0);
   scrollbar-width: thin;
-  scrollbar-color: rgba(220,232,255,0.08) transparent;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
 }
 .main::-webkit-scrollbar { width: 10px; }
 .main::-webkit-scrollbar-thumb {
-  background: rgba(220,232,255,0.08); border-radius: 6px;
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
   border: 3px solid transparent; background-clip: content-box;
 }
 
@@ -251,8 +259,8 @@ body {
   z-index: 6;
 }
 .topbar-l { display: flex; align-items: baseline; gap: 14px; }
-.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
-.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 1.3125rem; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.1em; text-transform: uppercase; }
 
 .topbar-c {
   display: flex; align-items: center; gap: 18px;
@@ -261,7 +269,7 @@ body {
   border-radius: 999px;
   background: var(--bg-1);
   color: var(--fg-2);
-  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.06em;
 }
 .topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
 .topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
@@ -271,13 +279,13 @@ body {
   appearance: none; border: 1px solid var(--line-2);
   background: var(--bg-1); color: var(--fg-1);
   padding: 7px 12px; border-radius: 8px;
-  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  font-family: var(--sans); font-size: 0.7188rem; font-weight: 500;
   display: inline-flex; align-items: center; gap: 8px;
   cursor: pointer; transition: all .15s ease;
   letter-spacing: 0.005em;
 }
 .tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
-.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+.tb-btn .kbd { font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
 
 /* ───────── Surface + cards + section headers ───────── */
 .surface {
@@ -297,8 +305,8 @@ body {
 }
 .card--bare { background: transparent; border: 0; padding: 0; }
 .card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
-.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
-.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 1rem; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
 
 .sec-hd {
   display: flex; align-items: flex-end; justify-content: space-between;
@@ -314,10 +322,10 @@ body {
 }
 .sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
 .sec-hd-row { display: flex; align-items: center; gap: 14px; }
-.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
-.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
-.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
-.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+.sec-hd-num { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 0.8125rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 1.875rem; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.04em; }
 
 /* ───────── Buttons / badges ───────── */
 .btn-ghost {
@@ -327,7 +335,7 @@ body {
   display: inline-flex; align-items: center; gap: 6px;
   font-family: inherit; transition: all .15s ease;
 }
-.btn-ghost:hover { color: var(--fg-0); background: rgba(220,232,255,0.04); }
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
 .btn-accent {
   appearance: none; background: var(--accent); border: 0;
   color: #001127; font: 600 11.5px var(--sans);
@@ -338,22 +346,22 @@ body {
 
 .badge {
   display: inline-flex; align-items: center; gap: 6px;
-  font-family: var(--mono); font-size: 9.5px;
+  font-family: var(--mono); font-size: 0.5938rem;
   letter-spacing: 0.12em; text-transform: uppercase;
   padding: 3px 7px; border-radius: 4px;
   border: 1px solid var(--line-2); color: var(--fg-2);
 }
 .badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
-.badge--gold   { color: var(--gold);   border-color: rgba(184,150,62,.32); background: var(--gold-soft); }
-.badge--green  { color: var(--green);  border-color: rgba(54,211,153,.32); background: var(--green-soft); }
-.badge--red    { color: var(--red);    border-color: rgba(229,72,77,.30);  background: var(--red-soft); }
-.badge--solid  { background: rgba(220,232,255,.06); border-color: transparent; color: var(--fg-1); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
 .badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
 
 /* Scroll inside cards */
-.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(220,232,255,0.08) transparent; }
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
 .scroll-y::-webkit-scrollbar { width: 6px; }
-.scroll-y::-webkit-scrollbar-thumb { background: rgba(220,232,255,0.08); border-radius: 3px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
 
 /* Page-in transition */
 .page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
@@ -368,11 +376,11 @@ body {
   z-index: 1900;
   display: flex; align-items: center; gap: 10px;
   padding: 8px 14px;
-  background: rgba(74,158,255,0.12);
+  background: rgba(var(--c-accent), 0.12);
   border: 1px solid var(--accent-line);
   border-radius: 999px;
   color: var(--accent);
-  font-family: var(--mono); font-size: 10.5px;
+  font-family: var(--mono); font-size: 0.6562rem;
   letter-spacing: 0.18em;
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -401,7 +409,7 @@ html.inspect [data-inspect]::after {
   background: var(--bg-2);
   border: 1px solid var(--accent-line);
   color: var(--fg-0);
-  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.06em;
   padding: 6px 10px; border-radius: 6px;
   opacity: 0; pointer-events: none; z-index: 1800;
   box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
@@ -427,7 +435,7 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
   -webkit-backdrop-filter: blur(20px) saturate(160%);
   border: 1px solid var(--line-2);
   border-radius: 10px;
-  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(74,158,255,.10);
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
   pointer-events: auto;
   animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
   position: relative; overflow: hidden;
@@ -447,9 +455,9 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
 .notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
 .notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
 .notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
-.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-text { font-family: var(--sans); font-size: 0.8125rem; color: var(--fg-0); letter-spacing: -0.005em; }
 .notif-time {
-  font-family: var(--mono); font-size: 9.5px;
+  font-family: var(--mono); font-size: 0.5938rem;
   color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
 }
 @keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
@@ -471,7 +479,7 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
 .cmdk-input-wrap { position: relative; }
 .cmdk-prefix {
   position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
-  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  color: var(--accent); font-family: var(--mono); font-size: 1rem;
   text-shadow: 0 0 8px var(--accent);
 }
 .cmdk {
@@ -479,7 +487,7 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
   background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
   border: 1px solid var(--line-3);
   border-radius: 16px;
-  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(74,158,255,.14), 0 0 60px -20px rgba(74,158,255,.4);
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
   overflow: hidden;
   display: flex; flex-direction: column;
   animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
@@ -495,16 +503,16 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
 }
 .cmdk-input.has-prefix { padding-left: 38px; }
 .cmdk-input::placeholder { color: var(--fg-3); }
-.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(220,232,255,0.08) transparent; }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
 .cmdk-list::-webkit-scrollbar { width: 6px; }
-.cmdk-list::-webkit-scrollbar-thumb { background: rgba(220,232,255,0.08); border-radius: 3px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
 .cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
 .cmdk-item {
   display: grid; grid-template-columns: 24px 1fr auto;
   gap: 12px; align-items: center;
   padding: 9px 14px; border-radius: 8px;
   cursor: pointer; color: var(--fg-1);
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 .cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
 .cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
@@ -517,7 +525,7 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
 }
 .cmdk-empty {
   padding: 32px 16px; text-align: center;
-  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+  color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.08em;
 }
 .cmdk-foot {
   display: flex; justify-content: space-between; align-items: center;
@@ -544,7 +552,7 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
 
 .select-mono {
   appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
-  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  color: var(--fg-1); font-family: var(--mono); font-size: 0.7188rem;
   padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
   background-repeat: no-repeat;
@@ -552,7 +560,7 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
 }
 .input-mono {
   appearance: none;
-  font-family: var(--mono); font-size: 12px;
+  font-family: var(--mono); font-size: 0.75rem;
   color: var(--fg-1);
   background: var(--bg-2);
   border: 1px solid var(--line-2);
@@ -560,7 +568,7 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
   padding: 8px 12px;
   width: 100%;
 }
-.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(74,158,255,.10); }
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
 
 /* ───────── Bottom nav (persistent pill) ───────── */
 #j-bottom-nav {
@@ -579,35 +587,35 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
   pointer-events: all;
   width: 36px; height: 36px;
   border-radius: 50%;
-  background: rgba(74, 158, 255, 0.08);
-  border: 1px solid rgba(74, 158, 255, 0.22);
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
   cursor: pointer;
   display: flex; align-items: center; justify-content: center;
   transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
-  color: rgba(74, 158, 255, 0.6);
+  color: rgba(var(--c-accent), 0.6);
   padding: 0; margin: 0; outline: none;
 }
 .jnav-btn:hover {
-  background: rgba(74, 158, 255, 0.18);
-  border-color: rgba(74, 158, 255, 0.7);
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
   transform: scale(1.1);
   color: #4A9EFF;
 }
 .jnav-btn.active {
-  background: rgba(74, 158, 255, 0.20);
-  border-color: rgba(74, 158, 255, 0.8);
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
   color: #4A9EFF;
-  box-shadow: 0 0 12px rgba(74, 158, 255, 0.25);
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
 }
 
 /* ───────── Loading / empty states ───────── */
 .j-loading {
-  font-family: var(--mono); font-size: 11px;
+  font-family: var(--mono); font-size: 0.6875rem;
   letter-spacing: 0.1em; color: var(--fg-3);
   padding: 32px 0; text-align: center; text-transform: uppercase;
 }
 .j-empty {
-  font-family: var(--mono); font-size: 11px;
+  font-family: var(--mono); font-size: 0.6875rem;
   letter-spacing: 0.08em; color: var(--fg-3);
   padding: 24px 0; text-align: center; text-transform: uppercase;
 }
@@ -637,12 +645,12 @@ html.inspect [data-inspect]:hover::after { opacity: 1; }
 body[data-mode="capacites"] {
   --nav-tint:      var(--gold);
   --nav-tint-soft: var(--gold-soft);
-  --nav-tint-line: rgba(184,150,62,0.32);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
 }
 body[data-mode="config"] {
   --nav-tint:      var(--fg-0);
-  --nav-tint-soft: rgba(220,232,255,0.06);
-  --nav-tint-line: rgba(220,232,255,0.16);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
 }
 
 /* ── Aurora par mode ── */
@@ -651,68 +659,73 @@ body[data-mode="config"] {
 }
 body[data-mode="home"] .atmo--aurora {
   background:
-    radial-gradient(60vw 65vh at 0% 0%,  rgba(74,158,255,0.16), rgba(74,158,255,0.05) 45%, transparent 70%),
-    radial-gradient(55vw 65vh at 110% 115%, rgba(184,150,62,0.10), rgba(184,150,62,0.02) 40%, transparent 70%),
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
     radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
 }
 body[data-mode="workspace"] .atmo--aurora {
   background:
-    radial-gradient(95vw 130vh at -15% -25%, rgba(74,158,255,0.24), rgba(74,158,255,0.04) 35%, transparent 60%),
-    radial-gradient(50vw 40vh at 100% 110%, rgba(74,158,255,0.08), transparent 70%);
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
 }
 body[data-mode="capacites"] .atmo--aurora {
   background:
-    radial-gradient(80vw 100vh at 110% 110%, rgba(184,150,62,0.20), rgba(184,150,62,0.04) 35%, transparent 60%),
-    radial-gradient(55vw 60vh at -10% -15%, rgba(74,158,255,0.06), transparent 65%),
-    radial-gradient(40vw 60vh at 100% -10%, rgba(184,150,62,0.06), transparent 70%);
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
 }
 body[data-mode="config"] .atmo--aurora {
   background:
-    radial-gradient(120vw 80vh at 50% -30%, rgba(220,232,255,0.05), transparent 70%),
-    radial-gradient(80vw 60vh at 50% 130%, rgba(74,158,255,0.04), transparent 70%);
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.06), rgba(var(--c-accent), 0.02) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.03), transparent 70%);
 }
 
 /* ── Mode glow — liseré laser sur droite + bas uniquement ── */
 .mode-glow {
   position: fixed; inset: 0; pointer-events: none; z-index: 3;
   border: none;
-  border-right:  1px solid rgba(74,158,255,0.18);
-  border-bottom: 1px solid rgba(74,158,255,0.18);
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
   box-shadow:
-    inset -6px 0  20px -6px rgba(74,158,255,0.22),
-    inset 0  -6px 20px -6px rgba(74,158,255,0.22);
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
   transition: box-shadow .9s ease, border-color .9s ease;
 }
 body[data-mode="home"] .mode-glow {
-  border-color: rgba(74,158,255,0.18);
+  border-color: rgba(var(--c-accent), 0.18);
   box-shadow:
-    inset -6px 0  20px -6px rgba(74,158,255,0.22),
-    inset 0  -6px 20px -6px rgba(74,158,255,0.22);
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
 }
 body[data-mode="workspace"] .mode-glow {
-  border-color: rgba(74,158,255,0.40);
+  border-color: rgba(var(--c-accent), 0.40);
   box-shadow:
-    inset -8px 0  28px -6px rgba(74,158,255,0.40),
-    inset 0  -8px 28px -6px rgba(74,158,255,0.40);
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
 }
 body[data-mode="capacites"] .mode-glow {
-  border-color: rgba(184,150,62,0.42);
+  border-color: rgba(var(--c-gold), 0.42);
   box-shadow:
-    inset -8px 0  28px -6px rgba(184,150,62,0.40),
-    inset 0  -8px 28px -6px rgba(184,150,62,0.40);
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
 }
 body[data-mode="config"] .mode-glow {
-  border-color: rgba(220,232,255,0.16);
+  border-color: rgba(var(--c-fg), 0.16);
   box-shadow:
-    inset -6px 0  20px -6px rgba(220,232,255,0.18),
-    inset 0  -6px 20px -6px rgba(220,232,255,0.18);
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
 }
 
 /* ── Spotlight (suit la souris) ── */
 .spotlight {
   position: fixed; inset: 0; pointer-events: none; z-index: 0;
   background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
-    rgba(74,158,255,0.04), transparent 70%);
+    rgba(var(--c-accent), 0.04), transparent 70%);
   transition: --mx .05s, --my .05s;
 }
 
@@ -725,7 +738,7 @@ body[data-mode="config"] .mode-glow {
   font-size: 22vw; line-height: 0.85;
   letter-spacing: -0.06em;
   color: transparent;
-  -webkit-text-stroke: 1px rgba(220,232,255,0.025);
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
   user-select: none;
   white-space: nowrap;
   transition: opacity .6s ease;
@@ -746,7 +759,7 @@ body[data-mode="config"] .mode-glow {
   animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
 }
 .scene-card-chapter {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.32em;
   text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
 }
 .scene-card-title {
@@ -768,13 +781,13 @@ body[data-mode="config"] .mode-glow {
 .rooms-chapter {
   position: fixed; top: 28px; left: 36px; z-index: 80;
   display: inline-flex; align-items: baseline; gap: 14px;
-  font-family: var(--mono); font-size: 10.5px;
+  font-family: var(--mono); font-size: 0.6562rem;
   letter-spacing: 0.24em; text-transform: uppercase;
   color: var(--fg-2); pointer-events: none;
 }
 .rooms-num {
   color: var(--nav-tint); font-family: var(--serif);
-  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  font-weight: 300; font-size: 1.375rem; letter-spacing: -0.025em;
   text-transform: none; line-height: 1;
 }
 .rooms-bar {
@@ -792,7 +805,7 @@ body[data-mode="config"] .mode-glow {
   backdrop-filter: blur(20px) saturate(160%);
   -webkit-backdrop-filter: blur(20px) saturate(160%);
   border: 0.5px solid var(--line-2); border-radius: 999px;
-  font-family: var(--mono); font-size: 10px;
+  font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.13em; text-transform: uppercase;
   color: var(--fg-3); cursor: pointer;
   transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
@@ -801,7 +814,7 @@ body[data-mode="config"] .mode-glow {
   color: var(--fg-1);
   border-color: var(--accent-line);
   background: rgba(10, 14, 22, 0.90);
-  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(74,158,255,0.10);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
 }
 .rooms-mc .mc-dot {
   width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
@@ -814,7 +827,7 @@ body[data-mode="config"] .mode-glow {
 .rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
 .rooms-mc .mc-kbd span {
   padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
-  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  font-size: 0.5625rem; color: var(--fg-4); letter-spacing: 0.06em;
   transition: border-color .2s, color .2s;
 }
 .rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
@@ -838,7 +851,7 @@ body[data-mode="config"] .mode-glow {
   background: transparent; border: none; outline: none; cursor: pointer;
   display: inline-flex; align-items: center; gap: 8px;
   padding: 7px 14px; border-radius: 999px;
-  font-family: var(--sans); font-size: 12px;
+  font-family: var(--sans); font-size: 0.75rem;
   color: var(--fg-2); white-space: nowrap;
   transition: color .15s, background .15s;
   animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
@@ -849,7 +862,7 @@ body[data-mode="config"] .mode-glow {
   background: var(--nav-tint-soft); color: var(--nav-tint);
 }
 .rooms-pages button .num {
-  font-family: var(--mono); font-size: 9.5px;
+  font-family: var(--mono); font-size: 0.5938rem;
   letter-spacing: 0.08em; color: var(--fg-3);
 }
 .rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
@@ -874,7 +887,7 @@ body[data-subpages="cocoon-wide-display"] .rooms-pages {
 }
 body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
   content: attr(data-mode-label);
-  font-family: var(--mono); font-size: 9.5px;
+  font-family: var(--mono); font-size: 0.5938rem;
   letter-spacing: 0.28em; text-transform: uppercase;
   color: var(--fg-3); display: block;
   margin-bottom: 18px; padding-left: 4px;
@@ -882,7 +895,7 @@ body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
 body[data-subpages="cocoon-wide-display"] .rooms-pages button {
   border-radius: 0; padding: 6px 4px;
   font-family: var(--serif); font-weight: 300;
-  font-size: 20px; letter-spacing: -0.025em;
+  font-size: 1.25rem; letter-spacing: -0.025em;
   color: var(--fg-3); animation: none;
   justify-content: flex-start;
   position: relative;
@@ -918,30 +931,30 @@ body[data-subpages="cocoon-wide-display"] .page-body {
   position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
   display: flex; align-items: center; justify-content: center;
   gap: 18px; padding: 20px 28px;
-  font-family: var(--mono); font-size: 10px;
+  font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
 }
 .mc-header-title {
-  font-family: var(--mono); font-size: 10.5px;
+  font-family: var(--mono); font-size: 0.6562rem;
   letter-spacing: 0.28em; text-transform: uppercase;
   color: var(--fg-1); font-weight: 500;
 }
 .mc-header-hint {
   display: inline-flex; align-items: center; gap: 5px;
-  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+  font-size: 0.625rem; letter-spacing: 0.14em; color: var(--fg-4);
 }
 .mc-hkbd {
   display: inline-flex; gap: 2px;
 }
 .mc-hkbd span {
   padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
-  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+  font-size: 0.5625rem; color: var(--fg-3); letter-spacing: 0.06em;
 }
 .mc-hdot { opacity: .5; }
 .mc-close {
   position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
   appearance: none; background: transparent; border: 0.5px solid var(--line-2);
-  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  border-radius: 6px; color: var(--fg-3); font-size: 1rem; line-height: 1;
   padding: 4px 9px; cursor: pointer; z-index: 3003;
   transition: color .15s, border-color .15s;
 }
@@ -962,16 +975,16 @@ body[data-subpages="cocoon-wide-display"] .page-body {
   min-height: 230px;
 }
 /* Per-card glow (box-shadow external halo) */
-.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(74,158,255,0.35); }
-.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(74,158,255,0.40); }
-.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(184,150,62,0.32); }
-.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(220,232,255,0.15); }
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
 
 .mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
-.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(74,158,255,0.50); }
-.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(74,158,255,0.55); }
-.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(184,150,62,0.45); }
-.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(220,232,255,0.25); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
 
 .mission-card::before {
   content: ""; position: absolute; inset: 0;
@@ -979,25 +992,25 @@ body[data-subpages="cocoon-wide-display"] .page-body {
   transition: background .3s ease;
 }
 .mission-card[data-mode="home"]::before {
-  background: radial-gradient(70% 90% at 0% 0%, rgba(74,158,255,0.12), transparent 65%);
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
 }
 .mission-card[data-mode="workspace"]::before {
-  background: radial-gradient(70% 90% at 0% 0%, rgba(74,158,255,0.16), transparent 65%);
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
 }
 .mission-card[data-mode="capacites"]::before {
-  background: radial-gradient(70% 90% at 0% 0%, rgba(184,150,62,0.16), transparent 65%);
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
 }
 .mission-card[data-mode="config"]::before {
-  background: radial-gradient(70% 90% at 0% 0%, rgba(220,232,255,0.06), transparent 65%);
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
 }
 .mc-card-eyebrow {
   display: flex; align-items: baseline; gap: 10px;
-  font-family: var(--mono); font-size: 9.5px;
+  font-family: var(--mono); font-size: 0.5938rem;
   letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
 }
 .mc-card-num {
   font-family: var(--serif); font-weight: 300;
-  font-size: 20px; letter-spacing: -0.025em;
+  font-size: 1.25rem; letter-spacing: -0.025em;
   color: var(--nav-tint); text-transform: none;
   line-height: 1;
 }
@@ -1011,7 +1024,7 @@ body[data-subpages="cocoon-wide-display"] .page-body {
   color: var(--fg-0);
 }
 .mc-card-sub {
-  font-family: var(--mono); font-size: 9.5px;
+  font-family: var(--mono); font-size: 0.5938rem;
   letter-spacing: 0.12em; color: var(--fg-3);
   text-transform: uppercase;
 }
@@ -1021,10 +1034,10 @@ body[data-subpages="cocoon-wide-display"] .page-body {
 }
 .mc-card-page {
   display: inline-flex; align-items: baseline; gap: 5px;
-  font-family: var(--mono); font-size: 9px;
+  font-family: var(--mono); font-size: 0.5625rem;
   color: var(--fg-3); letter-spacing: 0.06em;
 }
-.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-num { color: var(--fg-4); font-size: 0.5312rem; }
 .mc-pg-lbl { color: var(--fg-2); }
 
 /* ─────────────────────────────────────────────────────────────────────
@@ -1056,14 +1069,14 @@ body[data-subpages="cocoon-wide-display"] .page-head::after {
   left: 240px; width: calc(56% - 188px);
 }
 .page-eyebrow {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.28em;
   text-transform: uppercase; color: var(--nav-tint);
   display: flex; align-items: center; gap: 10px;
   margin-bottom: 12px; opacity: 0.8;
 }
 .page-eyebrow .num {
   font-family: var(--serif); font-weight: 300;
-  font-size: 20px; letter-spacing: -0.025em;
+  font-size: 1.25rem; letter-spacing: -0.025em;
   text-transform: none; color: var(--nav-tint);
 }
 .page-head h1 {
@@ -1072,7 +1085,7 @@ body[data-subpages="cocoon-wide-display"] .page-head::after {
   letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
 }
 .page-head-meta {
-  font-family: var(--mono); font-size: 11px;
+  font-family: var(--mono); font-size: 0.6875rem;
   letter-spacing: 0.04em; color: var(--fg-2);
   white-space: nowrap;
   display: flex; align-items: center; gap: 8px;
@@ -1098,14 +1111,14 @@ body[data-subpages="cocoon-wide-display"] .page-head::after {
 }
 .ghost-sec-title {
   font-family: var(--serif); font-weight: 300;
-  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+  font-size: 1.375rem; letter-spacing: -0.025em; color: var(--fg-0);
 }
 .ghost-sec-sub {
-  font-family: var(--mono); font-size: 10px;
+  font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
 }
 .ghost-sec-r {
-  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+  font-family: var(--mono); font-size: 0.6562rem; color: var(--fg-3);
 }
 
 /* ─────────────────────────────────────────────────────────────────────
@@ -1115,14 +1128,14 @@ body[data-subpages="cocoon-wide-display"] .page-head::after {
   display: grid; grid-template-columns: 4px 1fr auto;
   padding: 16px 18px 16px 22px; margin: 6px 0;
   border-radius: 14px;
-  background: rgba(220,232,255,0.012);
+  background: rgba(var(--c-fg), 0.012);
   border: 0.5px solid var(--line-1);
   cursor: pointer;
   transition: background .15s, border-color .15s, transform .15s;
   gap: 18px; align-items: center;
 }
 .row-stripe:hover {
-  background: rgba(220,232,255,0.035);
+  background: rgba(var(--c-fg), 0.035);
   border-color: var(--line-2);
   transform: translateY(-1px);
 }
@@ -1136,13 +1149,13 @@ body[data-subpages="cocoon-wide-display"] .page-head::after {
 .row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
 .row-stripe-inner { min-width: 0; }
 .row-stripe-title {
-  font-size: 13.5px; color: var(--fg-0);
+  font-size: 0.8438rem; color: var(--fg-0);
   letter-spacing: -0.005em; line-height: 1.35;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .row-stripe-meta {
   display: flex; gap: 10px; align-items: center; margin-top: 5px;
-  font-family: var(--mono); font-size: 10.5px;
+  font-family: var(--mono); font-size: 0.6562rem;
   color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
 }
 .row-stripe-right {
@@ -1168,7 +1181,7 @@ body[data-subpages="cocoon-wide-display"] .page-head::after {
 }
 .home-status .status-row {
   display: flex; align-items: center; gap: 8px;
-  font-family: var(--mono); font-size: 10px;
+  font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.18em; text-transform: uppercase;
   color: var(--fg-2);
 }
@@ -1194,9 +1207,9 @@ body[data-subpages="cocoon-wide-display"] .page-head::after {
   letter-spacing: 0.06em; white-space: nowrap;
   pointer-events: none; user-select: none;
   background: linear-gradient(180deg,
-    rgba(220,232,255,0.18)  0%,
-    rgba(220,232,255,0.11) 38%,
-    rgba(220,232,255,0.03) 74%,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
     transparent            100%);
   -webkit-background-clip: text; background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -1235,13 +1248,13 @@ body[data-subpages="cocoon-wide-display"] .page-head::after {
 }
 .home-channel .msg {
   font-family: var(--serif); font-weight: 300;
-  font-size: 14px; letter-spacing: -0.01em;
+  font-size: 0.875rem; letter-spacing: -0.01em;
   color: var(--fg-1); line-height: 1.55;
 }
 .home-channel .meta {
   display: flex; align-items: center; justify-content: flex-end;
   gap: 10px; margin-top: 6px;
-  font-family: var(--mono); font-size: 9px;
+  font-family: var(--mono); font-size: 0.5625rem;
   letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
 }
 .home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
@@ -1251,4 +1264,15 @@ body[data-subpages="cocoon-wide-display"] .page-head::after {
 @keyframes roomIn {
   from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
   to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+html.in-iframe .atmo--vignette,
+html.in-iframe .atmo--grain,
+html.in-iframe .atmo--aurora {
+  display: none;
 }

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782254922
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782254922
@@ -1,0 +1,1254 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(220, 232, 255, 0.06);
+  --line-2:      rgba(220, 232, 255, 0.10);
+  --line-3:      rgba(220, 232, 255, 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(220, 232, 255, 0.78);
+  --fg-2:        rgba(220, 232, 255, 0.55);
+  --fg-3:        rgba(220, 232, 255, 0.36);
+  --fg-4:        rgba(220, 232, 255, 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(74, 158, 255, 0.14);
+  --accent-line: rgba(74, 158, 255, 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(184, 150, 62, 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(54, 211, 153, 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(229, 72, 77, 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(74,158,255,.06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(184,150,62,.04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(74,158,255,0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 12.5px; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(220,232,255,0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(74,158,255,0.10), rgba(74,158,255,0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(74,158,255,.025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(220,232,255,0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(220,232,255,0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(220,232,255,0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(184,150,62,.32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(54,211,153,.32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(229,72,77,.30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(220,232,255,.06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(220,232,255,0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(220,232,255,0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(74,158,255,0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(74,158,255,.10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(74,158,255,.14), 0 0 60px -20px rgba(74,158,255,.4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(220,232,255,0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(220,232,255,0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 13px;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(74,158,255,.10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(74, 158, 255, 0.08);
+  border: 1px solid rgba(74, 158, 255, 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(74, 158, 255, 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(74, 158, 255, 0.18);
+  border-color: rgba(74, 158, 255, 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(74, 158, 255, 0.20);
+  border-color: rgba(74, 158, 255, 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(74, 158, 255, 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(184,150,62,0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(220,232,255,0.06);
+  --nav-tint-line: rgba(220,232,255,0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(74,158,255,0.16), rgba(74,158,255,0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(184,150,62,0.10), rgba(184,150,62,0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(74,158,255,0.24), rgba(74,158,255,0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(74,158,255,0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(184,150,62,0.20), rgba(184,150,62,0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(74,158,255,0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(184,150,62,0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(220,232,255,0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(74,158,255,0.04), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(74,158,255,0.18);
+  border-bottom: 1px solid rgba(74,158,255,0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(74,158,255,0.22),
+    inset 0  -6px 20px -6px rgba(74,158,255,0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(74,158,255,0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(74,158,255,0.22),
+    inset 0  -6px 20px -6px rgba(74,158,255,0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(74,158,255,0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(74,158,255,0.40),
+    inset 0  -8px 28px -6px rgba(74,158,255,0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(184,150,62,0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(184,150,62,0.40),
+    inset 0  -8px 28px -6px rgba(184,150,62,0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(220,232,255,0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(220,232,255,0.18),
+    inset 0  -6px 20px -6px rgba(220,232,255,0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(74,158,255,0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(220,232,255,0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(74,158,255,0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 12px;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(74,158,255,0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(74,158,255,0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(184,150,62,0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(220,232,255,0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(74,158,255,0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(74,158,255,0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(184,150,62,0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(220,232,255,0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(74,158,255,0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(74,158,255,0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(184,150,62,0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(220,232,255,0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9px;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(220,232,255,0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(220,232,255,0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 13.5px; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(220,232,255,0.18)  0%,
+    rgba(220,232,255,0.11) 38%,
+    rgba(220,232,255,0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 14px; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782256648
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782256648
@@ -1,0 +1,1260 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 12.5px; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 13px;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 12px;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9px;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 13.5px; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 14px; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782257126
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782257126
@@ -1,0 +1,1261 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 12.5px; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 13px;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc { display: none; } /* masqué — remplacé par /mc */
+.rooms-mc-legacy {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 12px;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9px;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 13.5px; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 14px; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782257286
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782257286
@@ -1,0 +1,1266 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 12.5px; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 13px;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.18), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.08), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc { display: none; } /* masqué — remplacé par /mc */
+.rooms-mc-legacy {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 12px;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9px;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 13.5px; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 14px; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782257517
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782257517
@@ -1,0 +1,1277 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 12.5px; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 13px;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.18), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.08), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc { display: none; } /* masqué — remplacé par /mc */
+.rooms-mc-legacy {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 12px;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9px;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 13.5px; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 14px; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+body.in-iframe .atmo--vignette,
+body.in-iframe .atmo--grain,
+body.in-iframe .atmo--aurora {
+  display: none;
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782257660
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782257660
@@ -1,0 +1,1277 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 12.5px; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 13px;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.06), rgba(var(--c-accent), 0.02) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.03), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc { display: none; } /* masqué — remplacé par /mc */
+.rooms-mc-legacy {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 12px;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9px;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 13.5px; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 14px; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+body.in-iframe .atmo--vignette,
+body.in-iframe .atmo--grain,
+body.in-iframe .atmo--aurora {
+  display: none;
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782258064
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782258064
@@ -1,0 +1,1276 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 12.5px; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 13px;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.06), rgba(var(--c-accent), 0.02) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.03), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 12px;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9px;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 13.5px; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 14px; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+body.in-iframe .atmo--vignette,
+body.in-iframe .atmo--grain,
+body.in-iframe .atmo--aurora {
+  display: none;
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782258861
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782258861
@@ -1,0 +1,1276 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 12.5px; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 13px;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.06), rgba(var(--c-accent), 0.02) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.03), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 12px;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9px;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 13.5px; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 14px; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+html.in-iframe .atmo--vignette,
+html.in-iframe .atmo--grain,
+html.in-iframe .atmo--aurora {
+  display: none;
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782259290
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782259290
@@ -1,0 +1,1275 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 12.5px; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 13px;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 80vh at 0% 0%, rgba(var(--c-accent), 0.08), rgba(var(--c-accent), 0.02) 50%, transparent 70%),
+    radial-gradient(60vw 60vh at 100% 100%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 80vh at 100% 100%, rgba(var(--c-gold), 0.08), rgba(var(--c-gold), 0.02) 50%, transparent 70%),
+    radial-gradient(60vw 60vh at 0% 0%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 80vh at 50% 0%, rgba(var(--c-fg), 0.04), transparent 70%),
+    radial-gradient(60vw 60vh at 50% 100%, rgba(var(--c-accent), 0.03), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.06), rgba(var(--c-accent), 0.02) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.03), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 12px;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9px;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 13.5px; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 14px; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+html.in-iframe .atmo--vignette,
+html.in-iframe .atmo--grain,
+html.in-iframe .atmo--aurora {
+  display: none;
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782259625
@@ -1,0 +1,1276 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 60px; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 32px; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 12.5px; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 21px; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 11.5px; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 9.5px; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 13px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 30px; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 16px;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 13px;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 12px;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.06), rgba(var(--c-accent), 0.02) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.03), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 22px; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 9px; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 12px;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 10px; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 9px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9px;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 20px; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 22px; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 13.5px; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 14px; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+html.in-iframe .atmo--vignette,
+html.in-iframe .atmo--grain,
+html.in-iframe .atmo--aurora {
+  display: none;
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782262051
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782262051
@@ -1,0 +1,1276 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 3.75rem; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 2rem; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 1rem; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 0.7812rem; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 1.3125rem; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 0.7188rem; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 1rem; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 0.8125rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 1.875rem; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 0.8125rem; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 1rem;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 0.8125rem;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 0.7188rem;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 0.75rem;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.06), rgba(var(--c-accent), 0.02) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.03), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 1.375rem; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 0.5625rem; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 0.75rem;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 0.625rem; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 0.5625rem; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 1rem; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 0.5625rem;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 0.5312rem; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.375rem; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 0.6562rem; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 0.8438rem; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 0.6562rem;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 0.875rem; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 0.5625rem;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+html.in-iframe .atmo--vignette,
+html.in-iframe .atmo--grain,
+html.in-iframe .atmo--aurora {
+  display: none;
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782262142
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782262142
@@ -1,0 +1,1277 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --accent-icon: rgba(var(--c-accent), 0.75);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 3.75rem; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 2rem; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 1rem; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 0.7812rem; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 1.3125rem; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 0.7188rem; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 1rem; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 0.8125rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 1.875rem; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 0.8125rem; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 1rem;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 0.8125rem;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 0.7188rem;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 0.75rem;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.06), rgba(var(--c-accent), 0.02) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.03), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 1.375rem; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 0.5625rem; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 0.75rem;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 0.625rem; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 0.5625rem; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 1rem; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 0.5625rem;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 0.5312rem; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.375rem; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 0.6562rem; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 0.8438rem; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 0.6562rem;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 0.875rem; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 0.5625rem;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+html.in-iframe .atmo--vignette,
+html.in-iframe .atmo--grain,
+html.in-iframe .atmo--aurora {
+  display: none;
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782262261
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782262261
@@ -1,0 +1,1278 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --accent-icon: rgba(var(--c-accent), 0.75);
+  --accent-icon: rgba(var(--c-accent), 0.75);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 3.75rem; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 2rem; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 1rem; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 0.7812rem; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 1.3125rem; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 0.7188rem; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 1rem; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 0.8125rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 1.875rem; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 0.8125rem; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 1rem;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 0.8125rem;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 0.7188rem;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 0.75rem;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.06), rgba(var(--c-accent), 0.02) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.03), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 1.375rem; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 0.5625rem; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 0.75rem;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 0.625rem; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 0.5625rem; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 1rem; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 0.5625rem;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 0.5312rem; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.375rem; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 0.6562rem; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 0.8438rem; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 0.6562rem;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 0.875rem; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 0.5625rem;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+html.in-iframe .atmo--vignette,
+html.in-iframe .atmo--grain,
+html.in-iframe .atmo--aurora {
+  display: none;
+}

--- a/src/jarvis/interfaces/ui/static/_shared.css.bak-1782262309
+++ b/src/jarvis/interfaces/ui/static/_shared.css.bak-1782262309
@@ -1,0 +1,1278 @@
+@font-face {
+  font-family: 'Landasans';
+  src: url('/fonts/Landasans-Medium.otf') format('opentype');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS V4 — Shared shell (Vision Pro × salle de contrôle)
+   À inclure AVANT dashboard.css et settings.css.
+   Dépend de Geist (Google Fonts) — voir <head> de chaque HTML.
+   ───────────────────────────────────────────────────────────────────── */
+
+:root {
+  /* ── Couleurs de base (RGB séparé pour rgba(var(--c-X), alpha)) ──────── */
+  --c-fg:     220, 232, 255;
+  --c-accent: 74, 158, 255;
+  --c-gold:   184, 150, 62;
+  --c-green:  54, 211, 153;
+  --c-red:    229, 72, 77;
+  /* Base palette */
+  --bg-0:        #06080D;
+  --bg-1:        #0A0E16;
+  --bg-2:        #0F141F;
+  --bg-3:        #161C2A;
+  --line-1:      rgba(var(--c-fg), 0.06);
+  --line-2:      rgba(var(--c-fg), 0.10);
+  --line-3:      rgba(var(--c-fg), 0.16);
+
+  /* Foreground */
+  --fg-0:        #DCE8FF;
+  --fg-1:        rgba(var(--c-fg), 0.78);
+  --fg-2:        rgba(var(--c-fg), 0.55);
+  --fg-3:        rgba(var(--c-fg), 0.36);
+  --fg-4:        rgba(var(--c-fg), 0.20);
+
+  /* Semantic */
+  --accent:      #4A9EFF;
+  --accent-soft: rgba(var(--c-accent), 0.14);
+  --accent-line: rgba(var(--c-accent), 0.32);
+  --accent-icon: color-mix(in srgb, var(--accent) 60%, white 40%);
+  --accent-icon: color-mix(in srgb, var(--accent) 60%, white 40%);
+  --gold:        #B8963E;
+  --gold-soft:   rgba(var(--c-gold), 0.12);
+  --green:       #36D399;
+  --green-soft:  rgba(var(--c-green), 0.12);
+  --red:         #E5484D;
+  --red-soft:    rgba(var(--c-red), 0.10);
+
+  /* Type */
+  --serif: "Geist", "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --sans:  "Geist", "Inter", -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+  --mono:  "Geist Mono", "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+
+  /* Spacing */
+  --gap-1: 4px;  --gap-2: 8px;  --gap-3: 12px; --gap-4: 16px;
+  --gap-5: 24px; --gap-6: 32px; --gap-7: 48px; --gap-8: 64px;
+
+  /* Radii */
+  --r-1: 4px; --r-2: 8px; --r-3: 12px; --r-4: 16px; --r-5: 20px;
+
+  /* Density (overridable via tweaks data-density) */
+  --density-pad: 24px;
+
+  /* Effects */
+  --grain-opacity: 0.035;
+  --vignette-opacity: 0.55;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; background: var(--bg-0); color: var(--fg-0); }
+body {
+  font-family: var(--sans);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-feature-settings: "ss01", "cv11", "tnum";
+  letter-spacing: -0.005em;
+  overflow: hidden;
+}
+
+/* ───────── Atmosphere layers ───────── */
+.atmo { position: fixed; inset: 0; pointer-events: none; z-index: 2; }
+.atmo--vignette {
+  background: radial-gradient(ellipse at 50% 40%, transparent 40%, #000 130%);
+  opacity: var(--vignette-opacity);
+}
+.atmo--grain {
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='180' height='180'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.86  0 0 0 0 0.91  0 0 0 0 1  0 0 0 1 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  mix-blend-mode: screen;
+}
+.atmo--aurora {
+  background:
+    radial-gradient(80vw 60vh at 12% 8%, rgba(var(--c-accent), .06), transparent 60%),
+    radial-gradient(60vw 50vh at 92% 96%, rgba(var(--c-gold), .04), transparent 60%);
+}
+
+/* ───────── Type primitives ───────── */
+.t-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  font-weight: 400;
+}
+.t-label {
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-2);
+}
+.t-mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.t-serif { font-family: var(--serif); font-weight: 300; letter-spacing: -0.025em; }
+
+.num-hero { font-family: var(--serif); font-weight: 300; font-size: 3.75rem; line-height: 0.95; letter-spacing: -0.04em; color: var(--fg-0); font-feature-settings: "tnum","lnum"; }
+.num-md   { font-family: var(--serif); font-weight: 300; font-size: 2rem; line-height: 1; letter-spacing: -0.03em; color: var(--fg-0); }
+
+/* ───────── App shell ───────── */
+.app {
+  position: relative;
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  grid-template-rows: 100vh;
+  width: 100vw; height: 100vh;
+  background: var(--bg-0);
+}
+
+/* ───────── Sidebar ───────── */
+.sidebar {
+  border-right: 1px solid var(--line-1);
+  display: flex; flex-direction: column;
+  padding: 22px 0 18px;
+  background: linear-gradient(180deg, rgba(var(--c-accent), 0.02), transparent 200px);
+  position: relative;
+  z-index: 5;
+}
+.sb-brand {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 22px 22px;
+  border-bottom: 1px solid var(--line-1);
+}
+.sb-brand-text { display: flex; flex-direction: column; line-height: 1; }
+.sb-brand-name { font-family: var(--serif); font-weight: 500; font-size: 1rem; letter-spacing: -0.005em; }
+.sb-brand-status {
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3);
+  letter-spacing: 0.12em; margin-top: 4px; text-transform: uppercase;
+  display: flex; align-items: center; gap: 5px;
+}
+.sb-brand-status::before {
+  content: ""; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--green); box-shadow: 0 0 6px var(--green);
+}
+
+
+.sb-section-eyebrow {
+  padding: 22px 22px 6px;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.18em;
+  color: var(--fg-3); text-transform: uppercase;
+  display: flex; justify-content: space-between; align-items: center;
+}
+
+.sb-nav { display: flex; flex-direction: column; padding: 0 10px; gap: 1px; }
+.sb-item {
+  position: relative;
+  display: grid; grid-template-columns: 12px 1fr auto;
+  align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 0.7812rem; letter-spacing: 0.005em;
+  border: 0; background: none; text-align: left; width: 100%;
+  font-family: inherit;
+  transition: background .15s ease, color .15s ease;
+}
+.sb-item:hover { background: rgba(var(--c-fg), 0.04); color: var(--fg-0); }
+.sb-item.is-on {
+  background: linear-gradient(90deg, rgba(var(--c-accent), 0.10), rgba(var(--c-accent), 0.02));
+  color: var(--fg-0);
+}
+.sb-item.is-on::before {
+  content: ""; position: absolute; left: -10px; top: 9px; bottom: 9px;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+  border-radius: 2px;
+}
+.sb-dot { width: 5px; height: 5px; border-radius: 50%; background: var(--fg-4); justify-self: center; }
+.sb-item.is-on .sb-dot { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+.sb-item .sb-meta { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); font-variant-numeric: tabular-nums; }
+.sb-item.is-on .sb-meta { color: var(--fg-1); }
+
+.sb-spark-wrap { padding: 20px 22px 0; }
+.sb-spark { display: block; height: 32px; width: 100%; }
+.sb-spark-meta {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3); letter-spacing: 0.06em;
+}
+
+.sb-foot {
+  margin-top: auto;
+  padding: 14px 22px 0;
+  border-top: 1px solid var(--line-1);
+  display: flex; flex-direction: column; gap: 10px;
+}
+.sb-foot-row {
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-foot-row > span:last-child { color: var(--fg-1); }
+.sb-foot-bar { height: 2px; background: var(--bg-2); border-radius: 2px; overflow: hidden; }
+.sb-foot-bar > div {
+  height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF);
+  transition: width .4s ease;
+}
+
+/* Sidebar breath (notification echo) */
+.sb-breath {
+  position: absolute; right: -1px; top: 0; bottom: 0;
+  width: 1px; background: var(--accent);
+  box-shadow: 0 0 12px var(--accent);
+  pointer-events: none; opacity: 0;
+  animation: sbBreath 1.6s ease both;
+}
+@keyframes sbBreath {
+  0%   { opacity: 0; transform: scaleY(0); transform-origin: top; }
+  20%  { opacity: 1; transform: scaleY(1); transform-origin: top; }
+  60%  { opacity: 1; transform: scaleY(1); transform-origin: bottom; }
+  100% { opacity: 0; transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ───────── Main scroll region ───────── */
+.main {
+  position: relative;
+  overflow-y: auto; overflow-x: hidden;
+  background:
+    radial-gradient(60vw 40vh at 100% 0%, rgba(var(--c-accent), .025), transparent 60%),
+    var(--bg-0);
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.main::-webkit-scrollbar { width: 10px; }
+.main::-webkit-scrollbar-thumb {
+  background: rgba(var(--c-fg), 0.08); border-radius: 6px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+
+/* ───────── Topbar ───────── */
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 18px var(--density-pad) 14px;
+  border-bottom: 1px solid var(--line-1);
+  position: sticky; top: 0;
+  background: rgba(6,8,13,0.72);
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  z-index: 6;
+}
+.topbar-l { display: flex; align-items: baseline; gap: 14px; }
+.topbar-page-title { font-family: var(--serif); font-weight: 400; font-size: 1.3125rem; letter-spacing: -0.025em; }
+.topbar-crumb { color: var(--fg-3); font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.1em; text-transform: uppercase; }
+
+.topbar-c {
+  display: flex; align-items: center; gap: 18px;
+  padding: 6px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 999px;
+  background: var(--bg-1);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.06em;
+}
+.topbar-c .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--green); box-shadow: 0 0 6px var(--green); }
+.topbar-c .sep { width: 1px; height: 10px; background: var(--line-2); }
+
+.topbar-r { display: flex; align-items: center; gap: 10px; justify-content: flex-end; }
+.tb-btn {
+  appearance: none; border: 1px solid var(--line-2);
+  background: var(--bg-1); color: var(--fg-1);
+  padding: 7px 12px; border-radius: 8px;
+  font-family: var(--sans); font-size: 0.7188rem; font-weight: 500;
+  display: inline-flex; align-items: center; gap: 8px;
+  cursor: pointer; transition: all .15s ease;
+  letter-spacing: 0.005em;
+}
+.tb-btn:hover { background: var(--bg-2); border-color: var(--line-3); color: var(--fg-0); }
+.tb-btn .kbd { font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3); letter-spacing: 0.06em; padding: 2px 5px; border: 1px solid var(--line-2); border-radius: 3px; }
+
+/* ───────── Surface + cards + section headers ───────── */
+.surface {
+  padding: var(--density-pad);
+  display: flex; flex-direction: column;
+  gap: 28px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 14px;
+  padding: var(--density-pad);
+  position: relative;
+}
+.card--bare { background: transparent; border: 0; padding: 0; }
+.card-hd { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 18px; }
+.card-title { font-family: var(--serif); font-weight: 500; font-size: 1rem; letter-spacing: -0.015em; color: var(--fg-0); }
+.card-sub { font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); margin-top: 6px; }
+
+.sec-hd {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 4px 0 10px;
+  border-bottom: 1px solid var(--line-1);
+  margin-bottom: 4px;
+  position: relative;
+}
+.sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -1px;
+  width: 32px; height: 1px; background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.sec-hd-l { display: flex; flex-direction: column; gap: 0; align-items: flex-start; }
+.sec-hd-row { display: flex; align-items: center; gap: 14px; }
+.sec-hd-num { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); letter-spacing: 0.16em; }
+.sec-hd-title { font-family: var(--mono); font-weight: 500; font-size: 0.8125rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-0); }
+.sec-hd-disp { font-family: var(--serif); font-weight: 300; font-size: 1.875rem; letter-spacing: -0.035em; color: var(--fg-0); display: block; margin-top: 8px; line-height: 1.05; }
+.sec-hd-r { color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.04em; }
+
+/* ───────── Buttons / badges ───────── */
+.btn-ghost {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-2); font: 500 11.5px var(--sans);
+  padding: 6px 10px; border-radius: 6px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; transition: all .15s ease;
+}
+.btn-ghost:hover { color: var(--fg-0); background: rgba(var(--c-fg), 0.04); }
+.btn-accent {
+  appearance: none; background: var(--accent); border: 0;
+  color: #001127; font: 600 11.5px var(--sans);
+  padding: 7px 12px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit;
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 4px;
+  border: 1px solid var(--line-2); color: var(--fg-2);
+}
+.badge--accent { color: var(--accent); border-color: var(--accent-line); background: var(--accent-soft); }
+.badge--gold   { color: var(--gold);   border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.badge--green  { color: var(--green);  border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.badge--red    { color: var(--red);    border-color: rgba(var(--c-red), .30);  background: var(--red-soft); }
+.badge--solid  { background: rgba(var(--c-fg), .06); border-color: transparent; color: var(--fg-1); }
+.badge .pri-dot { width: 5px; height: 5px; border-radius: 50%; background: currentColor; }
+
+/* Scroll inside cards */
+.scroll-y { overflow-y: auto; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.scroll-y::-webkit-scrollbar { width: 6px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+/* Page-in transition */
+.page-in { animation: pageIn .35s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes pageIn {
+  from { opacity: 0; transform: translateY(8px); filter: blur(6px); }
+  to   { opacity: 1; transform: translateY(0);   filter: blur(0); }
+}
+
+/* ───────── Inspector mode (hold Alt) ───────── */
+.inspect-hint {
+  position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%);
+  z-index: 1900;
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: rgba(var(--c-accent), 0.12);
+  border: 1px solid var(--accent-line);
+  border-radius: 999px;
+  color: var(--accent);
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.18em;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 0 24px -6px var(--accent);
+  animation: fadeIn .2s ease both;
+}
+.inspect-hint .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+  animation: blink 1.4s ease-in-out infinite;
+}
+html.inspect [data-inspect] {
+  position: relative; cursor: help;
+  outline: 1px dashed var(--accent-line); outline-offset: 2px;
+  border-radius: 2px; transition: outline-color .15s;
+}
+html.inspect [data-inspect]:hover {
+  outline-color: var(--accent); outline-style: solid;
+  background: var(--accent-soft);
+}
+html.inspect [data-inspect]::after {
+  content: attr(data-inspect);
+  position: absolute; left: 50%; bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-2);
+  border: 1px solid var(--accent-line);
+  color: var(--fg-0);
+  font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.06em;
+  padding: 6px 10px; border-radius: 6px;
+  opacity: 0; pointer-events: none; z-index: 1800;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.6), 0 0 0 1px var(--accent-line);
+  transition: opacity .12s;
+}
+html.inspect [data-inspect]:hover::after { opacity: 1; }
+
+/* ───────── Notification ribbon ───────── */
+.notif-stack {
+  position: fixed; top: 18px; right: 18px;
+  z-index: 1800;
+  display: flex; flex-direction: column; gap: 8px;
+  pointer-events: none;
+  width: 320px;
+}
+.notif {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: rgba(15,20,31,0.92);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -10px rgba(0,0,0,.6), 0 0 0 1px rgba(var(--c-accent), .10);
+  pointer-events: auto;
+  animation: notifIn .35s cubic-bezier(.2,.8,.25,1) both, notifOut .4s ease 3.8s both;
+  position: relative; overflow: hidden;
+}
+.notif::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 2px; background: var(--accent);
+  box-shadow: 0 0 10px var(--accent);
+}
+.notif--success::before { background: var(--green); box-shadow: 0 0 10px var(--green); }
+.notif--warn::before    { background: var(--gold);  box-shadow: 0 0 10px var(--gold); }
+.notif--error::before   { background: var(--red);   box-shadow: 0 0 10px var(--red); }
+.notif-mark {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--accent); box-shadow: 0 0 8px var(--accent);
+}
+.notif--success .notif-mark { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.notif--warn    .notif-mark { background: var(--gold);  box-shadow: 0 0 8px var(--gold); }
+.notif--error   .notif-mark { background: var(--red);   box-shadow: 0 0 8px var(--red); }
+.notif-text { font-family: var(--sans); font-size: 0.8125rem; color: var(--fg-0); letter-spacing: -0.005em; }
+.notif-time {
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3); letter-spacing: 0.1em; text-transform: uppercase;
+}
+@keyframes notifIn  { from { opacity: 0; transform: translateY(-8px) scale(.98); } to { opacity: 1; transform: none; } }
+@keyframes notifOut { to   { opacity: 0; transform: translateX(20px); } }
+@keyframes fadeIn   { from { opacity: 0; } to { opacity: 1; } }
+@keyframes blink    { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+
+/* ───────── Command palette ───────── */
+.cmdk-back {
+  position: fixed; inset: 0; z-index: 2000;
+  background: rgba(6,8,13,0.55);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  animation: fadeIn .18s ease both;
+}
+.cmdk-back.is-hidden { display: none; }
+.cmdk-input-wrap { position: relative; }
+.cmdk-prefix {
+  position: absolute; left: 22px; top: 50%; transform: translateY(-50%);
+  color: var(--accent); font-family: var(--mono); font-size: 1rem;
+  text-shadow: 0 0 8px var(--accent);
+}
+.cmdk {
+  width: min(640px, 92vw);
+  background: linear-gradient(180deg, rgba(15,20,31,.92), rgba(10,14,22,.92));
+  border: 1px solid var(--line-3);
+  border-radius: 16px;
+  box-shadow: 0 32px 80px -20px rgba(0,0,0,.7), 0 0 0 1px rgba(var(--c-accent), .14), 0 0 60px -20px rgba(var(--c-accent), .4);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  animation: cmdkIn .22s cubic-bezier(.2,.8,.25,1) both;
+}
+@keyframes cmdkIn { from { opacity: 0; transform: translateY(-12px) scale(.98); } to { opacity: 1; transform: none; } }
+.cmdk-input {
+  appearance: none; background: transparent; border: 0;
+  color: var(--fg-0); font: 16px var(--sans);
+  padding: 18px 22px; outline: none; width: 100%;
+  border-bottom: 1px solid var(--line-1);
+  letter-spacing: -0.01em;
+  font-family: inherit;
+}
+.cmdk-input.has-prefix { padding-left: 38px; }
+.cmdk-input::placeholder { color: var(--fg-3); }
+.cmdk-list { max-height: 380px; overflow-y: auto; padding: 8px; scrollbar-width: thin; scrollbar-color: rgba(var(--c-fg), 0.08) transparent; }
+.cmdk-list::-webkit-scrollbar { width: 6px; }
+.cmdk-list::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.cmdk-group-lbl { padding: 10px 14px 6px; font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.16em; text-transform: uppercase; }
+.cmdk-item {
+  display: grid; grid-template-columns: 24px 1fr auto;
+  gap: 12px; align-items: center;
+  padding: 9px 14px; border-radius: 8px;
+  cursor: pointer; color: var(--fg-1);
+  font-size: 0.8125rem;
+}
+.cmdk-item.is-on { background: var(--accent-soft); color: var(--fg-0); }
+.cmdk-item .ck-glyph { font: 10px var(--mono); color: var(--fg-3); width: 24px; text-align: center; }
+.cmdk-item.is-on .ck-glyph { color: var(--accent); }
+.cmdk-item .ck-sub { display: block; font: 10.5px var(--mono); color: var(--fg-3); margin-top: 2px; }
+.cmdk-item .ck-kbd { display: inline-flex; gap: 3px; }
+.cmdk-item .ck-kbd > span {
+  font: 9.5px var(--mono); color: var(--fg-3); letter-spacing: 0.06em;
+  border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 5px;
+}
+.cmdk-empty {
+  padding: 32px 16px; text-align: center;
+  color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.08em;
+}
+.cmdk-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 10px 16px; border-top: 1px solid var(--line-1);
+  font: 10px var(--mono); color: var(--fg-3); letter-spacing: 0.08em;
+}
+
+/* ───────── Toggle / select / inputs (utilities) ───────── */
+.toggle {
+  width: 34px; height: 19px; border-radius: 999px;
+  background: var(--bg-3); position: relative; cursor: pointer;
+  border: 1px solid var(--line-2);
+  transition: all .2s ease;
+  flex-shrink: 0;
+}
+.toggle::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 13px; height: 13px; border-radius: 50%;
+  background: var(--fg-2);
+  transition: all .2s ease;
+}
+.toggle.on { background: var(--accent-soft); border-color: var(--accent-line); }
+.toggle.on::after { left: 17px; background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+
+.select-mono {
+  appearance: none; background: var(--bg-2); border: 1px solid var(--line-2);
+  color: var(--fg-1); font-family: var(--mono); font-size: 0.7188rem;
+  padding: 7px 28px 7px 10px; border-radius: 6px; cursor: pointer;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+}
+.input-mono {
+  appearance: none;
+  font-family: var(--mono); font-size: 0.75rem;
+  color: var(--fg-1);
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  padding: 8px 12px;
+  width: 100%;
+}
+.input-mono:focus { outline: none; border-color: var(--accent-line); box-shadow: 0 0 0 3px rgba(var(--c-accent), .10); }
+
+/* ───────── Bottom nav (persistent pill) ───────── */
+#j-bottom-nav {
+  position: fixed;
+  bottom: 20px;
+  left: 220px; /* offset sidebar width */
+  right: 0;
+  z-index: 9990;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+.jnav-btn {
+  pointer-events: all;
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0; margin: 0; outline: none;
+}
+.jnav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+.jnav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* ───────── Loading / empty states ───────── */
+.j-loading {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.1em; color: var(--fg-3);
+  padding: 32px 0; text-align: center; text-transform: uppercase;
+}
+.j-empty {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.08em; color: var(--fg-3);
+  padding: 24px 0; text-align: center; text-transform: uppercase;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   DESIGN V2 — Mode system, atmosphère, navigation rooms, page-head
+   ───────────────────────────────────────────────────────────────────── */
+
+/* ── Tokens supplémentaires ── */
+:root {
+  --purple:      #A78BFA;
+  --purple-soft: rgba(167, 139, 250, 0.16);
+  --purple-glow: rgba(167, 139, 250, 0.55);
+  --amber:       #E5A23E;
+  --amber-soft:  rgba(229, 162, 62, 0.14);
+
+  /* Nav tint (overridé par mode) */
+  --nav-tint:       var(--accent);
+  --nav-tint-soft:  var(--accent-soft);
+  --nav-tint-line:  var(--accent-line);
+
+  /* HUD */
+  --hud-h: 54px;
+}
+
+/* ── Nav tint par mode ── */
+body[data-mode="capacites"] {
+  --nav-tint:      var(--gold);
+  --nav-tint-soft: var(--gold-soft);
+  --nav-tint-line: rgba(var(--c-gold), 0.32);
+}
+body[data-mode="config"] {
+  --nav-tint:      var(--fg-0);
+  --nav-tint-soft: rgba(var(--c-fg), 0.06);
+  --nav-tint-line: rgba(var(--c-fg), 0.16);
+}
+
+/* ── Aurora par mode ── */
+.atmo--aurora {
+  transition: background .9s cubic-bezier(.4,0,.2,1);
+}
+body[data-mode="home"] .atmo--aurora {
+  background:
+    radial-gradient(60vw 65vh at 0% 0%,  rgba(var(--c-accent), 0.16), rgba(var(--c-accent), 0.05) 45%, transparent 70%),
+    radial-gradient(55vw 65vh at 110% 115%, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.02) 40%, transparent 70%),
+    radial-gradient(70vw 50vh at 50% -10%, rgba(167,139,250,0.06), transparent 60%);
+}
+body[data-mode="workspace"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -15% -25%, rgba(var(--c-accent), 0.24), rgba(var(--c-accent), 0.04) 35%, transparent 60%),
+    radial-gradient(50vw 40vh at 100% 110%, rgba(var(--c-accent), 0.08), transparent 70%);
+}
+body[data-mode="capacites"] .atmo--aurora {
+  background:
+    radial-gradient(80vw 100vh at 110% 110%, rgba(var(--c-gold), 0.20), rgba(var(--c-gold), 0.04) 35%, transparent 60%),
+    radial-gradient(55vw 60vh at -10% -15%, rgba(var(--c-accent), 0.06), transparent 65%),
+    radial-gradient(40vw 60vh at 100% -10%, rgba(var(--c-gold), 0.06), transparent 70%);
+}
+body[data-mode="config"] .atmo--aurora {
+  background:
+    radial-gradient(120vw 80vh at 50% -30%, rgba(var(--c-fg), 0.05), transparent 70%),
+    radial-gradient(80vw 60vh at 50% 130%, rgba(var(--c-accent), 0.04), transparent 70%);
+}
+body[data-mode="mc"] .atmo--aurora {
+  background:
+    radial-gradient(95vw 130vh at -5% -20%, rgba(var(--c-accent), 0.06), rgba(var(--c-accent), 0.02) 35%, transparent 60%),
+    radial-gradient(60vw 50vh at 110% 110%, rgba(var(--c-gold), 0.03), transparent 70%);
+}
+
+/* ── Mode glow — liseré laser sur droite + bas uniquement ── */
+.mode-glow {
+  position: fixed; inset: 0; pointer-events: none; z-index: 3;
+  border: none;
+  border-right:  1px solid rgba(var(--c-accent), 0.18);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+  transition: box-shadow .9s ease, border-color .9s ease;
+}
+body[data-mode="home"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.18);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-accent), 0.22),
+    inset 0  -6px 20px -6px rgba(var(--c-accent), 0.22);
+}
+body[data-mode="workspace"] .mode-glow {
+  border-color: rgba(var(--c-accent), 0.40);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-accent), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-accent), 0.40);
+}
+body[data-mode="capacites"] .mode-glow {
+  border-color: rgba(var(--c-gold), 0.42);
+  box-shadow:
+    inset -8px 0  28px -6px rgba(var(--c-gold), 0.40),
+    inset 0  -8px 28px -6px rgba(var(--c-gold), 0.40);
+}
+body[data-mode="config"] .mode-glow {
+  border-color: rgba(var(--c-fg), 0.16);
+  box-shadow:
+    inset -6px 0  20px -6px rgba(var(--c-fg), 0.18),
+    inset 0  -6px 20px -6px rgba(var(--c-fg), 0.18);
+}
+
+/* ── Spotlight (suit la souris) ── */
+.spotlight {
+  position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background: radial-gradient(360px at var(--mx, 50%) var(--my, 50%),
+    rgba(var(--c-accent), 0.04), transparent 70%);
+  transition: --mx .05s, --my .05s;
+}
+
+/* ── Watermark mode ── */
+.mode-watermark {
+  position: fixed;
+  right: -0.08em; bottom: -0.12em;
+  z-index: 0; pointer-events: none;
+  font-family: var(--serif); font-weight: 700;
+  font-size: 22vw; line-height: 0.85;
+  letter-spacing: -0.06em;
+  color: transparent;
+  -webkit-text-stroke: 1px rgba(var(--c-fg), 0.025);
+  user-select: none;
+  white-space: nowrap;
+  transition: opacity .6s ease;
+}
+
+/* ── Scene card ── */
+.scene-card {
+  position: fixed; inset: 0; z-index: 2000;
+  display: grid; place-items: center;
+  background: var(--bg-0);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .6s ease;
+}
+.scene-card.is-visible { opacity: 1; }
+.scene-card-inner {
+  display: flex; flex-direction: column; align-items: center; gap: 16px;
+  animation: sceneIn .7s cubic-bezier(.2,.8,.25,1) both;
+}
+.scene-card-chapter {
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.32em;
+  text-transform: uppercase; color: var(--nav-tint); opacity: 0.7;
+}
+.scene-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(48px, 8vw, 96px);
+  letter-spacing: -0.04em; line-height: 0.95;
+  color: var(--fg-0);
+}
+@keyframes sceneIn {
+  from { opacity: 0; transform: translateY(16px); filter: blur(8px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   ROOMS NAV — Chapter indicator, Mission Control, Subpages pill
+   ───────────────────────────────────────────────────────────────────── */
+
+/* Chapter indicator top-left */
+.rooms-chapter {
+  position: fixed; top: 28px; left: 36px; z-index: 80;
+  display: inline-flex; align-items: baseline; gap: 14px;
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-2); pointer-events: none;
+}
+.rooms-num {
+  color: var(--nav-tint); font-family: var(--serif);
+  font-weight: 300; font-size: 1.375rem; letter-spacing: -0.025em;
+  text-transform: none; line-height: 1;
+}
+.rooms-bar {
+  width: 18px; height: 0.5px; background: var(--line-3);
+  display: inline-block; align-self: center; flex-shrink: 0;
+}
+.rooms-lbl { color: var(--fg-1); font-weight: 500; }
+
+/* Mission Control trigger bottom-left */
+.rooms-mc {
+  position: fixed; bottom: 28px; left: 28px; z-index: 80;
+  display: inline-flex; align-items: center; gap: 9px;
+  padding: 8px 14px 8px 10px;
+  background: rgba(10, 14, 22, 0.75);
+  backdrop-filter: blur(20px) saturate(160%);
+  -webkit-backdrop-filter: blur(20px) saturate(160%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.13em; text-transform: uppercase;
+  color: var(--fg-3); cursor: pointer;
+  transition: border-color .2s, color .2s, background .2s, box-shadow .2s;
+}
+.rooms-mc:hover {
+  color: var(--fg-1);
+  border-color: var(--accent-line);
+  background: rgba(10, 14, 22, 0.90);
+  box-shadow: 0 0 0 1px var(--accent-line), 0 4px 24px rgba(var(--c-accent), 0.10);
+}
+.rooms-mc .mc-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent);
+  opacity: 0.55;
+  transition: opacity .2s, box-shadow .2s;
+}
+.rooms-mc:hover .mc-dot { opacity: 1; box-shadow: 0 0 10px var(--accent); }
+.rooms-mc .mc-kbd { display: flex; gap: 3px; margin-left: 2px; }
+.rooms-mc .mc-kbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-size: 0.5625rem; color: var(--fg-4); letter-spacing: 0.06em;
+  transition: border-color .2s, color .2s;
+}
+.rooms-mc:hover .mc-kbd span { border-color: var(--line-3); color: var(--fg-3); }
+
+/* Subpages pill bottom-center */
+.rooms-pages {
+  position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+  z-index: 80;
+  display: inline-flex; gap: 6px; padding: 6px;
+  background: rgba(13,17,23,0.78);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 0.5px solid var(--line-2); border-radius: 999px;
+  max-width: calc(100vw - 400px);
+  overflow-x: auto; scrollbar-width: none;
+  transition: opacity .25s ease, transform .3s ease;
+}
+.rooms-pages::-webkit-scrollbar { display: none; }
+.rooms-pages button {
+  appearance: none; -webkit-appearance: none;
+  background: transparent; border: none; outline: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 14px; border-radius: 999px;
+  font-family: var(--sans); font-size: 0.75rem;
+  color: var(--fg-2); white-space: nowrap;
+  transition: color .15s, background .15s;
+  animation: roomsChipIn .32s cubic-bezier(.4,0,.2,1) both;
+  position: relative;
+}
+.rooms-pages button:hover { color: var(--fg-0); }
+.rooms-pages button[data-active="true"] {
+  background: var(--nav-tint-soft); color: var(--nav-tint);
+}
+.rooms-pages button .num {
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.08em; color: var(--fg-3);
+}
+.rooms-pages button[data-active="true"] .num { color: currentColor; opacity: 0.7; }
+@keyframes roomsChipIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Editorial sidebar (cocoon-wide-display) ── */
+body[data-subpages="cocoon-wide-display"] .sidebar { display: none !important; }
+
+body[data-subpages="cocoon-wide-display"] .rooms-pages {
+  position: fixed; top: 86px; left: 36px; bottom: 86px;
+  transform: none; bottom: 86px;
+  width: 190px;
+  max-width: 190px;
+  display: flex; flex-direction: column;
+  gap: 2px; padding: 0;
+  background: transparent; border: 0;
+  backdrop-filter: none; -webkit-backdrop-filter: none;
+  border-radius: 0; overflow: hidden;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages::before {
+  content: attr(data-mode-label);
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-3); display: block;
+  margin-bottom: 18px; padding-left: 4px;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button {
+  border-radius: 0; padding: 6px 4px;
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  color: var(--fg-3); animation: none;
+  justify-content: flex-start;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button:hover { color: var(--fg-1); background: none; }
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"] {
+  color: var(--nav-tint); background: none;
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button[data-active="true"]::before {
+  content: ""; position: absolute; left: -20px; top: 50%; transform: translateY(-50%);
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--nav-tint); box-shadow: 0 0 10px var(--nav-tint);
+}
+body[data-subpages="cocoon-wide-display"] .rooms-pages button .num { display: none; }
+body[data-subpages="cocoon-wide-display"] .page-body {
+  padding-left: 240px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   MISSION CONTROL overlay (⌘T)
+   ───────────────────────────────────────────────────────────────────── */
+.mission-overlay {
+  position: fixed; inset: 0; z-index: 3000;
+  background: rgba(6,8,13,0.82);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  display: grid; place-items: center;
+  animation: fadeIn .2s ease both;
+}
+.mission-overlay.is-hidden { display: none; }
+/* ── MC header bar ── */
+.mc-header {
+  position: fixed; top: 0; left: 0; right: 0; z-index: 3002;
+  display: flex; align-items: center; justify-content: center;
+  gap: 18px; padding: 20px 28px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-header-title {
+  font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: var(--fg-1); font-weight: 500;
+}
+.mc-header-hint {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: 0.625rem; letter-spacing: 0.14em; color: var(--fg-4);
+}
+.mc-hkbd {
+  display: inline-flex; gap: 2px;
+}
+.mc-hkbd span {
+  padding: 2px 5px; border: 0.5px solid var(--line-2); border-radius: 3px;
+  font-size: 0.5625rem; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-hdot { opacity: .5; }
+.mc-close {
+  position: absolute; right: 28px; top: 50%; transform: translateY(-50%);
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-3); font-size: 1rem; line-height: 1;
+  padding: 4px 9px; cursor: pointer; z-index: 3003;
+  transition: color .15s, border-color .15s;
+}
+.mc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+.mission-grid {
+  display: grid; grid-template-columns: 1fr 1fr;
+  gap: 22px; width: min(1100px, calc(100vw - 100px));
+}
+.mission-card {
+  position: relative; overflow: hidden;
+  padding: 36px 32px;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2); border-radius: 18px;
+  cursor: pointer; text-align: left;
+  transition: border-color .2s, transform .2s;
+  display: flex; flex-direction: column; gap: 10px;
+  min-height: 230px;
+}
+/* Per-card glow (box-shadow external halo) */
+.mission-card[data-mode="home"]      { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.35); }
+.mission-card[data-mode="workspace"] { box-shadow: 0 0 70px -12px rgba(var(--c-accent), 0.40); }
+.mission-card[data-mode="capacites"] { box-shadow: 0 0 70px -12px rgba(var(--c-gold), 0.32); }
+.mission-card[data-mode="config"]    { box-shadow: 0 0 70px -12px rgba(var(--c-fg), 0.15); }
+
+.mission-card:hover { border-color: var(--line-3); transform: scale(1.01); }
+.mission-card[data-mode="home"]:hover      { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.50); }
+.mission-card[data-mode="workspace"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-accent), 0.55); }
+.mission-card[data-mode="capacites"]:hover { box-shadow: 0 0 90px -8px rgba(var(--c-gold), 0.45); }
+.mission-card[data-mode="config"]:hover    { box-shadow: 0 0 90px -8px rgba(var(--c-fg), 0.25); }
+
+.mission-card::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 18px; pointer-events: none;
+  transition: background .3s ease;
+}
+.mission-card[data-mode="home"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.12), transparent 65%);
+}
+.mission-card[data-mode="workspace"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-accent), 0.16), transparent 65%);
+}
+.mission-card[data-mode="capacites"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-gold), 0.16), transparent 65%);
+}
+.mission-card[data-mode="config"]::before {
+  background: radial-gradient(70% 90% at 0% 0%, rgba(var(--c-fg), 0.06), transparent 65%);
+}
+.mc-card-eyebrow {
+  display: flex; align-items: baseline; gap: 10px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3);
+}
+.mc-card-num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  color: var(--nav-tint); text-transform: none;
+  line-height: 1;
+}
+.mission-card[data-mode="home"]      .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="workspace"] .mc-card-num { color: var(--accent); }
+.mission-card[data-mode="capacites"] .mc-card-num { color: var(--gold); }
+.mission-card[data-mode="config"]    .mc-card-num { color: var(--fg-2); }
+.mc-card-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(32px, 3vw, 44px); letter-spacing: -0.035em; line-height: 1;
+  color: var(--fg-0);
+}
+.mc-card-sub {
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.12em; color: var(--fg-3);
+  text-transform: uppercase;
+}
+.mc-card-pages {
+  margin-top: auto; display: flex; flex-wrap: wrap; gap: 6px 12px;
+  border-top: 0.5px solid var(--line-1); padding-top: 14px;
+}
+.mc-card-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 0.5625rem;
+  color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mc-pg-num { color: var(--fg-4); font-size: 0.5312rem; }
+.mc-pg-lbl { color: var(--fg-2); }
+
+/* ─────────────────────────────────────────────────────────────────────
+   PAGE HEAD (v2)
+   ───────────────────────────────────────────────────────────────────── */
+#page-root {
+  position: relative; z-index: 4;
+}
+.page {
+  min-height: 100vh;
+  padding: 0 0 80px 0;
+}
+.page-head {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 72px 52px 32px;
+  position: relative;
+}
+body[data-subpages="cocoon-wide-display"] .page-head {
+  padding-left: 240px;
+}
+.page-head::after {
+  content: ""; position: absolute; left: 52px; bottom: 8px;
+  width: 56%; height: 1px;
+  background: linear-gradient(to right, var(--nav-tint) 0%, var(--nav-tint) 30%, transparent 100%);
+  opacity: 0.55; box-shadow: 0 0 12px var(--nav-tint);
+  pointer-events: none;
+}
+body[data-subpages="cocoon-wide-display"] .page-head::after {
+  left: 240px; width: calc(56% - 188px);
+}
+.page-eyebrow {
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.28em;
+  text-transform: uppercase; color: var(--nav-tint);
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 12px; opacity: 0.8;
+}
+.page-eyebrow .num {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.25rem; letter-spacing: -0.025em;
+  text-transform: none; color: var(--nav-tint);
+}
+.page-head h1 {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(28px, 3.5vw, 48px);
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0); margin: 0;
+}
+.page-head-meta {
+  font-family: var(--mono); font-size: 0.6875rem;
+  letter-spacing: 0.04em; color: var(--fg-2);
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 8px;
+}
+.page-head-meta .v { color: var(--nav-tint); }
+.page-body {
+  padding: 36px 52px 0; display: flex; flex-direction: column; gap: 48px;
+}
+
+/* Ghost sections (no bg, no border) */
+.ghost-sec { display: flex; flex-direction: column; gap: 20px; }
+.ghost-sec-hd {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 0;
+  position: relative;
+}
+.ghost-sec-hd::after {
+  content: ""; position: absolute; left: 0; bottom: -0.5px;
+  width: 40px; height: 1px; background: var(--nav-tint);
+  box-shadow: 0 0 8px var(--nav-tint); pointer-events: none;
+}
+.ghost-sec-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 1.375rem; letter-spacing: -0.025em; color: var(--fg-0);
+}
+.ghost-sec-sub {
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.ghost-sec-r {
+  font-family: var(--mono); font-size: 0.6562rem; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   FLOATING STRIPE items
+   ───────────────────────────────────────────────────────────────────── */
+.row-stripe {
+  display: grid; grid-template-columns: 4px 1fr auto;
+  padding: 16px 18px 16px 22px; margin: 6px 0;
+  border-radius: 14px;
+  background: rgba(var(--c-fg), 0.012);
+  border: 0.5px solid var(--line-1);
+  cursor: pointer;
+  transition: background .15s, border-color .15s, transform .15s;
+  gap: 18px; align-items: center;
+}
+.row-stripe:hover {
+  background: rgba(var(--c-fg), 0.035);
+  border-color: var(--line-2);
+  transform: translateY(-1px);
+}
+.row-stripe-bar {
+  width: 3px; height: 80%; border-radius: 2px; align-self: center;
+  flex-shrink: 0;
+}
+.row-stripe-bar.high  { background: var(--red);   box-shadow: 0 0 8px -1px var(--red); }
+.row-stripe-bar.med   { background: var(--amber);  box-shadow: 0 0 8px -1px var(--amber); }
+.row-stripe-bar.low   { background: var(--accent); box-shadow: 0 0 8px -1px var(--accent); }
+.row-stripe-bar.green { background: var(--green);  box-shadow: 0 0 8px -1px var(--green); }
+.row-stripe-inner { min-width: 0; }
+.row-stripe-title {
+  font-size: 0.8438rem; color: var(--fg-0);
+  letter-spacing: -0.005em; line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.row-stripe-meta {
+  display: flex; gap: 10px; align-items: center; margin-top: 5px;
+  font-family: var(--mono); font-size: 0.6562rem;
+  color: var(--fg-2); letter-spacing: 0.04em; flex-wrap: wrap;
+}
+.row-stripe-right {
+  display: flex; flex-direction: column; align-items: flex-end;
+  gap: 6px; flex-shrink: 0;
+}
+
+/* ─────────────────────────────────────────────────────────────────────
+   HOME page shell
+   ───────────────────────────────────────────────────────────────────── */
+.home-shell {
+  position: fixed; inset: 0; overflow: hidden; z-index: 4;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: space-between;
+  padding: 32px;
+}
+.home-top {
+  width: 100%; display: flex; align-items: flex-start;
+  justify-content: space-between; z-index: 10; position: relative;
+}
+.home-status {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.home-status .status-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-2);
+}
+.home-status .status-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.blue   { background: var(--accent); box-shadow: 0 0 8px var(--accent); }
+.status-dot.purple { background: var(--purple); box-shadow: 0 0 8px var(--purple); }
+.status-dot.green  { background: var(--green);  box-shadow: 0 0 8px var(--green); }
+.status-dot.amber  { background: var(--amber);  box-shadow: 0 0 8px var(--amber); }
+.status-dot.gray   { background: var(--fg-4); }
+
+.home-signature {
+  position: relative; overflow: hidden;
+  width: 360px; min-height: 250px;
+  padding: 0 16px 20px; flex-shrink: 0;
+}
+.home-signature .brand {
+  position: absolute; top: 0; left: 0; right: 0;
+  text-align: center;
+  font: 500 150px/1 'Landasans', 'Syne', sans-serif;
+  letter-spacing: 0.06em; white-space: nowrap;
+  pointer-events: none; user-select: none;
+  background: linear-gradient(180deg,
+    rgba(var(--c-fg), 0.18)  0%,
+    rgba(var(--c-fg), 0.11) 38%,
+    rgba(var(--c-fg), 0.03) 74%,
+    transparent            100%);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.home-signature .clock-row {
+  position: relative; z-index: 1;
+  display: flex; justify-content: center; align-items: flex-start;
+  line-height: 1; margin-top: 100px;
+}
+.home-signature .clock {
+  font: 500 136px/1 'Landasans', 'Syne', sans-serif;
+  color: #fff; letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  text-shadow:
+    0 0 28px rgba(255,255,255,0.55),
+    0 0 70px rgba(255,255,255,0.18);
+}
+.home-signature .date {
+  position: relative; z-index: 1;
+  margin-top: 12px; text-align: center;
+  font: 400 13px/1 'DM Mono', var(--mono);
+  letter-spacing: 0.28em; text-transform: uppercase;
+  color: rgba(170,205,255,0.75);
+}
+
+.home-orb-wrap {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  z-index: 1; pointer-events: none;
+}
+.home-orb-wrap canvas { pointer-events: auto; }
+
+.home-channel {
+  position: fixed; bottom: 44px; right: 44px; z-index: 10;
+  max-width: 420px; text-align: right;
+}
+.home-channel .msg {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 0.875rem; letter-spacing: -0.01em;
+  color: var(--fg-1); line-height: 1.55;
+}
+.home-channel .meta {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 10px; margin-top: 6px;
+  font-family: var(--mono); font-size: 0.5625rem;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.home-channel .meta a { color: var(--accent); cursor: pointer; text-decoration: none; }
+
+/* ── Page transition ── */
+.room-in { animation: roomIn .4s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes roomIn {
+  from { opacity: 0; transform: translateY(12px); filter: blur(4px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ── Mode iframe — fond transparent pour laisser passer l'aurora de /mc ── */
+body.in-iframe,
+html.in-iframe body {
+  background: transparent !important;
+}
+html.in-iframe .atmo--vignette,
+html.in-iframe .atmo--grain,
+html.in-iframe .atmo--aurora {
+  display: none;
+}

--- a/src/jarvis/interfaces/ui/static/_shared.js
+++ b/src/jarvis/interfaces/ui/static/_shared.js
@@ -19,6 +19,10 @@
 
 (function () {
   "use strict";
+  /* Détection iframe — appliqué avant tout rendu */
+  if (window.self !== window.top) {
+    document.documentElement.classList.add('in-iframe');
+  }
 
   const Jarvis = (window.Jarvis = window.Jarvis || {});
 
@@ -351,7 +355,26 @@
   let mcRoot = null;
   let mcOpen = false;
 
+  /* ── Mission Control v2 — délégué à mission_control.js ──────────────
+     Les stubs ci-dessous sont surchargés par mission_control.js au boot.
+     Conserver pour ne pas casser les pages qui chargent _shared.js seul.   */
+
+  Jarvis.openMissionControl = function () {
+    window.location.href = '/mc';
+  };
+  Jarvis.closeMissionControl = function () {};
+
+  /* ROOMS reste déclaré ici car utilisé par la palette ⌘K. */
   const ROOMS = [
+    { mode: "home",      label: "Home",          sub: "Ambient · À l'écoute",             href: "/",             chapter: "—",   pages: [] },
+    { mode: "workspace", label: "Workspace",      sub: "Ce que tu pilotes en ce moment",   href: "/dashboard",    chapter: "I",   pages: ["Aperçu","Initiatives","Missions","Tâches","Analytics"] },
+    { mode: "capacites", label: "Capacités", sub: "Ce que Jarvis sait faire pour toi",href: "/capabilities", chapter: "II",  pages: ["Intégrations","Skills","Routines","Ambiances","Store","Écosystème"] },
+    { mode: "config",    label: "Configuration",  sub: "Tes préférences et ton coffre",    href: "/settings",     chapter: "III", pages: ["Préférences","Modèles & API","Audio & voix","Conso","Système","À propos"] },
+  ];
+
+  /* ── DEAD CODE ci-dessous — conservé pour référence, non exécuté ─────
+  function ensureMissionControl_LEGACY() {
+
     { mode: "home",      label: "Home",          sub: "Ambient · À l'écoute",                  href: "/",             chapter: "—",   pages: [] },
     { mode: "workspace", label: "Workspace",      sub: "Ce que tu pilotes en ce moment",         href: "/dashboard",    chapter: "I",   pages: ["Aperçu","Initiatives","Missions","Tâches","Analytics"] },
     { mode: "capacites", label: "Capacités",      sub: "Ce que Jarvis sait faire pour toi",      href: "/capabilities", chapter: "II",  pages: ["Intégrations","Skills","Routines","Ambiances","Store","Écosystème"] },
@@ -416,6 +439,8 @@
     mcOpen = false;
     mcRoot.classList.add("is-hidden");
   };
+  */ // fin DEAD CODE
+
 
   /* ───────── Legacy sidebar (still used on pages without rooms nav) ─────────
      opts: sections, activeId, onNav, footer

--- a/src/jarvis/interfaces/ui/static/_shared.js.bak-1782249019
+++ b/src/jarvis/interfaces/ui/static/_shared.js.bak-1782249019
@@ -1,0 +1,756 @@
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS — Shared runtime v2 (vanilla JS, ES2017+)
+   Public API attached to window.Jarvis :
+
+     Jarvis.mountAtmosphere()
+     Jarvis.setMode(mode)                        → "home"|"workspace"|"capacites"|"config"
+     Jarvis.mountRooms({ mode, pages, activePage, onNav, onMissionControl })
+     Jarvis.mountTopbar({ pageTitle, crumb, onAsk, onCmdK })
+     Jarvis.openCmdK() / .closeCmdK()
+     Jarvis.openMissionControl() / .closeMissionControl()
+     Jarvis.registerCommands(arr)
+     Jarvis.notify({ kind, text })
+     Jarvis.api.get(path) / .post(path, body)
+     Jarvis.fmt.num(v) / .pct(v) / .relTime(d)
+     Jarvis.sparkline(data, opts)
+
+   Depends on _shared.css being loaded first.
+   ───────────────────────────────────────────────────────────────────── */
+
+(function () {
+  "use strict";
+
+  const Jarvis = (window.Jarvis = window.Jarvis || {});
+
+  /* ───────── Tiny DOM helpers ───────── */
+  function el(tag, attrs, children) {
+    const node = document.createElement(tag);
+    if (attrs) {
+      for (const k in attrs) {
+        const v = attrs[k];
+        if (v == null || v === false) continue;
+        if (k === "class")        node.className = v;
+        else if (k === "html")    node.innerHTML = v;
+        else if (k === "text")    node.textContent = v;
+        else if (k === "style" && typeof v === "object") Object.assign(node.style, v);
+        else if (k.startsWith("on") && typeof v === "function") node.addEventListener(k.slice(2).toLowerCase(), v);
+        else if (k === "dataset" && typeof v === "object") for (const dk in v) node.dataset[dk] = v[dk];
+        else node.setAttribute(k, v === true ? "" : v);
+      }
+    }
+    if (children != null) {
+      const arr = Array.isArray(children) ? children : [children];
+      for (const c of arr) {
+        if (c == null || c === false) continue;
+        node.appendChild(c.nodeType ? c : document.createTextNode(String(c)));
+      }
+    }
+    return node;
+  }
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $$(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
+  Jarvis.el = el; Jarvis.$ = $; Jarvis.$$ = $$;
+
+  /* ───────── Formatting ───────── */
+  Jarvis.fmt = {
+    num(v) {
+      if (v == null) return "—";
+      const n = Number(v);
+      if (!isFinite(n)) return String(v);
+      if (Math.abs(n) >= 1000) return n.toLocaleString("en-US", { maximumFractionDigits: 1 });
+      return n.toString();
+    },
+    pct(v, digits = 1) {
+      if (v == null) return "—";
+      return Number(v).toFixed(digits) + "%";
+    },
+    relTime(date) {
+      const d = date instanceof Date ? date : new Date(date);
+      const s = Math.round((Date.now() - d.getTime()) / 1000);
+      if (s < 60)   return "à l'instant";
+      if (s < 3600) return Math.floor(s / 60) + " min";
+      if (s < 86400) return Math.floor(s / 3600) + " h";
+      return Math.floor(s / 86400) + " j";
+    },
+  };
+
+  /* ───────── View registry ───────── */
+  Jarvis.views = {
+    _registry: {},
+    _active: null,
+
+    register(id, { meta, show, hide, command, gestures }) {
+      this._registry[id] = { meta: meta || {}, show, hide, command, gestures: gestures || null };
+    },
+
+    list() {
+      return Object.entries(this._registry).map(([id, v]) => ({ id, ...v.meta }));
+    },
+
+    activate(id, params) {
+      const view = this._registry[id];
+      if (!view) return;
+      if (this._active && this._active !== id) this.deactivate(this._active);
+      this._active = id;
+      view.show(params || {});
+    },
+
+    deactivate(id) {
+      const target = id || this._active;
+      if (!target) return;
+      const view = this._registry[target];
+      if (view) view.hide();
+      if (this._active === target) this._active = null;
+    },
+
+    dispatch(id, cmd, params) {
+      const view = this._registry[id];
+      if (view?.command) view.command(cmd, params || {});
+    },
+  };
+
+  /* ───────── API wrapper ───────── */
+  function authHeaders(extra) {
+    const headers = Object.assign({}, extra || {});
+    const token = window.JARVIS_API_TOKEN;
+    if (token) headers.Authorization = "Bearer " + token;
+    return headers;
+  }
+
+  Jarvis.api = {
+    base: window.JARVIS_API_BASE || "",
+    async get(path) {
+      const r = await fetch(this.base + path, {
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("GET " + path + " → " + r.status);
+      return r.json();
+    },
+    async post(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "POST", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("POST " + path + " → " + r.status);
+      return r.json();
+    },
+    async put(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PUT", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PUT " + path + " → " + r.status);
+      return r.json();
+    },
+    async patch(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PATCH", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PATCH " + path + " → " + r.status);
+      return r.json();
+    },
+    async delete(path) {
+      const r = await fetch(this.base + path, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("DELETE " + path + " → " + r.status);
+      return r.json();
+    },
+  };
+  Jarvis.authHeaders = authHeaders;
+
+  /* ───────── Navigation (iframe-aware) ───────── */
+  Jarvis.navigate = function (url) {
+    // Si on tourne dans l'iframe, déléguer au shell parent
+    if (window !== window.top && window.top.Jarvis?.navigateFrame) {
+      window.top.Jarvis.navigateFrame(url);
+      return;
+    }
+    // Si le shell home a enregistré un handler iframe
+    if (typeof Jarvis.navigateFrame === "function") {
+      Jarvis.navigateFrame(url);
+      return;
+    }
+    window.location.href = url;
+  };
+
+  /* ───────── Atmosphere ───────── */
+  Jarvis.mountAtmosphere = function () {
+    if (document.querySelector(".atmo--vignette")) return;
+    document.body.appendChild(el("div", { class: "spotlight", id: "j-spotlight" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--aurora" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--vignette" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--grain" }));
+    document.body.appendChild(el("div", { class: "mode-glow" }));
+
+    // Spotlight mouse tracking
+    document.addEventListener("mousemove", (e) => {
+      const sp = document.getElementById("j-spotlight");
+      if (sp) {
+        sp.style.setProperty("--mx", e.clientX + "px");
+        sp.style.setProperty("--my", e.clientY + "px");
+      }
+    }, { passive: true });
+  };
+
+  /* ───────── Mode system ───────── */
+  const MODE_META = {
+    home:       { chapter: "—",  num: "00", label: "JARVIS",        watermark: "" },
+    workspace:  { chapter: "I",  num: "01", label: "PILOTAGE",      watermark: "Pilotage" },
+    capacites:  { chapter: "II", num: "02", label: "ATELIER",       watermark: "Atelier" },
+    config:     { chapter: "III",num: "03", label: "RÉGLAGES",      watermark: "Réglages" },
+  };
+
+  Jarvis.setMode = function (mode) {
+    document.body.dataset.mode = mode;
+    // Watermark
+    let wm = document.getElementById("j-watermark");
+    const meta = MODE_META[mode] || MODE_META.home;
+    if (meta.watermark) {
+      if (!wm) {
+        wm = el("div", { id: "j-watermark", class: "mode-watermark" });
+        document.body.appendChild(wm);
+      }
+      wm.textContent = meta.watermark;
+    } else if (wm) {
+      wm.textContent = "";
+    }
+    // Chapter indicator
+    const ch = document.getElementById("j-rooms-chapter");
+    if (ch && meta.chapter !== "—") {
+      ch.querySelector(".rooms-num").textContent = meta.chapter;
+      ch.querySelector(".rooms-lbl").textContent = meta.label;
+    }
+  };
+
+  /* ───────── Scene card ───────── */
+  Jarvis.showSceneCard = function (chapter, title, duration) {
+    duration = duration || 900;
+    let sc = document.getElementById("j-scene-card");
+    if (!sc) {
+      sc = el("div", { id: "j-scene-card", class: "scene-card" });
+      const inner = el("div", { class: "scene-card-inner" }, [
+        el("div", { class: "scene-card-chapter", id: "j-sc-chapter" }),
+        el("div", { class: "scene-card-title",   id: "j-sc-title" }),
+      ]);
+      sc.appendChild(inner);
+      document.body.appendChild(sc);
+    }
+    sc.querySelector("#j-sc-chapter").textContent = chapter || "";
+    sc.querySelector("#j-sc-title").textContent   = title   || "";
+    sc.classList.add("is-visible");
+    setTimeout(() => {
+      sc.style.transition = "opacity .5s ease";
+      sc.style.opacity = "0";
+      setTimeout(() => { sc.classList.remove("is-visible"); sc.style.opacity = ""; sc.style.transition = ""; }, 520);
+    }, duration);
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Rooms navigation (chapter indicator + subpages editorial sidebar)
+  ───────────────────────────────────────────────────────────────────── */
+  let _roomsOpts = null;
+
+  Jarvis.mountRooms = function (opts) {
+    _roomsOpts = opts;
+    const { mode, pages, activePage, onNav } = opts;
+    document.body.dataset.mode = mode;
+
+    // ── Chapter indicator top-left ──
+    let ch = document.getElementById("j-rooms-chapter");
+    if (!ch) {
+      ch = el("div", { id: "j-rooms-chapter", class: "rooms-chapter" });
+      document.body.appendChild(ch);
+    }
+    const meta = MODE_META[mode] || MODE_META.home;
+    ch.innerHTML = "";
+    ch.appendChild(el("span", { class: "rooms-num", text: meta.chapter }));
+    ch.appendChild(el("span", { class: "rooms-bar" }));
+    ch.appendChild(el("span", { class: "rooms-lbl", text: meta.label }));
+
+    // ── Watermark ──
+    Jarvis.setMode(mode);
+
+    // ── Mission Control trigger bottom-left ──
+    let mc = document.getElementById("j-rooms-mc");
+    if (!mc) {
+      mc = el("button", { id: "j-rooms-mc", class: "rooms-mc", onclick: () => Jarvis.openMissionControl() });
+      mc.appendChild(el("span", { class: "mc-dot" }));
+      mc.appendChild(el("span", { text: "Mission Control" }));
+      const kbd = el("span", { class: "mc-kbd" });
+      kbd.appendChild(el("span", { text: "⌘" }));
+      kbd.appendChild(el("span", { text: "T" }));
+      mc.appendChild(kbd);
+      document.body.appendChild(mc);
+    }
+
+    // ── Subpages nav (editorial sidebar or bottom pill) ──
+    const isEditorial = mode !== "home";
+    if (isEditorial) {
+      document.body.dataset.subpages = "cocoon-wide-display";
+    } else {
+      delete document.body.dataset.subpages;
+    }
+
+    let nav = document.getElementById("j-rooms-pages");
+    if (!nav) {
+      nav = el("div", { id: "j-rooms-pages", class: "rooms-pages" });
+      document.body.appendChild(nav);
+    }
+    nav.dataset.modeLabel = meta.label;
+    nav.innerHTML = "";
+
+    (pages || []).forEach((p, idx) => {
+      const btn = el("button", {
+        dataset: { active: p.id === activePage ? "true" : "false" },
+        onclick: () => {
+          $$(".rooms-pages button", nav).forEach(b => b.dataset.active = "false");
+          btn.dataset.active = "true";
+          onNav && onNav(p.id);
+        },
+      });
+      btn.appendChild(el("span", { class: "num", text: String(idx + 1).padStart(2, "0") }));
+      btn.appendChild(el("span", { class: "lbl", text: p.label }));
+      nav.appendChild(btn);
+    });
+
+    // Keyboard ←/→ for subpage cycling
+    document.addEventListener("keydown", _handleRoomsKey, { once: false });
+  };
+
+  function _handleRoomsKey(e) {
+    if (cmdkOpen || mcOpen) return;
+    if (!_roomsOpts || !_roomsOpts.pages) return;
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    if (document.activeElement && ["INPUT","TEXTAREA"].includes(document.activeElement.tagName)) return;
+
+    const pages = _roomsOpts.pages;
+    const nav = document.getElementById("j-rooms-pages");
+    if (!nav) return;
+    const btns = $$("button", nav);
+    const curIdx = btns.findIndex(b => b.dataset.active === "true");
+    let next = e.key === "ArrowRight" ? curIdx + 1 : curIdx - 1;
+    next = Math.max(0, Math.min(next, pages.length - 1));
+    if (next === curIdx) return;
+    e.preventDefault();
+    btns.forEach(b => b.dataset.active = "false");
+    btns[next].dataset.active = "true";
+    _roomsOpts.onNav && _roomsOpts.onNav(pages[next].id);
+  }
+
+  /* ─────────────────────────────────────────────────────────────────
+     Mission Control overlay (⌘T)
+  ───────────────────────────────────────────────────────────────────── */
+  let mcRoot = null;
+  let mcOpen = false;
+
+  const ROOMS = [
+    { mode: "home",      label: "Home",          sub: "Ambient · À l'écoute",                  href: "/",             chapter: "—",   pages: [] },
+    { mode: "workspace", label: "Workspace",      sub: "Ce que tu pilotes en ce moment",         href: "/dashboard",    chapter: "I",   pages: ["Aperçu","Initiatives","Missions","Tâches","Analytics"] },
+    { mode: "capacites", label: "Capacités",      sub: "Ce que Jarvis sait faire pour toi",      href: "/capabilities", chapter: "II",  pages: ["Intégrations","Skills","Routines","Ambiances","Store","Écosystème"] },
+    { mode: "config",    label: "Configuration",  sub: "Tes préférences et ton coffre",           href: "/settings",     chapter: "III", pages: ["Préférences","Modèles & API","Audio & voix","Conso","Système","À propos"] },
+  ];
+
+  function ensureMissionControl() {
+    if (mcRoot) return;
+    mcRoot = el("div", { class: "mission-overlay is-hidden", onclick: (e) => { if (e.target === mcRoot) Jarvis.closeMissionControl(); } });
+
+    // Header bar
+    const header = el("div", { class: "mc-header" });
+    header.appendChild(el("span", { class: "mc-header-title", text: "Mission Control" }));
+    const hint = el("span", { class: "mc-header-hint" });
+    const kbd1 = el("span", { class: "mc-hkbd" });
+    kbd1.appendChild(el("span", { text: "⌘" }));
+    kbd1.appendChild(el("span", { text: "T" }));
+    hint.appendChild(kbd1);
+    hint.appendChild(document.createTextNode(" pour fermer"));
+    hint.appendChild(el("span", { class: "mc-hdot", text: " · " }));
+    hint.appendChild(el("span", { class: "mc-hkbd", text: "ESC" }));
+    header.appendChild(hint);
+    header.appendChild(el("button", { class: "mc-close", onclick: () => Jarvis.closeMissionControl(), text: "×" }));
+    mcRoot.appendChild(header);
+
+    const grid = el("div", { class: "mission-grid" });
+    ROOMS.forEach(r => {
+      const card = el("button", {
+        class: "mission-card",
+        dataset: { mode: r.mode },
+        onclick: () => { Jarvis.closeMissionControl(); Jarvis.navigate(r.href); },
+      });
+      const eyebrow = el("div", { class: "mc-card-eyebrow" });
+      eyebrow.appendChild(el("span", { class: "mc-card-num", text: r.chapter }));
+      if (r.pages.length) eyebrow.appendChild(el("span", { text: r.pages.length + " SECTIONS" }));
+      card.appendChild(eyebrow);
+      card.appendChild(el("div", { class: "mc-card-title", text: r.label }));
+      card.appendChild(el("div", { class: "mc-card-sub",   text: r.sub }));
+      if (r.pages.length) {
+        const pagesEl = el("div", { class: "mc-card-pages" });
+        r.pages.forEach((p, i) => {
+          pagesEl.appendChild(el("span", { class: "mc-card-page" }, [
+            el("span", { class: "mc-pg-num", text: String(i + 1).padStart(2, "0") }),
+            el("span", { class: "mc-pg-lbl", text: p }),
+          ]));
+        });
+        card.appendChild(pagesEl);
+      }
+      grid.appendChild(card);
+    });
+    mcRoot.appendChild(grid);
+    document.body.appendChild(mcRoot);
+  }
+
+  Jarvis.openMissionControl = function () {
+    ensureMissionControl();
+    mcOpen = true;
+    mcRoot.classList.remove("is-hidden");
+  };
+  Jarvis.closeMissionControl = function () {
+    if (!mcRoot) return;
+    mcOpen = false;
+    mcRoot.classList.add("is-hidden");
+  };
+
+  /* ───────── Legacy sidebar (still used on pages without rooms nav) ─────────
+     opts: sections, activeId, onNav, footer
+  */
+  Jarvis.mountSidebar = function (opts) {
+    const root = document.getElementById("sidebar") || el("aside", { id: "sidebar" });
+    if (!root.parentNode) document.querySelector(".app").prepend(root);
+    root.className = "sidebar";
+    root.innerHTML = "";
+
+    root.appendChild(el("div", { class: "sb-brand" }, [
+      brandMark(),
+      el("div", { class: "sb-brand-text" }, [
+        el("span", { class: "sb-brand-name", text: "Jarvis" }),
+        el("span", { class: "sb-brand-status", text: "Online · v4.2" }),
+      ]),
+    ]));
+
+    (opts.sections || []).forEach(sec => {
+      root.appendChild(el("div", { class: "sb-section-eyebrow" }, [
+        el("span", { text: sec.label }),
+        sec.right ? el("span", { text: sec.right, style: { color: "var(--fg-2)" } }) : null,
+      ]));
+      const nav = el("div", { class: "sb-nav" });
+      sec.items.forEach(it => {
+        const b = el("button", {
+          class: "sb-item" + (it.id === opts.activeId ? " is-on" : ""),
+          dataset: { id: it.id },
+          onclick: () => opts.onNav && opts.onNav(it.id),
+        }, [
+          el("span", { class: "sb-dot" }),
+          el("span", { text: it.label }),
+          it.meta ? el("span", { class: "sb-meta", text: it.meta }) : el("span"),
+        ]);
+        nav.appendChild(b);
+      });
+      root.appendChild(nav);
+    });
+
+    if (opts.footer) {
+      const f = el("div", { class: "sb-foot" });
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "Spend · 24h" }),
+        el("span", { text: opts.footer.spend || "—" }),
+      ]));
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "CPU" }),
+        el("span", { text: opts.footer.cpu || "—" }),
+      ]));
+      const bar = el("div", { class: "sb-foot-bar" });
+      bar.appendChild(el("div", { style: { width: ((opts.footer.ramPct || 0) * 100) + "%" } }));
+      f.appendChild(bar);
+      root.appendChild(f);
+    }
+    return root;
+  };
+
+  function brandMark() {
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", "26"); svg.setAttribute("height", "26"); svg.setAttribute("viewBox", "0 0 26 26");
+    const c = document.createElementNS(ns, "circle");
+    c.setAttribute("cx", "13"); c.setAttribute("cy", "13"); c.setAttribute("r", "11");
+    c.setAttribute("fill", "none"); c.setAttribute("stroke", "var(--accent)"); c.setAttribute("stroke-width", "1"); c.setAttribute("opacity", "0.8");
+    const c2 = document.createElementNS(ns, "circle");
+    c2.setAttribute("cx", "13"); c2.setAttribute("cy", "13"); c2.setAttribute("r", "5");
+    c2.setAttribute("fill", "var(--accent)"); c2.setAttribute("opacity", "0.18");
+    const c3 = document.createElementNS(ns, "circle");
+    c3.setAttribute("cx", "13"); c3.setAttribute("cy", "13"); c3.setAttribute("r", "1.6"); c3.setAttribute("fill", "var(--accent)");
+    svg.appendChild(c); svg.appendChild(c2); svg.appendChild(c3);
+    return svg;
+  }
+
+  /* ───────── Topbar ───────── */
+  Jarvis.mountTopbar = function (opts) {
+    const root = document.getElementById("topbar") || el("header", { id: "topbar", class: "topbar" });
+    root.className = "topbar";
+    root.innerHTML = "";
+
+    const t = new Date();
+    const tStr = String(t.getHours()).padStart(2, "0") + ":" + String(t.getMinutes()).padStart(2, "0");
+
+    root.appendChild(el("div", { class: "topbar-l" }, [
+      el("span", { class: "topbar-page-title", text: opts.pageTitle || "Dashboard" }),
+      el("span", { class: "topbar-crumb",      text: opts.crumb || "/ control" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-c" }, [
+      el("span", { class: "dot" }),
+      el("span", { text: "Online" }),
+      el("span", { class: "sep" }),
+      el("span", { text: tStr }),
+      el("span", { class: "sep" }),
+      el("span", { text: "Paris" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-r" }, [
+      el("button", { class: "tb-btn", onclick: () => Jarvis.openCmdK() }, [
+        el("span", { text: "Recherche" }),
+        el("span", { class: "kbd", text: "⌘K" }),
+      ]),
+      el("button", { class: "tb-btn", onclick: () => opts.onAsk && opts.onAsk() }, [
+        el("span", { text: "Ask Jarvis" }),
+      ]),
+    ]));
+
+    return root;
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Command palette (⌘K)
+  ───────────────────────────────────────────────────────────────────── */
+  let cmdkRoot = null, cmdkInput = null, cmdkList = null;
+  let cmdkCommands = [], cmdkSelected = 0, cmdkOpen = false;
+
+  // Seed with room navigation commands
+  const _navCmds = ROOMS.map(r => ({
+    kind: "nav", id: "goto-" + r.mode, group: "Aller à",
+    title: r.label, sub: r.href, glyph: "→",
+    run: () => { Jarvis.navigate(r.href); },
+  }));
+  cmdkCommands = _navCmds;
+
+  Jarvis.registerCommands = function (cmds) {
+    const ids = new Set(cmdkCommands.map(c => c.id));
+    cmds.forEach(c => { if (!ids.has(c.id)) cmdkCommands.push(c); });
+  };
+
+  function ensureCmdK() {
+    if (cmdkRoot) return;
+    cmdkRoot = el("div", { class: "cmdk-back is-hidden", onclick: (e) => { if (e.target === cmdkRoot) Jarvis.closeCmdK(); } });
+    const box = el("div", { class: "cmdk" });
+    const inputWrap = el("div", { class: "cmdk-input-wrap" });
+    const prefix = el("span", { class: "cmdk-prefix", text: ">", style: { display: "none" } });
+    cmdkInput = el("input", {
+      class: "cmdk-input",
+      placeholder: "Cherche · navigue · > commandes",
+      autocomplete: "off",
+      oninput: (e) => {
+        const v = e.target.value;
+        const slash = v.startsWith(">");
+        prefix.style.display = slash ? "block" : "none";
+        cmdkInput.classList.toggle("has-prefix", slash);
+        cmdkSelected = 0; renderCmdK(v);
+      },
+      onkeydown: (e) => {
+        if (e.key === "Escape")    { e.preventDefault(); Jarvis.closeCmdK(); }
+        if (e.key === "ArrowDown") { e.preventDefault(); cmdkSelected = Math.min(cmdkSelected + 1, currentResults().length - 1); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "ArrowUp")   { e.preventDefault(); cmdkSelected = Math.max(cmdkSelected - 1, 0); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "Enter")     { e.preventDefault(); execSelected(); }
+      },
+    });
+    inputWrap.appendChild(prefix); inputWrap.appendChild(cmdkInput);
+    cmdkList = el("div", { class: "cmdk-list" });
+    const foot = el("div", { class: "cmdk-foot" }, [
+      el("span", { text: "↑↓ naviguer · ↵ exécuter · esc fermer" }),
+      el("span", { text: "> pour commandes" }),
+    ]);
+    box.appendChild(inputWrap); box.appendChild(cmdkList); box.appendChild(foot);
+    cmdkRoot.appendChild(box);
+    document.body.appendChild(cmdkRoot);
+  }
+
+  Jarvis.openCmdK = function () {
+    ensureCmdK();
+    cmdkOpen = true;
+    cmdkRoot.classList.remove("is-hidden");
+    cmdkInput.value = ""; cmdkSelected = 0;
+    renderCmdK("");
+    setTimeout(() => cmdkInput.focus(), 30);
+  };
+  Jarvis.closeCmdK = function () {
+    if (!cmdkRoot) return;
+    cmdkOpen = false;
+    cmdkRoot.classList.add("is-hidden");
+  };
+
+  function currentResults() {
+    const v = cmdkInput.value.trim();
+    if (v.startsWith(">")) {
+      const q = v.slice(1).trim().toLowerCase();
+      if (q.startsWith("ask ")) {
+        const p = q.slice(4);
+        return [{ kind: "ask", id: "ask", title: 'Demander : "' + p + '"', glyph: "›", group: "Faire", run: () => _askJarvis(p) }];
+      }
+      const slash = cmdkCommands.filter(c => c.kind === "slash");
+      if (!q) return slash;
+      return slash.filter(c => c.title.toLowerCase().includes(q));
+    }
+    const q = v.toLowerCase();
+    const all = cmdkCommands.filter(c => c.kind !== "slash");
+    if (!q) return all;
+    return all.filter(c => (c.title + " " + (c.sub || "")).toLowerCase().includes(q));
+  }
+
+  function renderCmdK(_v, keepFocus) {
+    cmdkList.innerHTML = "";
+    const items = currentResults();
+    if (!items.length) {
+      cmdkList.appendChild(el("div", { class: "cmdk-empty", text: "Aucune commande" }));
+      return;
+    }
+    const groups = {};
+    items.forEach(it => { const g = it.group || "Navigation"; (groups[g] = groups[g] || []).push(it); });
+    let idx = 0;
+    Object.keys(groups).forEach(g => {
+      cmdkList.appendChild(el("div", { class: "cmdk-group-lbl", text: g }));
+      groups[g].forEach(it => {
+        const i = idx++;
+        const row = el("div", {
+          class: "cmdk-item" + (i === cmdkSelected ? " is-on" : ""),
+          onclick: () => { cmdkSelected = i; execSelected(); },
+          onmousemove: () => { if (cmdkSelected !== i) { cmdkSelected = i; renderCmdK(cmdkInput.value, true); } },
+        }, [
+          el("span", { class: "ck-glyph", text: it.glyph || "·" }),
+          el("div", {}, [
+            el("span", { text: it.title }),
+            it.sub ? el("span", { class: "ck-sub", text: it.sub }) : null,
+          ]),
+          it.kbd ? el("span", { class: "ck-kbd" }, it.kbd.split("+").map(k => el("span", { text: k }))) : el("span"),
+        ]);
+        cmdkList.appendChild(row);
+      });
+    });
+    if (keepFocus) cmdkInput.focus();
+  }
+
+  function execSelected() {
+    const it = currentResults()[cmdkSelected];
+    if (!it) return;
+    Jarvis.closeCmdK();
+    if (typeof it.run === "function") it.run();
+  }
+
+  async function _askJarvis(prompt) {
+    Jarvis.notify({ kind: "info", text: "Jarvis · réflexion…" });
+    try {
+      const r = await Jarvis.api.post("/api/agent/ask", { prompt });
+      Jarvis.notify({ kind: "success", text: (r.answer || r.text || "").slice(0, 240) });
+    } catch (err) {
+      Jarvis.notify({ kind: "error", text: "Échec : " + err.message });
+    }
+  }
+
+  /* ───────── Global keyboard shortcuts ───────── */
+  document.addEventListener("keydown", (e) => {
+    // ⌘K — palette
+    if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+      e.preventDefault();
+      cmdkOpen ? Jarvis.closeCmdK() : Jarvis.openCmdK();
+    }
+    // ⌘T — Mission Control
+    if ((e.metaKey || e.ctrlKey) && (e.key === "t" || e.key === "T")) {
+      e.preventDefault();
+      mcOpen ? Jarvis.closeMissionControl() : Jarvis.openMissionControl();
+    }
+    // Escape
+    if (e.key === "Escape") {
+      if (cmdkOpen) Jarvis.closeCmdK();
+      if (mcOpen)   Jarvis.closeMissionControl();
+    }
+  });
+
+  /* ───────── Inspector mode (Alt) ───────── */
+  let inspectHint = null;
+  function setInspect(on) {
+    document.documentElement.classList.toggle("inspect", on);
+    if (on && !inspectHint) {
+      inspectHint = el("div", { class: "inspect-hint" }, [
+        el("span", { class: "dot" }), el("span", { text: "INSPECTOR · ⌥" }),
+      ]);
+      document.body.appendChild(inspectHint);
+    } else if (!on && inspectHint) {
+      inspectHint.remove(); inspectHint = null;
+    }
+  }
+  document.addEventListener("keydown", (e) => { if (e.key === "Alt") setInspect(true); });
+  document.addEventListener("keyup",   (e) => { if (e.key === "Alt") setInspect(false); });
+  window.addEventListener("blur", () => setInspect(false));
+
+  /* ───────── Notification ribbon ───────── */
+  let notifStack = null;
+  Jarvis.notify = function ({ kind = "info", text = "" }) {
+    if (!notifStack) {
+      notifStack = el("div", { class: "notif-stack" });
+      document.body.appendChild(notifStack);
+    }
+    const cls = "notif" + (kind && kind !== "info" ? " notif--" + kind : "");
+    const node = el("div", { class: cls }, [
+      el("span", { class: "notif-mark" }),
+      el("div", { class: "notif-text", text }),
+      el("span", { class: "notif-time", text: "MAINT." }),
+    ]);
+    notifStack.appendChild(node);
+    setTimeout(() => node.remove(), 4400);
+    const sb = document.querySelector(".sidebar");
+    if (sb) {
+      const breath = el("div", { class: "sb-breath" });
+      sb.appendChild(breath);
+      setTimeout(() => breath.remove(), 1700);
+    }
+  };
+
+  /* ───────── Sparkline ───────── */
+  Jarvis.sparkline = function (data, opts) {
+    opts = opts || {};
+    const w = opts.width || 180, h = opts.height || 28;
+    const color = opts.color || "var(--accent)";
+    if (!data || !data.length) return el("svg", { width: w, height: h });
+    const min = Math.min(...data), max = Math.max(...data), range = max - min || 1;
+    const pts = data.map((v, i) => [
+      (i / (data.length - 1)) * w,
+      h - ((v - min) / range) * h * 0.85 - 2,
+    ]);
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", w); svg.setAttribute("height", h);
+    svg.setAttribute("viewBox", "0 0 " + w + " " + h);
+    const path = document.createElementNS(ns, "path");
+    path.setAttribute("d", pts.map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" "));
+    path.setAttribute("fill", "none"); path.setAttribute("stroke", color);
+    path.setAttribute("stroke-width", "1.4"); path.setAttribute("stroke-linecap", "round");
+    svg.appendChild(path);
+    const last = pts[pts.length - 1];
+    const dot = document.createElementNS(ns, "circle");
+    dot.setAttribute("cx", last[0]); dot.setAttribute("cy", last[1]);
+    dot.setAttribute("r", "2"); dot.setAttribute("fill", color);
+    svg.appendChild(dot);
+    return svg;
+  };
+
+  /* ───────── Bottom nav (legacy, conservé pour compat) ───────── */
+  Jarvis.mountBottomNav = function (opts) {
+    const existing = document.getElementById("j-bottom-nav");
+    if (existing) existing.remove();
+    // No-op in v2 — navigation handled by rooms system
+  };
+})();

--- a/src/jarvis/interfaces/ui/static/_shared.js.bak-1782250447
+++ b/src/jarvis/interfaces/ui/static/_shared.js.bak-1782250447
@@ -1,0 +1,767 @@
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS — Shared runtime v2 (vanilla JS, ES2017+)
+   Public API attached to window.Jarvis :
+
+     Jarvis.mountAtmosphere()
+     Jarvis.setMode(mode)                        → "home"|"workspace"|"capacites"|"config"
+     Jarvis.mountRooms({ mode, pages, activePage, onNav, onMissionControl })
+     Jarvis.mountTopbar({ pageTitle, crumb, onAsk, onCmdK })
+     Jarvis.openCmdK() / .closeCmdK()
+     Jarvis.openMissionControl() / .closeMissionControl()
+     Jarvis.registerCommands(arr)
+     Jarvis.notify({ kind, text })
+     Jarvis.api.get(path) / .post(path, body)
+     Jarvis.fmt.num(v) / .pct(v) / .relTime(d)
+     Jarvis.sparkline(data, opts)
+
+   Depends on _shared.css being loaded first.
+   ───────────────────────────────────────────────────────────────────── */
+
+(function () {
+  "use strict";
+
+  const Jarvis = (window.Jarvis = window.Jarvis || {});
+
+  /* ───────── Tiny DOM helpers ───────── */
+  function el(tag, attrs, children) {
+    const node = document.createElement(tag);
+    if (attrs) {
+      for (const k in attrs) {
+        const v = attrs[k];
+        if (v == null || v === false) continue;
+        if (k === "class")        node.className = v;
+        else if (k === "html")    node.innerHTML = v;
+        else if (k === "text")    node.textContent = v;
+        else if (k === "style" && typeof v === "object") Object.assign(node.style, v);
+        else if (k.startsWith("on") && typeof v === "function") node.addEventListener(k.slice(2).toLowerCase(), v);
+        else if (k === "dataset" && typeof v === "object") for (const dk in v) node.dataset[dk] = v[dk];
+        else node.setAttribute(k, v === true ? "" : v);
+      }
+    }
+    if (children != null) {
+      const arr = Array.isArray(children) ? children : [children];
+      for (const c of arr) {
+        if (c == null || c === false) continue;
+        node.appendChild(c.nodeType ? c : document.createTextNode(String(c)));
+      }
+    }
+    return node;
+  }
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $$(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
+  Jarvis.el = el; Jarvis.$ = $; Jarvis.$$ = $$;
+
+  /* ───────── Formatting ───────── */
+  Jarvis.fmt = {
+    num(v) {
+      if (v == null) return "—";
+      const n = Number(v);
+      if (!isFinite(n)) return String(v);
+      if (Math.abs(n) >= 1000) return n.toLocaleString("en-US", { maximumFractionDigits: 1 });
+      return n.toString();
+    },
+    pct(v, digits = 1) {
+      if (v == null) return "—";
+      return Number(v).toFixed(digits) + "%";
+    },
+    relTime(date) {
+      const d = date instanceof Date ? date : new Date(date);
+      const s = Math.round((Date.now() - d.getTime()) / 1000);
+      if (s < 60)   return "à l'instant";
+      if (s < 3600) return Math.floor(s / 60) + " min";
+      if (s < 86400) return Math.floor(s / 3600) + " h";
+      return Math.floor(s / 86400) + " j";
+    },
+  };
+
+  /* ───────── View registry ───────── */
+  Jarvis.views = {
+    _registry: {},
+    _active: null,
+
+    register(id, { meta, show, hide, command, gestures }) {
+      this._registry[id] = { meta: meta || {}, show, hide, command, gestures: gestures || null };
+    },
+
+    list() {
+      return Object.entries(this._registry).map(([id, v]) => ({ id, ...v.meta }));
+    },
+
+    activate(id, params) {
+      const view = this._registry[id];
+      if (!view) return;
+      if (this._active && this._active !== id) this.deactivate(this._active);
+      this._active = id;
+      view.show(params || {});
+    },
+
+    deactivate(id) {
+      const target = id || this._active;
+      if (!target) return;
+      const view = this._registry[target];
+      if (view) view.hide();
+      if (this._active === target) this._active = null;
+    },
+
+    dispatch(id, cmd, params) {
+      const view = this._registry[id];
+      if (view?.command) view.command(cmd, params || {});
+    },
+  };
+
+  /* ───────── API wrapper ───────── */
+  function authHeaders(extra) {
+    const headers = Object.assign({}, extra || {});
+    const token = window.JARVIS_API_TOKEN;
+    if (token) headers.Authorization = "Bearer " + token;
+    return headers;
+  }
+
+  Jarvis.api = {
+    base: window.JARVIS_API_BASE || "",
+    async get(path) {
+      const r = await fetch(this.base + path, {
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("GET " + path + " → " + r.status);
+      return r.json();
+    },
+    async post(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "POST", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("POST " + path + " → " + r.status);
+      return r.json();
+    },
+    async put(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PUT", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PUT " + path + " → " + r.status);
+      return r.json();
+    },
+    async patch(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PATCH", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PATCH " + path + " → " + r.status);
+      return r.json();
+    },
+    async delete(path) {
+      const r = await fetch(this.base + path, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("DELETE " + path + " → " + r.status);
+      return r.json();
+    },
+  };
+  Jarvis.authHeaders = authHeaders;
+
+  /* ───────── Navigation (iframe-aware) ───────── */
+  Jarvis.navigate = function (url) {
+    // Si on tourne dans l'iframe, déléguer au shell parent
+    if (window !== window.top && window.top.Jarvis?.navigateFrame) {
+      window.top.Jarvis.navigateFrame(url);
+      return;
+    }
+    // Si le shell home a enregistré un handler iframe
+    if (typeof Jarvis.navigateFrame === "function") {
+      Jarvis.navigateFrame(url);
+      return;
+    }
+    window.location.href = url;
+  };
+
+  /* ───────── Atmosphere ───────── */
+  Jarvis.mountAtmosphere = function () {
+    if (document.querySelector(".atmo--vignette")) return;
+    document.body.appendChild(el("div", { class: "spotlight", id: "j-spotlight" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--aurora" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--vignette" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--grain" }));
+    document.body.appendChild(el("div", { class: "mode-glow" }));
+
+    // Spotlight mouse tracking
+    document.addEventListener("mousemove", (e) => {
+      const sp = document.getElementById("j-spotlight");
+      if (sp) {
+        sp.style.setProperty("--mx", e.clientX + "px");
+        sp.style.setProperty("--my", e.clientY + "px");
+      }
+    }, { passive: true });
+  };
+
+  /* ───────── Mode system ───────── */
+  const MODE_META = {
+    home:       { chapter: "—",  num: "00", label: "JARVIS",        watermark: "" },
+    workspace:  { chapter: "I",  num: "01", label: "PILOTAGE",      watermark: "Pilotage" },
+    capacites:  { chapter: "II", num: "02", label: "ATELIER",       watermark: "Atelier" },
+    config:     { chapter: "III",num: "03", label: "RÉGLAGES",      watermark: "Réglages" },
+  };
+
+  Jarvis.setMode = function (mode) {
+    document.body.dataset.mode = mode;
+    // Watermark
+    let wm = document.getElementById("j-watermark");
+    const meta = MODE_META[mode] || MODE_META.home;
+    if (meta.watermark) {
+      if (!wm) {
+        wm = el("div", { id: "j-watermark", class: "mode-watermark" });
+        document.body.appendChild(wm);
+      }
+      wm.textContent = meta.watermark;
+    } else if (wm) {
+      wm.textContent = "";
+    }
+    // Chapter indicator
+    const ch = document.getElementById("j-rooms-chapter");
+    if (ch && meta.chapter !== "—") {
+      ch.querySelector(".rooms-num").textContent = meta.chapter;
+      ch.querySelector(".rooms-lbl").textContent = meta.label;
+    }
+  };
+
+  /* ───────── Scene card ───────── */
+  Jarvis.showSceneCard = function (chapter, title, duration) {
+    duration = duration || 900;
+    let sc = document.getElementById("j-scene-card");
+    if (!sc) {
+      sc = el("div", { id: "j-scene-card", class: "scene-card" });
+      const inner = el("div", { class: "scene-card-inner" }, [
+        el("div", { class: "scene-card-chapter", id: "j-sc-chapter" }),
+        el("div", { class: "scene-card-title",   id: "j-sc-title" }),
+      ]);
+      sc.appendChild(inner);
+      document.body.appendChild(sc);
+    }
+    sc.querySelector("#j-sc-chapter").textContent = chapter || "";
+    sc.querySelector("#j-sc-title").textContent   = title   || "";
+    sc.classList.add("is-visible");
+    setTimeout(() => {
+      sc.style.transition = "opacity .5s ease";
+      sc.style.opacity = "0";
+      setTimeout(() => { sc.classList.remove("is-visible"); sc.style.opacity = ""; sc.style.transition = ""; }, 520);
+    }, duration);
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Rooms navigation (chapter indicator + subpages editorial sidebar)
+  ───────────────────────────────────────────────────────────────────── */
+  let _roomsOpts = null;
+
+  Jarvis.mountRooms = function (opts) {
+    _roomsOpts = opts;
+    const { mode, pages, activePage, onNav } = opts;
+    document.body.dataset.mode = mode;
+
+    // ── Chapter indicator top-left ──
+    let ch = document.getElementById("j-rooms-chapter");
+    if (!ch) {
+      ch = el("div", { id: "j-rooms-chapter", class: "rooms-chapter" });
+      document.body.appendChild(ch);
+    }
+    const meta = MODE_META[mode] || MODE_META.home;
+    ch.innerHTML = "";
+    ch.appendChild(el("span", { class: "rooms-num", text: meta.chapter }));
+    ch.appendChild(el("span", { class: "rooms-bar" }));
+    ch.appendChild(el("span", { class: "rooms-lbl", text: meta.label }));
+
+    // ── Watermark ──
+    Jarvis.setMode(mode);
+
+    // ── Mission Control trigger bottom-left ──
+    let mc = document.getElementById("j-rooms-mc");
+    if (!mc) {
+      mc = el("button", { id: "j-rooms-mc", class: "rooms-mc", onclick: () => Jarvis.openMissionControl() });
+      mc.appendChild(el("span", { class: "mc-dot" }));
+      mc.appendChild(el("span", { text: "Mission Control" }));
+      const kbd = el("span", { class: "mc-kbd" });
+      kbd.appendChild(el("span", { text: "⌘" }));
+      kbd.appendChild(el("span", { text: "T" }));
+      mc.appendChild(kbd);
+      document.body.appendChild(mc);
+    }
+
+    // ── Subpages nav (editorial sidebar or bottom pill) ──
+    const isEditorial = mode !== "home";
+    if (isEditorial) {
+      document.body.dataset.subpages = "cocoon-wide-display";
+    } else {
+      delete document.body.dataset.subpages;
+    }
+
+    let nav = document.getElementById("j-rooms-pages");
+    if (!nav) {
+      nav = el("div", { id: "j-rooms-pages", class: "rooms-pages" });
+      document.body.appendChild(nav);
+    }
+    nav.dataset.modeLabel = meta.label;
+    nav.innerHTML = "";
+
+    (pages || []).forEach((p, idx) => {
+      const btn = el("button", {
+        dataset: { active: p.id === activePage ? "true" : "false" },
+        onclick: () => {
+          $$(".rooms-pages button", nav).forEach(b => b.dataset.active = "false");
+          btn.dataset.active = "true";
+          onNav && onNav(p.id);
+        },
+      });
+      btn.appendChild(el("span", { class: "num", text: String(idx + 1).padStart(2, "0") }));
+      btn.appendChild(el("span", { class: "lbl", text: p.label }));
+      nav.appendChild(btn);
+    });
+
+    // Keyboard ←/→ for subpage cycling
+    document.addEventListener("keydown", _handleRoomsKey, { once: false });
+  };
+
+  function _handleRoomsKey(e) {
+    if (cmdkOpen || mcOpen) return;
+    if (!_roomsOpts || !_roomsOpts.pages) return;
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    if (document.activeElement && ["INPUT","TEXTAREA"].includes(document.activeElement.tagName)) return;
+
+    const pages = _roomsOpts.pages;
+    const nav = document.getElementById("j-rooms-pages");
+    if (!nav) return;
+    const btns = $$("button", nav);
+    const curIdx = btns.findIndex(b => b.dataset.active === "true");
+    let next = e.key === "ArrowRight" ? curIdx + 1 : curIdx - 1;
+    next = Math.max(0, Math.min(next, pages.length - 1));
+    if (next === curIdx) return;
+    e.preventDefault();
+    btns.forEach(b => b.dataset.active = "false");
+    btns[next].dataset.active = "true";
+    _roomsOpts.onNav && _roomsOpts.onNav(pages[next].id);
+  }
+
+  /* ─────────────────────────────────────────────────────────────────
+     Mission Control overlay (⌘T)
+  ───────────────────────────────────────────────────────────────────── */
+  let mcRoot = null;
+  let mcOpen = false;
+
+  /* ── Mission Control v2 — délégué à mission_control.js ──────────────
+     Les stubs ci-dessous sont surchargés par mission_control.js au boot.
+     Conserver pour ne pas casser les pages qui chargent _shared.js seul.   */
+
+  Jarvis.openMissionControl  = function () {};
+  Jarvis.closeMissionControl = function () {};
+
+  /* ── DEAD CODE ci-dessous — conservé pour référence, non exécuté ─────
+  function ensureMissionControl_LEGACY() {
+
+    { mode: "home",      label: "Home",          sub: "Ambient · À l'écoute",                  href: "/",             chapter: "—",   pages: [] },
+    { mode: "workspace", label: "Workspace",      sub: "Ce que tu pilotes en ce moment",         href: "/dashboard",    chapter: "I",   pages: ["Aperçu","Initiatives","Missions","Tâches","Analytics"] },
+    { mode: "capacites", label: "Capacités",      sub: "Ce que Jarvis sait faire pour toi",      href: "/capabilities", chapter: "II",  pages: ["Intégrations","Skills","Routines","Ambiances","Store","Écosystème"] },
+    { mode: "config",    label: "Configuration",  sub: "Tes préférences et ton coffre",           href: "/settings",     chapter: "III", pages: ["Préférences","Modèles & API","Audio & voix","Conso","Système","À propos"] },
+  ];
+
+  function ensureMissionControl() {
+    if (mcRoot) return;
+    mcRoot = el("div", { class: "mission-overlay is-hidden", onclick: (e) => { if (e.target === mcRoot) Jarvis.closeMissionControl(); } });
+
+    // Header bar
+    const header = el("div", { class: "mc-header" });
+    header.appendChild(el("span", { class: "mc-header-title", text: "Mission Control" }));
+    const hint = el("span", { class: "mc-header-hint" });
+    const kbd1 = el("span", { class: "mc-hkbd" });
+    kbd1.appendChild(el("span", { text: "⌘" }));
+    kbd1.appendChild(el("span", { text: "T" }));
+    hint.appendChild(kbd1);
+    hint.appendChild(document.createTextNode(" pour fermer"));
+    hint.appendChild(el("span", { class: "mc-hdot", text: " · " }));
+    hint.appendChild(el("span", { class: "mc-hkbd", text: "ESC" }));
+    header.appendChild(hint);
+    header.appendChild(el("button", { class: "mc-close", onclick: () => Jarvis.closeMissionControl(), text: "×" }));
+    mcRoot.appendChild(header);
+
+    const grid = el("div", { class: "mission-grid" });
+    ROOMS.forEach(r => {
+      const card = el("button", {
+        class: "mission-card",
+        dataset: { mode: r.mode },
+        onclick: () => { Jarvis.closeMissionControl(); Jarvis.navigate(r.href); },
+      });
+      const eyebrow = el("div", { class: "mc-card-eyebrow" });
+      eyebrow.appendChild(el("span", { class: "mc-card-num", text: r.chapter }));
+      if (r.pages.length) eyebrow.appendChild(el("span", { text: r.pages.length + " SECTIONS" }));
+      card.appendChild(eyebrow);
+      card.appendChild(el("div", { class: "mc-card-title", text: r.label }));
+      card.appendChild(el("div", { class: "mc-card-sub",   text: r.sub }));
+      if (r.pages.length) {
+        const pagesEl = el("div", { class: "mc-card-pages" });
+        r.pages.forEach((p, i) => {
+          pagesEl.appendChild(el("span", { class: "mc-card-page" }, [
+            el("span", { class: "mc-pg-num", text: String(i + 1).padStart(2, "0") }),
+            el("span", { class: "mc-pg-lbl", text: p }),
+          ]));
+        });
+        card.appendChild(pagesEl);
+      }
+      grid.appendChild(card);
+    });
+    mcRoot.appendChild(grid);
+    document.body.appendChild(mcRoot);
+  }
+
+  Jarvis.openMissionControl = function () {
+    ensureMissionControl();
+    mcOpen = true;
+    mcRoot.classList.remove("is-hidden");
+  };
+  Jarvis.closeMissionControl = function () {
+    if (!mcRoot) return;
+    mcOpen = false;
+    mcRoot.classList.add("is-hidden");
+  };
+  */ // fin DEAD CODE
+
+
+  /* ───────── Legacy sidebar (still used on pages without rooms nav) ─────────
+     opts: sections, activeId, onNav, footer
+  */
+  Jarvis.mountSidebar = function (opts) {
+    const root = document.getElementById("sidebar") || el("aside", { id: "sidebar" });
+    if (!root.parentNode) document.querySelector(".app").prepend(root);
+    root.className = "sidebar";
+    root.innerHTML = "";
+
+    root.appendChild(el("div", { class: "sb-brand" }, [
+      brandMark(),
+      el("div", { class: "sb-brand-text" }, [
+        el("span", { class: "sb-brand-name", text: "Jarvis" }),
+        el("span", { class: "sb-brand-status", text: "Online · v4.2" }),
+      ]),
+    ]));
+
+    (opts.sections || []).forEach(sec => {
+      root.appendChild(el("div", { class: "sb-section-eyebrow" }, [
+        el("span", { text: sec.label }),
+        sec.right ? el("span", { text: sec.right, style: { color: "var(--fg-2)" } }) : null,
+      ]));
+      const nav = el("div", { class: "sb-nav" });
+      sec.items.forEach(it => {
+        const b = el("button", {
+          class: "sb-item" + (it.id === opts.activeId ? " is-on" : ""),
+          dataset: { id: it.id },
+          onclick: () => opts.onNav && opts.onNav(it.id),
+        }, [
+          el("span", { class: "sb-dot" }),
+          el("span", { text: it.label }),
+          it.meta ? el("span", { class: "sb-meta", text: it.meta }) : el("span"),
+        ]);
+        nav.appendChild(b);
+      });
+      root.appendChild(nav);
+    });
+
+    if (opts.footer) {
+      const f = el("div", { class: "sb-foot" });
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "Spend · 24h" }),
+        el("span", { text: opts.footer.spend || "—" }),
+      ]));
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "CPU" }),
+        el("span", { text: opts.footer.cpu || "—" }),
+      ]));
+      const bar = el("div", { class: "sb-foot-bar" });
+      bar.appendChild(el("div", { style: { width: ((opts.footer.ramPct || 0) * 100) + "%" } }));
+      f.appendChild(bar);
+      root.appendChild(f);
+    }
+    return root;
+  };
+
+  function brandMark() {
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", "26"); svg.setAttribute("height", "26"); svg.setAttribute("viewBox", "0 0 26 26");
+    const c = document.createElementNS(ns, "circle");
+    c.setAttribute("cx", "13"); c.setAttribute("cy", "13"); c.setAttribute("r", "11");
+    c.setAttribute("fill", "none"); c.setAttribute("stroke", "var(--accent)"); c.setAttribute("stroke-width", "1"); c.setAttribute("opacity", "0.8");
+    const c2 = document.createElementNS(ns, "circle");
+    c2.setAttribute("cx", "13"); c2.setAttribute("cy", "13"); c2.setAttribute("r", "5");
+    c2.setAttribute("fill", "var(--accent)"); c2.setAttribute("opacity", "0.18");
+    const c3 = document.createElementNS(ns, "circle");
+    c3.setAttribute("cx", "13"); c3.setAttribute("cy", "13"); c3.setAttribute("r", "1.6"); c3.setAttribute("fill", "var(--accent)");
+    svg.appendChild(c); svg.appendChild(c2); svg.appendChild(c3);
+    return svg;
+  }
+
+  /* ───────── Topbar ───────── */
+  Jarvis.mountTopbar = function (opts) {
+    const root = document.getElementById("topbar") || el("header", { id: "topbar", class: "topbar" });
+    root.className = "topbar";
+    root.innerHTML = "";
+
+    const t = new Date();
+    const tStr = String(t.getHours()).padStart(2, "0") + ":" + String(t.getMinutes()).padStart(2, "0");
+
+    root.appendChild(el("div", { class: "topbar-l" }, [
+      el("span", { class: "topbar-page-title", text: opts.pageTitle || "Dashboard" }),
+      el("span", { class: "topbar-crumb",      text: opts.crumb || "/ control" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-c" }, [
+      el("span", { class: "dot" }),
+      el("span", { text: "Online" }),
+      el("span", { class: "sep" }),
+      el("span", { text: tStr }),
+      el("span", { class: "sep" }),
+      el("span", { text: "Paris" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-r" }, [
+      el("button", { class: "tb-btn", onclick: () => Jarvis.openCmdK() }, [
+        el("span", { text: "Recherche" }),
+        el("span", { class: "kbd", text: "⌘K" }),
+      ]),
+      el("button", { class: "tb-btn", onclick: () => opts.onAsk && opts.onAsk() }, [
+        el("span", { text: "Ask Jarvis" }),
+      ]),
+    ]));
+
+    return root;
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Command palette (⌘K)
+  ───────────────────────────────────────────────────────────────────── */
+  let cmdkRoot = null, cmdkInput = null, cmdkList = null;
+  let cmdkCommands = [], cmdkSelected = 0, cmdkOpen = false;
+
+  // Seed with room navigation commands
+  const _navCmds = ROOMS.map(r => ({
+    kind: "nav", id: "goto-" + r.mode, group: "Aller à",
+    title: r.label, sub: r.href, glyph: "→",
+    run: () => { Jarvis.navigate(r.href); },
+  }));
+  cmdkCommands = _navCmds;
+
+  Jarvis.registerCommands = function (cmds) {
+    const ids = new Set(cmdkCommands.map(c => c.id));
+    cmds.forEach(c => { if (!ids.has(c.id)) cmdkCommands.push(c); });
+  };
+
+  function ensureCmdK() {
+    if (cmdkRoot) return;
+    cmdkRoot = el("div", { class: "cmdk-back is-hidden", onclick: (e) => { if (e.target === cmdkRoot) Jarvis.closeCmdK(); } });
+    const box = el("div", { class: "cmdk" });
+    const inputWrap = el("div", { class: "cmdk-input-wrap" });
+    const prefix = el("span", { class: "cmdk-prefix", text: ">", style: { display: "none" } });
+    cmdkInput = el("input", {
+      class: "cmdk-input",
+      placeholder: "Cherche · navigue · > commandes",
+      autocomplete: "off",
+      oninput: (e) => {
+        const v = e.target.value;
+        const slash = v.startsWith(">");
+        prefix.style.display = slash ? "block" : "none";
+        cmdkInput.classList.toggle("has-prefix", slash);
+        cmdkSelected = 0; renderCmdK(v);
+      },
+      onkeydown: (e) => {
+        if (e.key === "Escape")    { e.preventDefault(); Jarvis.closeCmdK(); }
+        if (e.key === "ArrowDown") { e.preventDefault(); cmdkSelected = Math.min(cmdkSelected + 1, currentResults().length - 1); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "ArrowUp")   { e.preventDefault(); cmdkSelected = Math.max(cmdkSelected - 1, 0); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "Enter")     { e.preventDefault(); execSelected(); }
+      },
+    });
+    inputWrap.appendChild(prefix); inputWrap.appendChild(cmdkInput);
+    cmdkList = el("div", { class: "cmdk-list" });
+    const foot = el("div", { class: "cmdk-foot" }, [
+      el("span", { text: "↑↓ naviguer · ↵ exécuter · esc fermer" }),
+      el("span", { text: "> pour commandes" }),
+    ]);
+    box.appendChild(inputWrap); box.appendChild(cmdkList); box.appendChild(foot);
+    cmdkRoot.appendChild(box);
+    document.body.appendChild(cmdkRoot);
+  }
+
+  Jarvis.openCmdK = function () {
+    ensureCmdK();
+    cmdkOpen = true;
+    cmdkRoot.classList.remove("is-hidden");
+    cmdkInput.value = ""; cmdkSelected = 0;
+    renderCmdK("");
+    setTimeout(() => cmdkInput.focus(), 30);
+  };
+  Jarvis.closeCmdK = function () {
+    if (!cmdkRoot) return;
+    cmdkOpen = false;
+    cmdkRoot.classList.add("is-hidden");
+  };
+
+  function currentResults() {
+    const v = cmdkInput.value.trim();
+    if (v.startsWith(">")) {
+      const q = v.slice(1).trim().toLowerCase();
+      if (q.startsWith("ask ")) {
+        const p = q.slice(4);
+        return [{ kind: "ask", id: "ask", title: 'Demander : "' + p + '"', glyph: "›", group: "Faire", run: () => _askJarvis(p) }];
+      }
+      const slash = cmdkCommands.filter(c => c.kind === "slash");
+      if (!q) return slash;
+      return slash.filter(c => c.title.toLowerCase().includes(q));
+    }
+    const q = v.toLowerCase();
+    const all = cmdkCommands.filter(c => c.kind !== "slash");
+    if (!q) return all;
+    return all.filter(c => (c.title + " " + (c.sub || "")).toLowerCase().includes(q));
+  }
+
+  function renderCmdK(_v, keepFocus) {
+    cmdkList.innerHTML = "";
+    const items = currentResults();
+    if (!items.length) {
+      cmdkList.appendChild(el("div", { class: "cmdk-empty", text: "Aucune commande" }));
+      return;
+    }
+    const groups = {};
+    items.forEach(it => { const g = it.group || "Navigation"; (groups[g] = groups[g] || []).push(it); });
+    let idx = 0;
+    Object.keys(groups).forEach(g => {
+      cmdkList.appendChild(el("div", { class: "cmdk-group-lbl", text: g }));
+      groups[g].forEach(it => {
+        const i = idx++;
+        const row = el("div", {
+          class: "cmdk-item" + (i === cmdkSelected ? " is-on" : ""),
+          onclick: () => { cmdkSelected = i; execSelected(); },
+          onmousemove: () => { if (cmdkSelected !== i) { cmdkSelected = i; renderCmdK(cmdkInput.value, true); } },
+        }, [
+          el("span", { class: "ck-glyph", text: it.glyph || "·" }),
+          el("div", {}, [
+            el("span", { text: it.title }),
+            it.sub ? el("span", { class: "ck-sub", text: it.sub }) : null,
+          ]),
+          it.kbd ? el("span", { class: "ck-kbd" }, it.kbd.split("+").map(k => el("span", { text: k }))) : el("span"),
+        ]);
+        cmdkList.appendChild(row);
+      });
+    });
+    if (keepFocus) cmdkInput.focus();
+  }
+
+  function execSelected() {
+    const it = currentResults()[cmdkSelected];
+    if (!it) return;
+    Jarvis.closeCmdK();
+    if (typeof it.run === "function") it.run();
+  }
+
+  async function _askJarvis(prompt) {
+    Jarvis.notify({ kind: "info", text: "Jarvis · réflexion…" });
+    try {
+      const r = await Jarvis.api.post("/api/agent/ask", { prompt });
+      Jarvis.notify({ kind: "success", text: (r.answer || r.text || "").slice(0, 240) });
+    } catch (err) {
+      Jarvis.notify({ kind: "error", text: "Échec : " + err.message });
+    }
+  }
+
+  /* ───────── Global keyboard shortcuts ───────── */
+  document.addEventListener("keydown", (e) => {
+    // ⌘K — palette
+    if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+      e.preventDefault();
+      cmdkOpen ? Jarvis.closeCmdK() : Jarvis.openCmdK();
+    }
+    // ⌘T — Mission Control
+    if ((e.metaKey || e.ctrlKey) && (e.key === "t" || e.key === "T")) {
+      e.preventDefault();
+      mcOpen ? Jarvis.closeMissionControl() : Jarvis.openMissionControl();
+    }
+    // Escape
+    if (e.key === "Escape") {
+      if (cmdkOpen) Jarvis.closeCmdK();
+      if (mcOpen)   Jarvis.closeMissionControl();
+    }
+  });
+
+  /* ───────── Inspector mode (Alt) ───────── */
+  let inspectHint = null;
+  function setInspect(on) {
+    document.documentElement.classList.toggle("inspect", on);
+    if (on && !inspectHint) {
+      inspectHint = el("div", { class: "inspect-hint" }, [
+        el("span", { class: "dot" }), el("span", { text: "INSPECTOR · ⌥" }),
+      ]);
+      document.body.appendChild(inspectHint);
+    } else if (!on && inspectHint) {
+      inspectHint.remove(); inspectHint = null;
+    }
+  }
+  document.addEventListener("keydown", (e) => { if (e.key === "Alt") setInspect(true); });
+  document.addEventListener("keyup",   (e) => { if (e.key === "Alt") setInspect(false); });
+  window.addEventListener("blur", () => setInspect(false));
+
+  /* ───────── Notification ribbon ───────── */
+  let notifStack = null;
+  Jarvis.notify = function ({ kind = "info", text = "" }) {
+    if (!notifStack) {
+      notifStack = el("div", { class: "notif-stack" });
+      document.body.appendChild(notifStack);
+    }
+    const cls = "notif" + (kind && kind !== "info" ? " notif--" + kind : "");
+    const node = el("div", { class: cls }, [
+      el("span", { class: "notif-mark" }),
+      el("div", { class: "notif-text", text }),
+      el("span", { class: "notif-time", text: "MAINT." }),
+    ]);
+    notifStack.appendChild(node);
+    setTimeout(() => node.remove(), 4400);
+    const sb = document.querySelector(".sidebar");
+    if (sb) {
+      const breath = el("div", { class: "sb-breath" });
+      sb.appendChild(breath);
+      setTimeout(() => breath.remove(), 1700);
+    }
+  };
+
+  /* ───────── Sparkline ───────── */
+  Jarvis.sparkline = function (data, opts) {
+    opts = opts || {};
+    const w = opts.width || 180, h = opts.height || 28;
+    const color = opts.color || "var(--accent)";
+    if (!data || !data.length) return el("svg", { width: w, height: h });
+    const min = Math.min(...data), max = Math.max(...data), range = max - min || 1;
+    const pts = data.map((v, i) => [
+      (i / (data.length - 1)) * w,
+      h - ((v - min) / range) * h * 0.85 - 2,
+    ]);
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", w); svg.setAttribute("height", h);
+    svg.setAttribute("viewBox", "0 0 " + w + " " + h);
+    const path = document.createElementNS(ns, "path");
+    path.setAttribute("d", pts.map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" "));
+    path.setAttribute("fill", "none"); path.setAttribute("stroke", color);
+    path.setAttribute("stroke-width", "1.4"); path.setAttribute("stroke-linecap", "round");
+    svg.appendChild(path);
+    const last = pts[pts.length - 1];
+    const dot = document.createElementNS(ns, "circle");
+    dot.setAttribute("cx", last[0]); dot.setAttribute("cy", last[1]);
+    dot.setAttribute("r", "2"); dot.setAttribute("fill", color);
+    svg.appendChild(dot);
+    return svg;
+  };
+
+  /* ───────── Bottom nav (legacy, conservé pour compat) ───────── */
+  Jarvis.mountBottomNav = function (opts) {
+    const existing = document.getElementById("j-bottom-nav");
+    if (existing) existing.remove();
+    // No-op in v2 — navigation handled by rooms system
+  };
+})();

--- a/src/jarvis/interfaces/ui/static/_shared.js.bak-1782251102
+++ b/src/jarvis/interfaces/ui/static/_shared.js.bak-1782251102
@@ -1,0 +1,775 @@
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS — Shared runtime v2 (vanilla JS, ES2017+)
+   Public API attached to window.Jarvis :
+
+     Jarvis.mountAtmosphere()
+     Jarvis.setMode(mode)                        → "home"|"workspace"|"capacites"|"config"
+     Jarvis.mountRooms({ mode, pages, activePage, onNav, onMissionControl })
+     Jarvis.mountTopbar({ pageTitle, crumb, onAsk, onCmdK })
+     Jarvis.openCmdK() / .closeCmdK()
+     Jarvis.openMissionControl() / .closeMissionControl()
+     Jarvis.registerCommands(arr)
+     Jarvis.notify({ kind, text })
+     Jarvis.api.get(path) / .post(path, body)
+     Jarvis.fmt.num(v) / .pct(v) / .relTime(d)
+     Jarvis.sparkline(data, opts)
+
+   Depends on _shared.css being loaded first.
+   ───────────────────────────────────────────────────────────────────── */
+
+(function () {
+  "use strict";
+
+  const Jarvis = (window.Jarvis = window.Jarvis || {});
+
+  /* ───────── Tiny DOM helpers ───────── */
+  function el(tag, attrs, children) {
+    const node = document.createElement(tag);
+    if (attrs) {
+      for (const k in attrs) {
+        const v = attrs[k];
+        if (v == null || v === false) continue;
+        if (k === "class")        node.className = v;
+        else if (k === "html")    node.innerHTML = v;
+        else if (k === "text")    node.textContent = v;
+        else if (k === "style" && typeof v === "object") Object.assign(node.style, v);
+        else if (k.startsWith("on") && typeof v === "function") node.addEventListener(k.slice(2).toLowerCase(), v);
+        else if (k === "dataset" && typeof v === "object") for (const dk in v) node.dataset[dk] = v[dk];
+        else node.setAttribute(k, v === true ? "" : v);
+      }
+    }
+    if (children != null) {
+      const arr = Array.isArray(children) ? children : [children];
+      for (const c of arr) {
+        if (c == null || c === false) continue;
+        node.appendChild(c.nodeType ? c : document.createTextNode(String(c)));
+      }
+    }
+    return node;
+  }
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $$(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
+  Jarvis.el = el; Jarvis.$ = $; Jarvis.$$ = $$;
+
+  /* ───────── Formatting ───────── */
+  Jarvis.fmt = {
+    num(v) {
+      if (v == null) return "—";
+      const n = Number(v);
+      if (!isFinite(n)) return String(v);
+      if (Math.abs(n) >= 1000) return n.toLocaleString("en-US", { maximumFractionDigits: 1 });
+      return n.toString();
+    },
+    pct(v, digits = 1) {
+      if (v == null) return "—";
+      return Number(v).toFixed(digits) + "%";
+    },
+    relTime(date) {
+      const d = date instanceof Date ? date : new Date(date);
+      const s = Math.round((Date.now() - d.getTime()) / 1000);
+      if (s < 60)   return "à l'instant";
+      if (s < 3600) return Math.floor(s / 60) + " min";
+      if (s < 86400) return Math.floor(s / 3600) + " h";
+      return Math.floor(s / 86400) + " j";
+    },
+  };
+
+  /* ───────── View registry ───────── */
+  Jarvis.views = {
+    _registry: {},
+    _active: null,
+
+    register(id, { meta, show, hide, command, gestures }) {
+      this._registry[id] = { meta: meta || {}, show, hide, command, gestures: gestures || null };
+    },
+
+    list() {
+      return Object.entries(this._registry).map(([id, v]) => ({ id, ...v.meta }));
+    },
+
+    activate(id, params) {
+      const view = this._registry[id];
+      if (!view) return;
+      if (this._active && this._active !== id) this.deactivate(this._active);
+      this._active = id;
+      view.show(params || {});
+    },
+
+    deactivate(id) {
+      const target = id || this._active;
+      if (!target) return;
+      const view = this._registry[target];
+      if (view) view.hide();
+      if (this._active === target) this._active = null;
+    },
+
+    dispatch(id, cmd, params) {
+      const view = this._registry[id];
+      if (view?.command) view.command(cmd, params || {});
+    },
+  };
+
+  /* ───────── API wrapper ───────── */
+  function authHeaders(extra) {
+    const headers = Object.assign({}, extra || {});
+    const token = window.JARVIS_API_TOKEN;
+    if (token) headers.Authorization = "Bearer " + token;
+    return headers;
+  }
+
+  Jarvis.api = {
+    base: window.JARVIS_API_BASE || "",
+    async get(path) {
+      const r = await fetch(this.base + path, {
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("GET " + path + " → " + r.status);
+      return r.json();
+    },
+    async post(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "POST", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("POST " + path + " → " + r.status);
+      return r.json();
+    },
+    async put(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PUT", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PUT " + path + " → " + r.status);
+      return r.json();
+    },
+    async patch(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PATCH", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PATCH " + path + " → " + r.status);
+      return r.json();
+    },
+    async delete(path) {
+      const r = await fetch(this.base + path, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("DELETE " + path + " → " + r.status);
+      return r.json();
+    },
+  };
+  Jarvis.authHeaders = authHeaders;
+
+  /* ───────── Navigation (iframe-aware) ───────── */
+  Jarvis.navigate = function (url) {
+    // Si on tourne dans l'iframe, déléguer au shell parent
+    if (window !== window.top && window.top.Jarvis?.navigateFrame) {
+      window.top.Jarvis.navigateFrame(url);
+      return;
+    }
+    // Si le shell home a enregistré un handler iframe
+    if (typeof Jarvis.navigateFrame === "function") {
+      Jarvis.navigateFrame(url);
+      return;
+    }
+    window.location.href = url;
+  };
+
+  /* ───────── Atmosphere ───────── */
+  Jarvis.mountAtmosphere = function () {
+    if (document.querySelector(".atmo--vignette")) return;
+    document.body.appendChild(el("div", { class: "spotlight", id: "j-spotlight" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--aurora" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--vignette" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--grain" }));
+    document.body.appendChild(el("div", { class: "mode-glow" }));
+
+    // Spotlight mouse tracking
+    document.addEventListener("mousemove", (e) => {
+      const sp = document.getElementById("j-spotlight");
+      if (sp) {
+        sp.style.setProperty("--mx", e.clientX + "px");
+        sp.style.setProperty("--my", e.clientY + "px");
+      }
+    }, { passive: true });
+  };
+
+  /* ───────── Mode system ───────── */
+  const MODE_META = {
+    home:       { chapter: "—",  num: "00", label: "JARVIS",        watermark: "" },
+    workspace:  { chapter: "I",  num: "01", label: "PILOTAGE",      watermark: "Pilotage" },
+    capacites:  { chapter: "II", num: "02", label: "ATELIER",       watermark: "Atelier" },
+    config:     { chapter: "III",num: "03", label: "RÉGLAGES",      watermark: "Réglages" },
+  };
+
+  Jarvis.setMode = function (mode) {
+    document.body.dataset.mode = mode;
+    // Watermark
+    let wm = document.getElementById("j-watermark");
+    const meta = MODE_META[mode] || MODE_META.home;
+    if (meta.watermark) {
+      if (!wm) {
+        wm = el("div", { id: "j-watermark", class: "mode-watermark" });
+        document.body.appendChild(wm);
+      }
+      wm.textContent = meta.watermark;
+    } else if (wm) {
+      wm.textContent = "";
+    }
+    // Chapter indicator
+    const ch = document.getElementById("j-rooms-chapter");
+    if (ch && meta.chapter !== "—") {
+      ch.querySelector(".rooms-num").textContent = meta.chapter;
+      ch.querySelector(".rooms-lbl").textContent = meta.label;
+    }
+  };
+
+  /* ───────── Scene card ───────── */
+  Jarvis.showSceneCard = function (chapter, title, duration) {
+    duration = duration || 900;
+    let sc = document.getElementById("j-scene-card");
+    if (!sc) {
+      sc = el("div", { id: "j-scene-card", class: "scene-card" });
+      const inner = el("div", { class: "scene-card-inner" }, [
+        el("div", { class: "scene-card-chapter", id: "j-sc-chapter" }),
+        el("div", { class: "scene-card-title",   id: "j-sc-title" }),
+      ]);
+      sc.appendChild(inner);
+      document.body.appendChild(sc);
+    }
+    sc.querySelector("#j-sc-chapter").textContent = chapter || "";
+    sc.querySelector("#j-sc-title").textContent   = title   || "";
+    sc.classList.add("is-visible");
+    setTimeout(() => {
+      sc.style.transition = "opacity .5s ease";
+      sc.style.opacity = "0";
+      setTimeout(() => { sc.classList.remove("is-visible"); sc.style.opacity = ""; sc.style.transition = ""; }, 520);
+    }, duration);
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Rooms navigation (chapter indicator + subpages editorial sidebar)
+  ───────────────────────────────────────────────────────────────────── */
+  let _roomsOpts = null;
+
+  Jarvis.mountRooms = function (opts) {
+    _roomsOpts = opts;
+    const { mode, pages, activePage, onNav } = opts;
+    document.body.dataset.mode = mode;
+
+    // ── Chapter indicator top-left ──
+    let ch = document.getElementById("j-rooms-chapter");
+    if (!ch) {
+      ch = el("div", { id: "j-rooms-chapter", class: "rooms-chapter" });
+      document.body.appendChild(ch);
+    }
+    const meta = MODE_META[mode] || MODE_META.home;
+    ch.innerHTML = "";
+    ch.appendChild(el("span", { class: "rooms-num", text: meta.chapter }));
+    ch.appendChild(el("span", { class: "rooms-bar" }));
+    ch.appendChild(el("span", { class: "rooms-lbl", text: meta.label }));
+
+    // ── Watermark ──
+    Jarvis.setMode(mode);
+
+    // ── Mission Control trigger bottom-left ──
+    let mc = document.getElementById("j-rooms-mc");
+    if (!mc) {
+      mc = el("button", { id: "j-rooms-mc", class: "rooms-mc", onclick: () => Jarvis.openMissionControl() });
+      mc.appendChild(el("span", { class: "mc-dot" }));
+      mc.appendChild(el("span", { text: "Mission Control" }));
+      const kbd = el("span", { class: "mc-kbd" });
+      kbd.appendChild(el("span", { text: "⌘" }));
+      kbd.appendChild(el("span", { text: "T" }));
+      mc.appendChild(kbd);
+      document.body.appendChild(mc);
+    }
+
+    // ── Subpages nav (editorial sidebar or bottom pill) ──
+    const isEditorial = mode !== "home";
+    if (isEditorial) {
+      document.body.dataset.subpages = "cocoon-wide-display";
+    } else {
+      delete document.body.dataset.subpages;
+    }
+
+    let nav = document.getElementById("j-rooms-pages");
+    if (!nav) {
+      nav = el("div", { id: "j-rooms-pages", class: "rooms-pages" });
+      document.body.appendChild(nav);
+    }
+    nav.dataset.modeLabel = meta.label;
+    nav.innerHTML = "";
+
+    (pages || []).forEach((p, idx) => {
+      const btn = el("button", {
+        dataset: { active: p.id === activePage ? "true" : "false" },
+        onclick: () => {
+          $$(".rooms-pages button", nav).forEach(b => b.dataset.active = "false");
+          btn.dataset.active = "true";
+          onNav && onNav(p.id);
+        },
+      });
+      btn.appendChild(el("span", { class: "num", text: String(idx + 1).padStart(2, "0") }));
+      btn.appendChild(el("span", { class: "lbl", text: p.label }));
+      nav.appendChild(btn);
+    });
+
+    // Keyboard ←/→ for subpage cycling
+    document.addEventListener("keydown", _handleRoomsKey, { once: false });
+  };
+
+  function _handleRoomsKey(e) {
+    if (cmdkOpen || mcOpen) return;
+    if (!_roomsOpts || !_roomsOpts.pages) return;
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    if (document.activeElement && ["INPUT","TEXTAREA"].includes(document.activeElement.tagName)) return;
+
+    const pages = _roomsOpts.pages;
+    const nav = document.getElementById("j-rooms-pages");
+    if (!nav) return;
+    const btns = $$("button", nav);
+    const curIdx = btns.findIndex(b => b.dataset.active === "true");
+    let next = e.key === "ArrowRight" ? curIdx + 1 : curIdx - 1;
+    next = Math.max(0, Math.min(next, pages.length - 1));
+    if (next === curIdx) return;
+    e.preventDefault();
+    btns.forEach(b => b.dataset.active = "false");
+    btns[next].dataset.active = "true";
+    _roomsOpts.onNav && _roomsOpts.onNav(pages[next].id);
+  }
+
+  /* ─────────────────────────────────────────────────────────────────
+     Mission Control overlay (⌘T)
+  ───────────────────────────────────────────────────────────────────── */
+  let mcRoot = null;
+  let mcOpen = false;
+
+  /* ── Mission Control v2 — délégué à mission_control.js ──────────────
+     Les stubs ci-dessous sont surchargés par mission_control.js au boot.
+     Conserver pour ne pas casser les pages qui chargent _shared.js seul.   */
+
+  Jarvis.openMissionControl = function () {
+    if (typeof Jarvis.navigateFrame === 'function') {
+      Jarvis.navigateFrame('/mc');
+    } else if (typeof Jarvis.navigate === 'function') {
+      Jarvis.navigate('/mc');
+    } else {
+      window.location.href = '/mc';
+    }
+  };
+  Jarvis.closeMissionControl = function () {};
+
+  /* ── DEAD CODE ci-dessous — conservé pour référence, non exécuté ─────
+  function ensureMissionControl_LEGACY() {
+
+    { mode: "home",      label: "Home",          sub: "Ambient · À l'écoute",                  href: "/",             chapter: "—",   pages: [] },
+    { mode: "workspace", label: "Workspace",      sub: "Ce que tu pilotes en ce moment",         href: "/dashboard",    chapter: "I",   pages: ["Aperçu","Initiatives","Missions","Tâches","Analytics"] },
+    { mode: "capacites", label: "Capacités",      sub: "Ce que Jarvis sait faire pour toi",      href: "/capabilities", chapter: "II",  pages: ["Intégrations","Skills","Routines","Ambiances","Store","Écosystème"] },
+    { mode: "config",    label: "Configuration",  sub: "Tes préférences et ton coffre",           href: "/settings",     chapter: "III", pages: ["Préférences","Modèles & API","Audio & voix","Conso","Système","À propos"] },
+  ];
+
+  function ensureMissionControl() {
+    if (mcRoot) return;
+    mcRoot = el("div", { class: "mission-overlay is-hidden", onclick: (e) => { if (e.target === mcRoot) Jarvis.closeMissionControl(); } });
+
+    // Header bar
+    const header = el("div", { class: "mc-header" });
+    header.appendChild(el("span", { class: "mc-header-title", text: "Mission Control" }));
+    const hint = el("span", { class: "mc-header-hint" });
+    const kbd1 = el("span", { class: "mc-hkbd" });
+    kbd1.appendChild(el("span", { text: "⌘" }));
+    kbd1.appendChild(el("span", { text: "T" }));
+    hint.appendChild(kbd1);
+    hint.appendChild(document.createTextNode(" pour fermer"));
+    hint.appendChild(el("span", { class: "mc-hdot", text: " · " }));
+    hint.appendChild(el("span", { class: "mc-hkbd", text: "ESC" }));
+    header.appendChild(hint);
+    header.appendChild(el("button", { class: "mc-close", onclick: () => Jarvis.closeMissionControl(), text: "×" }));
+    mcRoot.appendChild(header);
+
+    const grid = el("div", { class: "mission-grid" });
+    ROOMS.forEach(r => {
+      const card = el("button", {
+        class: "mission-card",
+        dataset: { mode: r.mode },
+        onclick: () => { Jarvis.closeMissionControl(); Jarvis.navigate(r.href); },
+      });
+      const eyebrow = el("div", { class: "mc-card-eyebrow" });
+      eyebrow.appendChild(el("span", { class: "mc-card-num", text: r.chapter }));
+      if (r.pages.length) eyebrow.appendChild(el("span", { text: r.pages.length + " SECTIONS" }));
+      card.appendChild(eyebrow);
+      card.appendChild(el("div", { class: "mc-card-title", text: r.label }));
+      card.appendChild(el("div", { class: "mc-card-sub",   text: r.sub }));
+      if (r.pages.length) {
+        const pagesEl = el("div", { class: "mc-card-pages" });
+        r.pages.forEach((p, i) => {
+          pagesEl.appendChild(el("span", { class: "mc-card-page" }, [
+            el("span", { class: "mc-pg-num", text: String(i + 1).padStart(2, "0") }),
+            el("span", { class: "mc-pg-lbl", text: p }),
+          ]));
+        });
+        card.appendChild(pagesEl);
+      }
+      grid.appendChild(card);
+    });
+    mcRoot.appendChild(grid);
+    document.body.appendChild(mcRoot);
+  }
+
+  Jarvis.openMissionControl = function () {
+    ensureMissionControl();
+    mcOpen = true;
+    mcRoot.classList.remove("is-hidden");
+  };
+  Jarvis.closeMissionControl = function () {
+    if (!mcRoot) return;
+    mcOpen = false;
+    mcRoot.classList.add("is-hidden");
+  };
+  */ // fin DEAD CODE
+
+
+  /* ───────── Legacy sidebar (still used on pages without rooms nav) ─────────
+     opts: sections, activeId, onNav, footer
+  */
+  Jarvis.mountSidebar = function (opts) {
+    const root = document.getElementById("sidebar") || el("aside", { id: "sidebar" });
+    if (!root.parentNode) document.querySelector(".app").prepend(root);
+    root.className = "sidebar";
+    root.innerHTML = "";
+
+    root.appendChild(el("div", { class: "sb-brand" }, [
+      brandMark(),
+      el("div", { class: "sb-brand-text" }, [
+        el("span", { class: "sb-brand-name", text: "Jarvis" }),
+        el("span", { class: "sb-brand-status", text: "Online · v4.2" }),
+      ]),
+    ]));
+
+    (opts.sections || []).forEach(sec => {
+      root.appendChild(el("div", { class: "sb-section-eyebrow" }, [
+        el("span", { text: sec.label }),
+        sec.right ? el("span", { text: sec.right, style: { color: "var(--fg-2)" } }) : null,
+      ]));
+      const nav = el("div", { class: "sb-nav" });
+      sec.items.forEach(it => {
+        const b = el("button", {
+          class: "sb-item" + (it.id === opts.activeId ? " is-on" : ""),
+          dataset: { id: it.id },
+          onclick: () => opts.onNav && opts.onNav(it.id),
+        }, [
+          el("span", { class: "sb-dot" }),
+          el("span", { text: it.label }),
+          it.meta ? el("span", { class: "sb-meta", text: it.meta }) : el("span"),
+        ]);
+        nav.appendChild(b);
+      });
+      root.appendChild(nav);
+    });
+
+    if (opts.footer) {
+      const f = el("div", { class: "sb-foot" });
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "Spend · 24h" }),
+        el("span", { text: opts.footer.spend || "—" }),
+      ]));
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "CPU" }),
+        el("span", { text: opts.footer.cpu || "—" }),
+      ]));
+      const bar = el("div", { class: "sb-foot-bar" });
+      bar.appendChild(el("div", { style: { width: ((opts.footer.ramPct || 0) * 100) + "%" } }));
+      f.appendChild(bar);
+      root.appendChild(f);
+    }
+    return root;
+  };
+
+  function brandMark() {
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", "26"); svg.setAttribute("height", "26"); svg.setAttribute("viewBox", "0 0 26 26");
+    const c = document.createElementNS(ns, "circle");
+    c.setAttribute("cx", "13"); c.setAttribute("cy", "13"); c.setAttribute("r", "11");
+    c.setAttribute("fill", "none"); c.setAttribute("stroke", "var(--accent)"); c.setAttribute("stroke-width", "1"); c.setAttribute("opacity", "0.8");
+    const c2 = document.createElementNS(ns, "circle");
+    c2.setAttribute("cx", "13"); c2.setAttribute("cy", "13"); c2.setAttribute("r", "5");
+    c2.setAttribute("fill", "var(--accent)"); c2.setAttribute("opacity", "0.18");
+    const c3 = document.createElementNS(ns, "circle");
+    c3.setAttribute("cx", "13"); c3.setAttribute("cy", "13"); c3.setAttribute("r", "1.6"); c3.setAttribute("fill", "var(--accent)");
+    svg.appendChild(c); svg.appendChild(c2); svg.appendChild(c3);
+    return svg;
+  }
+
+  /* ───────── Topbar ───────── */
+  Jarvis.mountTopbar = function (opts) {
+    const root = document.getElementById("topbar") || el("header", { id: "topbar", class: "topbar" });
+    root.className = "topbar";
+    root.innerHTML = "";
+
+    const t = new Date();
+    const tStr = String(t.getHours()).padStart(2, "0") + ":" + String(t.getMinutes()).padStart(2, "0");
+
+    root.appendChild(el("div", { class: "topbar-l" }, [
+      el("span", { class: "topbar-page-title", text: opts.pageTitle || "Dashboard" }),
+      el("span", { class: "topbar-crumb",      text: opts.crumb || "/ control" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-c" }, [
+      el("span", { class: "dot" }),
+      el("span", { text: "Online" }),
+      el("span", { class: "sep" }),
+      el("span", { text: tStr }),
+      el("span", { class: "sep" }),
+      el("span", { text: "Paris" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-r" }, [
+      el("button", { class: "tb-btn", onclick: () => Jarvis.openCmdK() }, [
+        el("span", { text: "Recherche" }),
+        el("span", { class: "kbd", text: "⌘K" }),
+      ]),
+      el("button", { class: "tb-btn", onclick: () => opts.onAsk && opts.onAsk() }, [
+        el("span", { text: "Ask Jarvis" }),
+      ]),
+    ]));
+
+    return root;
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Command palette (⌘K)
+  ───────────────────────────────────────────────────────────────────── */
+  let cmdkRoot = null, cmdkInput = null, cmdkList = null;
+  let cmdkCommands = [], cmdkSelected = 0, cmdkOpen = false;
+
+  // Seed with room navigation commands
+  const _navCmds = ROOMS.map(r => ({
+    kind: "nav", id: "goto-" + r.mode, group: "Aller à",
+    title: r.label, sub: r.href, glyph: "→",
+    run: () => { Jarvis.navigate(r.href); },
+  }));
+  cmdkCommands = _navCmds;
+
+  Jarvis.registerCommands = function (cmds) {
+    const ids = new Set(cmdkCommands.map(c => c.id));
+    cmds.forEach(c => { if (!ids.has(c.id)) cmdkCommands.push(c); });
+  };
+
+  function ensureCmdK() {
+    if (cmdkRoot) return;
+    cmdkRoot = el("div", { class: "cmdk-back is-hidden", onclick: (e) => { if (e.target === cmdkRoot) Jarvis.closeCmdK(); } });
+    const box = el("div", { class: "cmdk" });
+    const inputWrap = el("div", { class: "cmdk-input-wrap" });
+    const prefix = el("span", { class: "cmdk-prefix", text: ">", style: { display: "none" } });
+    cmdkInput = el("input", {
+      class: "cmdk-input",
+      placeholder: "Cherche · navigue · > commandes",
+      autocomplete: "off",
+      oninput: (e) => {
+        const v = e.target.value;
+        const slash = v.startsWith(">");
+        prefix.style.display = slash ? "block" : "none";
+        cmdkInput.classList.toggle("has-prefix", slash);
+        cmdkSelected = 0; renderCmdK(v);
+      },
+      onkeydown: (e) => {
+        if (e.key === "Escape")    { e.preventDefault(); Jarvis.closeCmdK(); }
+        if (e.key === "ArrowDown") { e.preventDefault(); cmdkSelected = Math.min(cmdkSelected + 1, currentResults().length - 1); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "ArrowUp")   { e.preventDefault(); cmdkSelected = Math.max(cmdkSelected - 1, 0); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "Enter")     { e.preventDefault(); execSelected(); }
+      },
+    });
+    inputWrap.appendChild(prefix); inputWrap.appendChild(cmdkInput);
+    cmdkList = el("div", { class: "cmdk-list" });
+    const foot = el("div", { class: "cmdk-foot" }, [
+      el("span", { text: "↑↓ naviguer · ↵ exécuter · esc fermer" }),
+      el("span", { text: "> pour commandes" }),
+    ]);
+    box.appendChild(inputWrap); box.appendChild(cmdkList); box.appendChild(foot);
+    cmdkRoot.appendChild(box);
+    document.body.appendChild(cmdkRoot);
+  }
+
+  Jarvis.openCmdK = function () {
+    ensureCmdK();
+    cmdkOpen = true;
+    cmdkRoot.classList.remove("is-hidden");
+    cmdkInput.value = ""; cmdkSelected = 0;
+    renderCmdK("");
+    setTimeout(() => cmdkInput.focus(), 30);
+  };
+  Jarvis.closeCmdK = function () {
+    if (!cmdkRoot) return;
+    cmdkOpen = false;
+    cmdkRoot.classList.add("is-hidden");
+  };
+
+  function currentResults() {
+    const v = cmdkInput.value.trim();
+    if (v.startsWith(">")) {
+      const q = v.slice(1).trim().toLowerCase();
+      if (q.startsWith("ask ")) {
+        const p = q.slice(4);
+        return [{ kind: "ask", id: "ask", title: 'Demander : "' + p + '"', glyph: "›", group: "Faire", run: () => _askJarvis(p) }];
+      }
+      const slash = cmdkCommands.filter(c => c.kind === "slash");
+      if (!q) return slash;
+      return slash.filter(c => c.title.toLowerCase().includes(q));
+    }
+    const q = v.toLowerCase();
+    const all = cmdkCommands.filter(c => c.kind !== "slash");
+    if (!q) return all;
+    return all.filter(c => (c.title + " " + (c.sub || "")).toLowerCase().includes(q));
+  }
+
+  function renderCmdK(_v, keepFocus) {
+    cmdkList.innerHTML = "";
+    const items = currentResults();
+    if (!items.length) {
+      cmdkList.appendChild(el("div", { class: "cmdk-empty", text: "Aucune commande" }));
+      return;
+    }
+    const groups = {};
+    items.forEach(it => { const g = it.group || "Navigation"; (groups[g] = groups[g] || []).push(it); });
+    let idx = 0;
+    Object.keys(groups).forEach(g => {
+      cmdkList.appendChild(el("div", { class: "cmdk-group-lbl", text: g }));
+      groups[g].forEach(it => {
+        const i = idx++;
+        const row = el("div", {
+          class: "cmdk-item" + (i === cmdkSelected ? " is-on" : ""),
+          onclick: () => { cmdkSelected = i; execSelected(); },
+          onmousemove: () => { if (cmdkSelected !== i) { cmdkSelected = i; renderCmdK(cmdkInput.value, true); } },
+        }, [
+          el("span", { class: "ck-glyph", text: it.glyph || "·" }),
+          el("div", {}, [
+            el("span", { text: it.title }),
+            it.sub ? el("span", { class: "ck-sub", text: it.sub }) : null,
+          ]),
+          it.kbd ? el("span", { class: "ck-kbd" }, it.kbd.split("+").map(k => el("span", { text: k }))) : el("span"),
+        ]);
+        cmdkList.appendChild(row);
+      });
+    });
+    if (keepFocus) cmdkInput.focus();
+  }
+
+  function execSelected() {
+    const it = currentResults()[cmdkSelected];
+    if (!it) return;
+    Jarvis.closeCmdK();
+    if (typeof it.run === "function") it.run();
+  }
+
+  async function _askJarvis(prompt) {
+    Jarvis.notify({ kind: "info", text: "Jarvis · réflexion…" });
+    try {
+      const r = await Jarvis.api.post("/api/agent/ask", { prompt });
+      Jarvis.notify({ kind: "success", text: (r.answer || r.text || "").slice(0, 240) });
+    } catch (err) {
+      Jarvis.notify({ kind: "error", text: "Échec : " + err.message });
+    }
+  }
+
+  /* ───────── Global keyboard shortcuts ───────── */
+  document.addEventListener("keydown", (e) => {
+    // ⌘K — palette
+    if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+      e.preventDefault();
+      cmdkOpen ? Jarvis.closeCmdK() : Jarvis.openCmdK();
+    }
+    // ⌘T — Mission Control
+    if ((e.metaKey || e.ctrlKey) && (e.key === "t" || e.key === "T")) {
+      e.preventDefault();
+      mcOpen ? Jarvis.closeMissionControl() : Jarvis.openMissionControl();
+    }
+    // Escape
+    if (e.key === "Escape") {
+      if (cmdkOpen) Jarvis.closeCmdK();
+      if (mcOpen)   Jarvis.closeMissionControl();
+    }
+  });
+
+  /* ───────── Inspector mode (Alt) ───────── */
+  let inspectHint = null;
+  function setInspect(on) {
+    document.documentElement.classList.toggle("inspect", on);
+    if (on && !inspectHint) {
+      inspectHint = el("div", { class: "inspect-hint" }, [
+        el("span", { class: "dot" }), el("span", { text: "INSPECTOR · ⌥" }),
+      ]);
+      document.body.appendChild(inspectHint);
+    } else if (!on && inspectHint) {
+      inspectHint.remove(); inspectHint = null;
+    }
+  }
+  document.addEventListener("keydown", (e) => { if (e.key === "Alt") setInspect(true); });
+  document.addEventListener("keyup",   (e) => { if (e.key === "Alt") setInspect(false); });
+  window.addEventListener("blur", () => setInspect(false));
+
+  /* ───────── Notification ribbon ───────── */
+  let notifStack = null;
+  Jarvis.notify = function ({ kind = "info", text = "" }) {
+    if (!notifStack) {
+      notifStack = el("div", { class: "notif-stack" });
+      document.body.appendChild(notifStack);
+    }
+    const cls = "notif" + (kind && kind !== "info" ? " notif--" + kind : "");
+    const node = el("div", { class: cls }, [
+      el("span", { class: "notif-mark" }),
+      el("div", { class: "notif-text", text }),
+      el("span", { class: "notif-time", text: "MAINT." }),
+    ]);
+    notifStack.appendChild(node);
+    setTimeout(() => node.remove(), 4400);
+    const sb = document.querySelector(".sidebar");
+    if (sb) {
+      const breath = el("div", { class: "sb-breath" });
+      sb.appendChild(breath);
+      setTimeout(() => breath.remove(), 1700);
+    }
+  };
+
+  /* ───────── Sparkline ───────── */
+  Jarvis.sparkline = function (data, opts) {
+    opts = opts || {};
+    const w = opts.width || 180, h = opts.height || 28;
+    const color = opts.color || "var(--accent)";
+    if (!data || !data.length) return el("svg", { width: w, height: h });
+    const min = Math.min(...data), max = Math.max(...data), range = max - min || 1;
+    const pts = data.map((v, i) => [
+      (i / (data.length - 1)) * w,
+      h - ((v - min) / range) * h * 0.85 - 2,
+    ]);
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", w); svg.setAttribute("height", h);
+    svg.setAttribute("viewBox", "0 0 " + w + " " + h);
+    const path = document.createElementNS(ns, "path");
+    path.setAttribute("d", pts.map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" "));
+    path.setAttribute("fill", "none"); path.setAttribute("stroke", color);
+    path.setAttribute("stroke-width", "1.4"); path.setAttribute("stroke-linecap", "round");
+    svg.appendChild(path);
+    const last = pts[pts.length - 1];
+    const dot = document.createElementNS(ns, "circle");
+    dot.setAttribute("cx", last[0]); dot.setAttribute("cy", last[1]);
+    dot.setAttribute("r", "2"); dot.setAttribute("fill", color);
+    svg.appendChild(dot);
+    return svg;
+  };
+
+  /* ───────── Bottom nav (legacy, conservé pour compat) ───────── */
+  Jarvis.mountBottomNav = function (opts) {
+    const existing = document.getElementById("j-bottom-nav");
+    if (existing) existing.remove();
+    // No-op in v2 — navigation handled by rooms system
+  };
+})();

--- a/src/jarvis/interfaces/ui/static/_shared.js.bak-1782251989
+++ b/src/jarvis/interfaces/ui/static/_shared.js.bak-1782251989
@@ -1,0 +1,769 @@
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS — Shared runtime v2 (vanilla JS, ES2017+)
+   Public API attached to window.Jarvis :
+
+     Jarvis.mountAtmosphere()
+     Jarvis.setMode(mode)                        → "home"|"workspace"|"capacites"|"config"
+     Jarvis.mountRooms({ mode, pages, activePage, onNav, onMissionControl })
+     Jarvis.mountTopbar({ pageTitle, crumb, onAsk, onCmdK })
+     Jarvis.openCmdK() / .closeCmdK()
+     Jarvis.openMissionControl() / .closeMissionControl()
+     Jarvis.registerCommands(arr)
+     Jarvis.notify({ kind, text })
+     Jarvis.api.get(path) / .post(path, body)
+     Jarvis.fmt.num(v) / .pct(v) / .relTime(d)
+     Jarvis.sparkline(data, opts)
+
+   Depends on _shared.css being loaded first.
+   ───────────────────────────────────────────────────────────────────── */
+
+(function () {
+  "use strict";
+
+  const Jarvis = (window.Jarvis = window.Jarvis || {});
+
+  /* ───────── Tiny DOM helpers ───────── */
+  function el(tag, attrs, children) {
+    const node = document.createElement(tag);
+    if (attrs) {
+      for (const k in attrs) {
+        const v = attrs[k];
+        if (v == null || v === false) continue;
+        if (k === "class")        node.className = v;
+        else if (k === "html")    node.innerHTML = v;
+        else if (k === "text")    node.textContent = v;
+        else if (k === "style" && typeof v === "object") Object.assign(node.style, v);
+        else if (k.startsWith("on") && typeof v === "function") node.addEventListener(k.slice(2).toLowerCase(), v);
+        else if (k === "dataset" && typeof v === "object") for (const dk in v) node.dataset[dk] = v[dk];
+        else node.setAttribute(k, v === true ? "" : v);
+      }
+    }
+    if (children != null) {
+      const arr = Array.isArray(children) ? children : [children];
+      for (const c of arr) {
+        if (c == null || c === false) continue;
+        node.appendChild(c.nodeType ? c : document.createTextNode(String(c)));
+      }
+    }
+    return node;
+  }
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $$(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
+  Jarvis.el = el; Jarvis.$ = $; Jarvis.$$ = $$;
+
+  /* ───────── Formatting ───────── */
+  Jarvis.fmt = {
+    num(v) {
+      if (v == null) return "—";
+      const n = Number(v);
+      if (!isFinite(n)) return String(v);
+      if (Math.abs(n) >= 1000) return n.toLocaleString("en-US", { maximumFractionDigits: 1 });
+      return n.toString();
+    },
+    pct(v, digits = 1) {
+      if (v == null) return "—";
+      return Number(v).toFixed(digits) + "%";
+    },
+    relTime(date) {
+      const d = date instanceof Date ? date : new Date(date);
+      const s = Math.round((Date.now() - d.getTime()) / 1000);
+      if (s < 60)   return "à l'instant";
+      if (s < 3600) return Math.floor(s / 60) + " min";
+      if (s < 86400) return Math.floor(s / 3600) + " h";
+      return Math.floor(s / 86400) + " j";
+    },
+  };
+
+  /* ───────── View registry ───────── */
+  Jarvis.views = {
+    _registry: {},
+    _active: null,
+
+    register(id, { meta, show, hide, command, gestures }) {
+      this._registry[id] = { meta: meta || {}, show, hide, command, gestures: gestures || null };
+    },
+
+    list() {
+      return Object.entries(this._registry).map(([id, v]) => ({ id, ...v.meta }));
+    },
+
+    activate(id, params) {
+      const view = this._registry[id];
+      if (!view) return;
+      if (this._active && this._active !== id) this.deactivate(this._active);
+      this._active = id;
+      view.show(params || {});
+    },
+
+    deactivate(id) {
+      const target = id || this._active;
+      if (!target) return;
+      const view = this._registry[target];
+      if (view) view.hide();
+      if (this._active === target) this._active = null;
+    },
+
+    dispatch(id, cmd, params) {
+      const view = this._registry[id];
+      if (view?.command) view.command(cmd, params || {});
+    },
+  };
+
+  /* ───────── API wrapper ───────── */
+  function authHeaders(extra) {
+    const headers = Object.assign({}, extra || {});
+    const token = window.JARVIS_API_TOKEN;
+    if (token) headers.Authorization = "Bearer " + token;
+    return headers;
+  }
+
+  Jarvis.api = {
+    base: window.JARVIS_API_BASE || "",
+    async get(path) {
+      const r = await fetch(this.base + path, {
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("GET " + path + " → " + r.status);
+      return r.json();
+    },
+    async post(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "POST", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("POST " + path + " → " + r.status);
+      return r.json();
+    },
+    async put(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PUT", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PUT " + path + " → " + r.status);
+      return r.json();
+    },
+    async patch(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PATCH", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PATCH " + path + " → " + r.status);
+      return r.json();
+    },
+    async delete(path) {
+      const r = await fetch(this.base + path, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("DELETE " + path + " → " + r.status);
+      return r.json();
+    },
+  };
+  Jarvis.authHeaders = authHeaders;
+
+  /* ───────── Navigation (iframe-aware) ───────── */
+  Jarvis.navigate = function (url) {
+    // Si on tourne dans l'iframe, déléguer au shell parent
+    if (window !== window.top && window.top.Jarvis?.navigateFrame) {
+      window.top.Jarvis.navigateFrame(url);
+      return;
+    }
+    // Si le shell home a enregistré un handler iframe
+    if (typeof Jarvis.navigateFrame === "function") {
+      Jarvis.navigateFrame(url);
+      return;
+    }
+    window.location.href = url;
+  };
+
+  /* ───────── Atmosphere ───────── */
+  Jarvis.mountAtmosphere = function () {
+    if (document.querySelector(".atmo--vignette")) return;
+    document.body.appendChild(el("div", { class: "spotlight", id: "j-spotlight" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--aurora" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--vignette" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--grain" }));
+    document.body.appendChild(el("div", { class: "mode-glow" }));
+
+    // Spotlight mouse tracking
+    document.addEventListener("mousemove", (e) => {
+      const sp = document.getElementById("j-spotlight");
+      if (sp) {
+        sp.style.setProperty("--mx", e.clientX + "px");
+        sp.style.setProperty("--my", e.clientY + "px");
+      }
+    }, { passive: true });
+  };
+
+  /* ───────── Mode system ───────── */
+  const MODE_META = {
+    home:       { chapter: "—",  num: "00", label: "JARVIS",        watermark: "" },
+    workspace:  { chapter: "I",  num: "01", label: "PILOTAGE",      watermark: "Pilotage" },
+    capacites:  { chapter: "II", num: "02", label: "ATELIER",       watermark: "Atelier" },
+    config:     { chapter: "III",num: "03", label: "RÉGLAGES",      watermark: "Réglages" },
+  };
+
+  Jarvis.setMode = function (mode) {
+    document.body.dataset.mode = mode;
+    // Watermark
+    let wm = document.getElementById("j-watermark");
+    const meta = MODE_META[mode] || MODE_META.home;
+    if (meta.watermark) {
+      if (!wm) {
+        wm = el("div", { id: "j-watermark", class: "mode-watermark" });
+        document.body.appendChild(wm);
+      }
+      wm.textContent = meta.watermark;
+    } else if (wm) {
+      wm.textContent = "";
+    }
+    // Chapter indicator
+    const ch = document.getElementById("j-rooms-chapter");
+    if (ch && meta.chapter !== "—") {
+      ch.querySelector(".rooms-num").textContent = meta.chapter;
+      ch.querySelector(".rooms-lbl").textContent = meta.label;
+    }
+  };
+
+  /* ───────── Scene card ───────── */
+  Jarvis.showSceneCard = function (chapter, title, duration) {
+    duration = duration || 900;
+    let sc = document.getElementById("j-scene-card");
+    if (!sc) {
+      sc = el("div", { id: "j-scene-card", class: "scene-card" });
+      const inner = el("div", { class: "scene-card-inner" }, [
+        el("div", { class: "scene-card-chapter", id: "j-sc-chapter" }),
+        el("div", { class: "scene-card-title",   id: "j-sc-title" }),
+      ]);
+      sc.appendChild(inner);
+      document.body.appendChild(sc);
+    }
+    sc.querySelector("#j-sc-chapter").textContent = chapter || "";
+    sc.querySelector("#j-sc-title").textContent   = title   || "";
+    sc.classList.add("is-visible");
+    setTimeout(() => {
+      sc.style.transition = "opacity .5s ease";
+      sc.style.opacity = "0";
+      setTimeout(() => { sc.classList.remove("is-visible"); sc.style.opacity = ""; sc.style.transition = ""; }, 520);
+    }, duration);
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Rooms navigation (chapter indicator + subpages editorial sidebar)
+  ───────────────────────────────────────────────────────────────────── */
+  let _roomsOpts = null;
+
+  Jarvis.mountRooms = function (opts) {
+    _roomsOpts = opts;
+    const { mode, pages, activePage, onNav } = opts;
+    document.body.dataset.mode = mode;
+
+    // ── Chapter indicator top-left ──
+    let ch = document.getElementById("j-rooms-chapter");
+    if (!ch) {
+      ch = el("div", { id: "j-rooms-chapter", class: "rooms-chapter" });
+      document.body.appendChild(ch);
+    }
+    const meta = MODE_META[mode] || MODE_META.home;
+    ch.innerHTML = "";
+    ch.appendChild(el("span", { class: "rooms-num", text: meta.chapter }));
+    ch.appendChild(el("span", { class: "rooms-bar" }));
+    ch.appendChild(el("span", { class: "rooms-lbl", text: meta.label }));
+
+    // ── Watermark ──
+    Jarvis.setMode(mode);
+
+    // ── Mission Control trigger bottom-left ──
+    let mc = document.getElementById("j-rooms-mc");
+    if (!mc) {
+      mc = el("button", { id: "j-rooms-mc", class: "rooms-mc", onclick: () => Jarvis.openMissionControl() });
+      mc.appendChild(el("span", { class: "mc-dot" }));
+      mc.appendChild(el("span", { text: "Mission Control" }));
+      const kbd = el("span", { class: "mc-kbd" });
+      kbd.appendChild(el("span", { text: "⌘" }));
+      kbd.appendChild(el("span", { text: "T" }));
+      mc.appendChild(kbd);
+      document.body.appendChild(mc);
+    }
+
+    // ── Subpages nav (editorial sidebar or bottom pill) ──
+    const isEditorial = mode !== "home";
+    if (isEditorial) {
+      document.body.dataset.subpages = "cocoon-wide-display";
+    } else {
+      delete document.body.dataset.subpages;
+    }
+
+    let nav = document.getElementById("j-rooms-pages");
+    if (!nav) {
+      nav = el("div", { id: "j-rooms-pages", class: "rooms-pages" });
+      document.body.appendChild(nav);
+    }
+    nav.dataset.modeLabel = meta.label;
+    nav.innerHTML = "";
+
+    (pages || []).forEach((p, idx) => {
+      const btn = el("button", {
+        dataset: { active: p.id === activePage ? "true" : "false" },
+        onclick: () => {
+          $$(".rooms-pages button", nav).forEach(b => b.dataset.active = "false");
+          btn.dataset.active = "true";
+          onNav && onNav(p.id);
+        },
+      });
+      btn.appendChild(el("span", { class: "num", text: String(idx + 1).padStart(2, "0") }));
+      btn.appendChild(el("span", { class: "lbl", text: p.label }));
+      nav.appendChild(btn);
+    });
+
+    // Keyboard ←/→ for subpage cycling
+    document.addEventListener("keydown", _handleRoomsKey, { once: false });
+  };
+
+  function _handleRoomsKey(e) {
+    if (cmdkOpen || mcOpen) return;
+    if (!_roomsOpts || !_roomsOpts.pages) return;
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    if (document.activeElement && ["INPUT","TEXTAREA"].includes(document.activeElement.tagName)) return;
+
+    const pages = _roomsOpts.pages;
+    const nav = document.getElementById("j-rooms-pages");
+    if (!nav) return;
+    const btns = $$("button", nav);
+    const curIdx = btns.findIndex(b => b.dataset.active === "true");
+    let next = e.key === "ArrowRight" ? curIdx + 1 : curIdx - 1;
+    next = Math.max(0, Math.min(next, pages.length - 1));
+    if (next === curIdx) return;
+    e.preventDefault();
+    btns.forEach(b => b.dataset.active = "false");
+    btns[next].dataset.active = "true";
+    _roomsOpts.onNav && _roomsOpts.onNav(pages[next].id);
+  }
+
+  /* ─────────────────────────────────────────────────────────────────
+     Mission Control overlay (⌘T)
+  ───────────────────────────────────────────────────────────────────── */
+  let mcRoot = null;
+  let mcOpen = false;
+
+  /* ── Mission Control v2 — délégué à mission_control.js ──────────────
+     Les stubs ci-dessous sont surchargés par mission_control.js au boot.
+     Conserver pour ne pas casser les pages qui chargent _shared.js seul.   */
+
+  Jarvis.openMissionControl = function () {
+    window.location.href = '/mc';
+  };
+  Jarvis.closeMissionControl = function () {};
+
+  /* ── DEAD CODE ci-dessous — conservé pour référence, non exécuté ─────
+  function ensureMissionControl_LEGACY() {
+
+    { mode: "home",      label: "Home",          sub: "Ambient · À l'écoute",                  href: "/",             chapter: "—",   pages: [] },
+    { mode: "workspace", label: "Workspace",      sub: "Ce que tu pilotes en ce moment",         href: "/dashboard",    chapter: "I",   pages: ["Aperçu","Initiatives","Missions","Tâches","Analytics"] },
+    { mode: "capacites", label: "Capacités",      sub: "Ce que Jarvis sait faire pour toi",      href: "/capabilities", chapter: "II",  pages: ["Intégrations","Skills","Routines","Ambiances","Store","Écosystème"] },
+    { mode: "config",    label: "Configuration",  sub: "Tes préférences et ton coffre",           href: "/settings",     chapter: "III", pages: ["Préférences","Modèles & API","Audio & voix","Conso","Système","À propos"] },
+  ];
+
+  function ensureMissionControl() {
+    if (mcRoot) return;
+    mcRoot = el("div", { class: "mission-overlay is-hidden", onclick: (e) => { if (e.target === mcRoot) Jarvis.closeMissionControl(); } });
+
+    // Header bar
+    const header = el("div", { class: "mc-header" });
+    header.appendChild(el("span", { class: "mc-header-title", text: "Mission Control" }));
+    const hint = el("span", { class: "mc-header-hint" });
+    const kbd1 = el("span", { class: "mc-hkbd" });
+    kbd1.appendChild(el("span", { text: "⌘" }));
+    kbd1.appendChild(el("span", { text: "T" }));
+    hint.appendChild(kbd1);
+    hint.appendChild(document.createTextNode(" pour fermer"));
+    hint.appendChild(el("span", { class: "mc-hdot", text: " · " }));
+    hint.appendChild(el("span", { class: "mc-hkbd", text: "ESC" }));
+    header.appendChild(hint);
+    header.appendChild(el("button", { class: "mc-close", onclick: () => Jarvis.closeMissionControl(), text: "×" }));
+    mcRoot.appendChild(header);
+
+    const grid = el("div", { class: "mission-grid" });
+    ROOMS.forEach(r => {
+      const card = el("button", {
+        class: "mission-card",
+        dataset: { mode: r.mode },
+        onclick: () => { Jarvis.closeMissionControl(); Jarvis.navigate(r.href); },
+      });
+      const eyebrow = el("div", { class: "mc-card-eyebrow" });
+      eyebrow.appendChild(el("span", { class: "mc-card-num", text: r.chapter }));
+      if (r.pages.length) eyebrow.appendChild(el("span", { text: r.pages.length + " SECTIONS" }));
+      card.appendChild(eyebrow);
+      card.appendChild(el("div", { class: "mc-card-title", text: r.label }));
+      card.appendChild(el("div", { class: "mc-card-sub",   text: r.sub }));
+      if (r.pages.length) {
+        const pagesEl = el("div", { class: "mc-card-pages" });
+        r.pages.forEach((p, i) => {
+          pagesEl.appendChild(el("span", { class: "mc-card-page" }, [
+            el("span", { class: "mc-pg-num", text: String(i + 1).padStart(2, "0") }),
+            el("span", { class: "mc-pg-lbl", text: p }),
+          ]));
+        });
+        card.appendChild(pagesEl);
+      }
+      grid.appendChild(card);
+    });
+    mcRoot.appendChild(grid);
+    document.body.appendChild(mcRoot);
+  }
+
+  Jarvis.openMissionControl = function () {
+    ensureMissionControl();
+    mcOpen = true;
+    mcRoot.classList.remove("is-hidden");
+  };
+  Jarvis.closeMissionControl = function () {
+    if (!mcRoot) return;
+    mcOpen = false;
+    mcRoot.classList.add("is-hidden");
+  };
+  */ // fin DEAD CODE
+
+
+  /* ───────── Legacy sidebar (still used on pages without rooms nav) ─────────
+     opts: sections, activeId, onNav, footer
+  */
+  Jarvis.mountSidebar = function (opts) {
+    const root = document.getElementById("sidebar") || el("aside", { id: "sidebar" });
+    if (!root.parentNode) document.querySelector(".app").prepend(root);
+    root.className = "sidebar";
+    root.innerHTML = "";
+
+    root.appendChild(el("div", { class: "sb-brand" }, [
+      brandMark(),
+      el("div", { class: "sb-brand-text" }, [
+        el("span", { class: "sb-brand-name", text: "Jarvis" }),
+        el("span", { class: "sb-brand-status", text: "Online · v4.2" }),
+      ]),
+    ]));
+
+    (opts.sections || []).forEach(sec => {
+      root.appendChild(el("div", { class: "sb-section-eyebrow" }, [
+        el("span", { text: sec.label }),
+        sec.right ? el("span", { text: sec.right, style: { color: "var(--fg-2)" } }) : null,
+      ]));
+      const nav = el("div", { class: "sb-nav" });
+      sec.items.forEach(it => {
+        const b = el("button", {
+          class: "sb-item" + (it.id === opts.activeId ? " is-on" : ""),
+          dataset: { id: it.id },
+          onclick: () => opts.onNav && opts.onNav(it.id),
+        }, [
+          el("span", { class: "sb-dot" }),
+          el("span", { text: it.label }),
+          it.meta ? el("span", { class: "sb-meta", text: it.meta }) : el("span"),
+        ]);
+        nav.appendChild(b);
+      });
+      root.appendChild(nav);
+    });
+
+    if (opts.footer) {
+      const f = el("div", { class: "sb-foot" });
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "Spend · 24h" }),
+        el("span", { text: opts.footer.spend || "—" }),
+      ]));
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "CPU" }),
+        el("span", { text: opts.footer.cpu || "—" }),
+      ]));
+      const bar = el("div", { class: "sb-foot-bar" });
+      bar.appendChild(el("div", { style: { width: ((opts.footer.ramPct || 0) * 100) + "%" } }));
+      f.appendChild(bar);
+      root.appendChild(f);
+    }
+    return root;
+  };
+
+  function brandMark() {
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", "26"); svg.setAttribute("height", "26"); svg.setAttribute("viewBox", "0 0 26 26");
+    const c = document.createElementNS(ns, "circle");
+    c.setAttribute("cx", "13"); c.setAttribute("cy", "13"); c.setAttribute("r", "11");
+    c.setAttribute("fill", "none"); c.setAttribute("stroke", "var(--accent)"); c.setAttribute("stroke-width", "1"); c.setAttribute("opacity", "0.8");
+    const c2 = document.createElementNS(ns, "circle");
+    c2.setAttribute("cx", "13"); c2.setAttribute("cy", "13"); c2.setAttribute("r", "5");
+    c2.setAttribute("fill", "var(--accent)"); c2.setAttribute("opacity", "0.18");
+    const c3 = document.createElementNS(ns, "circle");
+    c3.setAttribute("cx", "13"); c3.setAttribute("cy", "13"); c3.setAttribute("r", "1.6"); c3.setAttribute("fill", "var(--accent)");
+    svg.appendChild(c); svg.appendChild(c2); svg.appendChild(c3);
+    return svg;
+  }
+
+  /* ───────── Topbar ───────── */
+  Jarvis.mountTopbar = function (opts) {
+    const root = document.getElementById("topbar") || el("header", { id: "topbar", class: "topbar" });
+    root.className = "topbar";
+    root.innerHTML = "";
+
+    const t = new Date();
+    const tStr = String(t.getHours()).padStart(2, "0") + ":" + String(t.getMinutes()).padStart(2, "0");
+
+    root.appendChild(el("div", { class: "topbar-l" }, [
+      el("span", { class: "topbar-page-title", text: opts.pageTitle || "Dashboard" }),
+      el("span", { class: "topbar-crumb",      text: opts.crumb || "/ control" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-c" }, [
+      el("span", { class: "dot" }),
+      el("span", { text: "Online" }),
+      el("span", { class: "sep" }),
+      el("span", { text: tStr }),
+      el("span", { class: "sep" }),
+      el("span", { text: "Paris" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-r" }, [
+      el("button", { class: "tb-btn", onclick: () => Jarvis.openCmdK() }, [
+        el("span", { text: "Recherche" }),
+        el("span", { class: "kbd", text: "⌘K" }),
+      ]),
+      el("button", { class: "tb-btn", onclick: () => opts.onAsk && opts.onAsk() }, [
+        el("span", { text: "Ask Jarvis" }),
+      ]),
+    ]));
+
+    return root;
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Command palette (⌘K)
+  ───────────────────────────────────────────────────────────────────── */
+  let cmdkRoot = null, cmdkInput = null, cmdkList = null;
+  let cmdkCommands = [], cmdkSelected = 0, cmdkOpen = false;
+
+  // Seed with room navigation commands
+  const _navCmds = ROOMS.map(r => ({
+    kind: "nav", id: "goto-" + r.mode, group: "Aller à",
+    title: r.label, sub: r.href, glyph: "→",
+    run: () => { Jarvis.navigate(r.href); },
+  }));
+  cmdkCommands = _navCmds;
+
+  Jarvis.registerCommands = function (cmds) {
+    const ids = new Set(cmdkCommands.map(c => c.id));
+    cmds.forEach(c => { if (!ids.has(c.id)) cmdkCommands.push(c); });
+  };
+
+  function ensureCmdK() {
+    if (cmdkRoot) return;
+    cmdkRoot = el("div", { class: "cmdk-back is-hidden", onclick: (e) => { if (e.target === cmdkRoot) Jarvis.closeCmdK(); } });
+    const box = el("div", { class: "cmdk" });
+    const inputWrap = el("div", { class: "cmdk-input-wrap" });
+    const prefix = el("span", { class: "cmdk-prefix", text: ">", style: { display: "none" } });
+    cmdkInput = el("input", {
+      class: "cmdk-input",
+      placeholder: "Cherche · navigue · > commandes",
+      autocomplete: "off",
+      oninput: (e) => {
+        const v = e.target.value;
+        const slash = v.startsWith(">");
+        prefix.style.display = slash ? "block" : "none";
+        cmdkInput.classList.toggle("has-prefix", slash);
+        cmdkSelected = 0; renderCmdK(v);
+      },
+      onkeydown: (e) => {
+        if (e.key === "Escape")    { e.preventDefault(); Jarvis.closeCmdK(); }
+        if (e.key === "ArrowDown") { e.preventDefault(); cmdkSelected = Math.min(cmdkSelected + 1, currentResults().length - 1); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "ArrowUp")   { e.preventDefault(); cmdkSelected = Math.max(cmdkSelected - 1, 0); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "Enter")     { e.preventDefault(); execSelected(); }
+      },
+    });
+    inputWrap.appendChild(prefix); inputWrap.appendChild(cmdkInput);
+    cmdkList = el("div", { class: "cmdk-list" });
+    const foot = el("div", { class: "cmdk-foot" }, [
+      el("span", { text: "↑↓ naviguer · ↵ exécuter · esc fermer" }),
+      el("span", { text: "> pour commandes" }),
+    ]);
+    box.appendChild(inputWrap); box.appendChild(cmdkList); box.appendChild(foot);
+    cmdkRoot.appendChild(box);
+    document.body.appendChild(cmdkRoot);
+  }
+
+  Jarvis.openCmdK = function () {
+    ensureCmdK();
+    cmdkOpen = true;
+    cmdkRoot.classList.remove("is-hidden");
+    cmdkInput.value = ""; cmdkSelected = 0;
+    renderCmdK("");
+    setTimeout(() => cmdkInput.focus(), 30);
+  };
+  Jarvis.closeCmdK = function () {
+    if (!cmdkRoot) return;
+    cmdkOpen = false;
+    cmdkRoot.classList.add("is-hidden");
+  };
+
+  function currentResults() {
+    const v = cmdkInput.value.trim();
+    if (v.startsWith(">")) {
+      const q = v.slice(1).trim().toLowerCase();
+      if (q.startsWith("ask ")) {
+        const p = q.slice(4);
+        return [{ kind: "ask", id: "ask", title: 'Demander : "' + p + '"', glyph: "›", group: "Faire", run: () => _askJarvis(p) }];
+      }
+      const slash = cmdkCommands.filter(c => c.kind === "slash");
+      if (!q) return slash;
+      return slash.filter(c => c.title.toLowerCase().includes(q));
+    }
+    const q = v.toLowerCase();
+    const all = cmdkCommands.filter(c => c.kind !== "slash");
+    if (!q) return all;
+    return all.filter(c => (c.title + " " + (c.sub || "")).toLowerCase().includes(q));
+  }
+
+  function renderCmdK(_v, keepFocus) {
+    cmdkList.innerHTML = "";
+    const items = currentResults();
+    if (!items.length) {
+      cmdkList.appendChild(el("div", { class: "cmdk-empty", text: "Aucune commande" }));
+      return;
+    }
+    const groups = {};
+    items.forEach(it => { const g = it.group || "Navigation"; (groups[g] = groups[g] || []).push(it); });
+    let idx = 0;
+    Object.keys(groups).forEach(g => {
+      cmdkList.appendChild(el("div", { class: "cmdk-group-lbl", text: g }));
+      groups[g].forEach(it => {
+        const i = idx++;
+        const row = el("div", {
+          class: "cmdk-item" + (i === cmdkSelected ? " is-on" : ""),
+          onclick: () => { cmdkSelected = i; execSelected(); },
+          onmousemove: () => { if (cmdkSelected !== i) { cmdkSelected = i; renderCmdK(cmdkInput.value, true); } },
+        }, [
+          el("span", { class: "ck-glyph", text: it.glyph || "·" }),
+          el("div", {}, [
+            el("span", { text: it.title }),
+            it.sub ? el("span", { class: "ck-sub", text: it.sub }) : null,
+          ]),
+          it.kbd ? el("span", { class: "ck-kbd" }, it.kbd.split("+").map(k => el("span", { text: k }))) : el("span"),
+        ]);
+        cmdkList.appendChild(row);
+      });
+    });
+    if (keepFocus) cmdkInput.focus();
+  }
+
+  function execSelected() {
+    const it = currentResults()[cmdkSelected];
+    if (!it) return;
+    Jarvis.closeCmdK();
+    if (typeof it.run === "function") it.run();
+  }
+
+  async function _askJarvis(prompt) {
+    Jarvis.notify({ kind: "info", text: "Jarvis · réflexion…" });
+    try {
+      const r = await Jarvis.api.post("/api/agent/ask", { prompt });
+      Jarvis.notify({ kind: "success", text: (r.answer || r.text || "").slice(0, 240) });
+    } catch (err) {
+      Jarvis.notify({ kind: "error", text: "Échec : " + err.message });
+    }
+  }
+
+  /* ───────── Global keyboard shortcuts ───────── */
+  document.addEventListener("keydown", (e) => {
+    // ⌘K — palette
+    if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+      e.preventDefault();
+      cmdkOpen ? Jarvis.closeCmdK() : Jarvis.openCmdK();
+    }
+    // ⌘T — Mission Control
+    if ((e.metaKey || e.ctrlKey) && (e.key === "t" || e.key === "T")) {
+      e.preventDefault();
+      mcOpen ? Jarvis.closeMissionControl() : Jarvis.openMissionControl();
+    }
+    // Escape
+    if (e.key === "Escape") {
+      if (cmdkOpen) Jarvis.closeCmdK();
+      if (mcOpen)   Jarvis.closeMissionControl();
+    }
+  });
+
+  /* ───────── Inspector mode (Alt) ───────── */
+  let inspectHint = null;
+  function setInspect(on) {
+    document.documentElement.classList.toggle("inspect", on);
+    if (on && !inspectHint) {
+      inspectHint = el("div", { class: "inspect-hint" }, [
+        el("span", { class: "dot" }), el("span", { text: "INSPECTOR · ⌥" }),
+      ]);
+      document.body.appendChild(inspectHint);
+    } else if (!on && inspectHint) {
+      inspectHint.remove(); inspectHint = null;
+    }
+  }
+  document.addEventListener("keydown", (e) => { if (e.key === "Alt") setInspect(true); });
+  document.addEventListener("keyup",   (e) => { if (e.key === "Alt") setInspect(false); });
+  window.addEventListener("blur", () => setInspect(false));
+
+  /* ───────── Notification ribbon ───────── */
+  let notifStack = null;
+  Jarvis.notify = function ({ kind = "info", text = "" }) {
+    if (!notifStack) {
+      notifStack = el("div", { class: "notif-stack" });
+      document.body.appendChild(notifStack);
+    }
+    const cls = "notif" + (kind && kind !== "info" ? " notif--" + kind : "");
+    const node = el("div", { class: cls }, [
+      el("span", { class: "notif-mark" }),
+      el("div", { class: "notif-text", text }),
+      el("span", { class: "notif-time", text: "MAINT." }),
+    ]);
+    notifStack.appendChild(node);
+    setTimeout(() => node.remove(), 4400);
+    const sb = document.querySelector(".sidebar");
+    if (sb) {
+      const breath = el("div", { class: "sb-breath" });
+      sb.appendChild(breath);
+      setTimeout(() => breath.remove(), 1700);
+    }
+  };
+
+  /* ───────── Sparkline ───────── */
+  Jarvis.sparkline = function (data, opts) {
+    opts = opts || {};
+    const w = opts.width || 180, h = opts.height || 28;
+    const color = opts.color || "var(--accent)";
+    if (!data || !data.length) return el("svg", { width: w, height: h });
+    const min = Math.min(...data), max = Math.max(...data), range = max - min || 1;
+    const pts = data.map((v, i) => [
+      (i / (data.length - 1)) * w,
+      h - ((v - min) / range) * h * 0.85 - 2,
+    ]);
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", w); svg.setAttribute("height", h);
+    svg.setAttribute("viewBox", "0 0 " + w + " " + h);
+    const path = document.createElementNS(ns, "path");
+    path.setAttribute("d", pts.map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" "));
+    path.setAttribute("fill", "none"); path.setAttribute("stroke", color);
+    path.setAttribute("stroke-width", "1.4"); path.setAttribute("stroke-linecap", "round");
+    svg.appendChild(path);
+    const last = pts[pts.length - 1];
+    const dot = document.createElementNS(ns, "circle");
+    dot.setAttribute("cx", last[0]); dot.setAttribute("cy", last[1]);
+    dot.setAttribute("r", "2"); dot.setAttribute("fill", color);
+    svg.appendChild(dot);
+    return svg;
+  };
+
+  /* ───────── Bottom nav (legacy, conservé pour compat) ───────── */
+  Jarvis.mountBottomNav = function (opts) {
+    const existing = document.getElementById("j-bottom-nav");
+    if (existing) existing.remove();
+    // No-op in v2 — navigation handled by rooms system
+  };
+})();

--- a/src/jarvis/interfaces/ui/static/_shared.js.bak-1782257286
+++ b/src/jarvis/interfaces/ui/static/_shared.js.bak-1782257286
@@ -1,0 +1,777 @@
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS — Shared runtime v2 (vanilla JS, ES2017+)
+   Public API attached to window.Jarvis :
+
+     Jarvis.mountAtmosphere()
+     Jarvis.setMode(mode)                        → "home"|"workspace"|"capacites"|"config"
+     Jarvis.mountRooms({ mode, pages, activePage, onNav, onMissionControl })
+     Jarvis.mountTopbar({ pageTitle, crumb, onAsk, onCmdK })
+     Jarvis.openCmdK() / .closeCmdK()
+     Jarvis.openMissionControl() / .closeMissionControl()
+     Jarvis.registerCommands(arr)
+     Jarvis.notify({ kind, text })
+     Jarvis.api.get(path) / .post(path, body)
+     Jarvis.fmt.num(v) / .pct(v) / .relTime(d)
+     Jarvis.sparkline(data, opts)
+
+   Depends on _shared.css being loaded first.
+   ───────────────────────────────────────────────────────────────────── */
+
+(function () {
+  "use strict";
+
+  const Jarvis = (window.Jarvis = window.Jarvis || {});
+
+  /* ───────── Tiny DOM helpers ───────── */
+  function el(tag, attrs, children) {
+    const node = document.createElement(tag);
+    if (attrs) {
+      for (const k in attrs) {
+        const v = attrs[k];
+        if (v == null || v === false) continue;
+        if (k === "class")        node.className = v;
+        else if (k === "html")    node.innerHTML = v;
+        else if (k === "text")    node.textContent = v;
+        else if (k === "style" && typeof v === "object") Object.assign(node.style, v);
+        else if (k.startsWith("on") && typeof v === "function") node.addEventListener(k.slice(2).toLowerCase(), v);
+        else if (k === "dataset" && typeof v === "object") for (const dk in v) node.dataset[dk] = v[dk];
+        else node.setAttribute(k, v === true ? "" : v);
+      }
+    }
+    if (children != null) {
+      const arr = Array.isArray(children) ? children : [children];
+      for (const c of arr) {
+        if (c == null || c === false) continue;
+        node.appendChild(c.nodeType ? c : document.createTextNode(String(c)));
+      }
+    }
+    return node;
+  }
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $$(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
+  Jarvis.el = el; Jarvis.$ = $; Jarvis.$$ = $$;
+
+  /* ───────── Formatting ───────── */
+  Jarvis.fmt = {
+    num(v) {
+      if (v == null) return "—";
+      const n = Number(v);
+      if (!isFinite(n)) return String(v);
+      if (Math.abs(n) >= 1000) return n.toLocaleString("en-US", { maximumFractionDigits: 1 });
+      return n.toString();
+    },
+    pct(v, digits = 1) {
+      if (v == null) return "—";
+      return Number(v).toFixed(digits) + "%";
+    },
+    relTime(date) {
+      const d = date instanceof Date ? date : new Date(date);
+      const s = Math.round((Date.now() - d.getTime()) / 1000);
+      if (s < 60)   return "à l'instant";
+      if (s < 3600) return Math.floor(s / 60) + " min";
+      if (s < 86400) return Math.floor(s / 3600) + " h";
+      return Math.floor(s / 86400) + " j";
+    },
+  };
+
+  /* ───────── View registry ───────── */
+  Jarvis.views = {
+    _registry: {},
+    _active: null,
+
+    register(id, { meta, show, hide, command, gestures }) {
+      this._registry[id] = { meta: meta || {}, show, hide, command, gestures: gestures || null };
+    },
+
+    list() {
+      return Object.entries(this._registry).map(([id, v]) => ({ id, ...v.meta }));
+    },
+
+    activate(id, params) {
+      const view = this._registry[id];
+      if (!view) return;
+      if (this._active && this._active !== id) this.deactivate(this._active);
+      this._active = id;
+      view.show(params || {});
+    },
+
+    deactivate(id) {
+      const target = id || this._active;
+      if (!target) return;
+      const view = this._registry[target];
+      if (view) view.hide();
+      if (this._active === target) this._active = null;
+    },
+
+    dispatch(id, cmd, params) {
+      const view = this._registry[id];
+      if (view?.command) view.command(cmd, params || {});
+    },
+  };
+
+  /* ───────── API wrapper ───────── */
+  function authHeaders(extra) {
+    const headers = Object.assign({}, extra || {});
+    const token = window.JARVIS_API_TOKEN;
+    if (token) headers.Authorization = "Bearer " + token;
+    return headers;
+  }
+
+  Jarvis.api = {
+    base: window.JARVIS_API_BASE || "",
+    async get(path) {
+      const r = await fetch(this.base + path, {
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("GET " + path + " → " + r.status);
+      return r.json();
+    },
+    async post(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "POST", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("POST " + path + " → " + r.status);
+      return r.json();
+    },
+    async put(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PUT", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PUT " + path + " → " + r.status);
+      return r.json();
+    },
+    async patch(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PATCH", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PATCH " + path + " → " + r.status);
+      return r.json();
+    },
+    async delete(path) {
+      const r = await fetch(this.base + path, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("DELETE " + path + " → " + r.status);
+      return r.json();
+    },
+  };
+  Jarvis.authHeaders = authHeaders;
+
+  /* ───────── Navigation (iframe-aware) ───────── */
+  Jarvis.navigate = function (url) {
+    // Si on tourne dans l'iframe, déléguer au shell parent
+    if (window !== window.top && window.top.Jarvis?.navigateFrame) {
+      window.top.Jarvis.navigateFrame(url);
+      return;
+    }
+    // Si le shell home a enregistré un handler iframe
+    if (typeof Jarvis.navigateFrame === "function") {
+      Jarvis.navigateFrame(url);
+      return;
+    }
+    window.location.href = url;
+  };
+
+  /* ───────── Atmosphere ───────── */
+  Jarvis.mountAtmosphere = function () {
+    if (document.querySelector(".atmo--vignette")) return;
+    document.body.appendChild(el("div", { class: "spotlight", id: "j-spotlight" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--aurora" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--vignette" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--grain" }));
+    document.body.appendChild(el("div", { class: "mode-glow" }));
+
+    // Spotlight mouse tracking
+    document.addEventListener("mousemove", (e) => {
+      const sp = document.getElementById("j-spotlight");
+      if (sp) {
+        sp.style.setProperty("--mx", e.clientX + "px");
+        sp.style.setProperty("--my", e.clientY + "px");
+      }
+    }, { passive: true });
+  };
+
+  /* ───────── Mode system ───────── */
+  const MODE_META = {
+    home:       { chapter: "—",  num: "00", label: "JARVIS",        watermark: "" },
+    workspace:  { chapter: "I",  num: "01", label: "PILOTAGE",      watermark: "Pilotage" },
+    capacites:  { chapter: "II", num: "02", label: "ATELIER",       watermark: "Atelier" },
+    config:     { chapter: "III",num: "03", label: "RÉGLAGES",      watermark: "Réglages" },
+  };
+
+  Jarvis.setMode = function (mode) {
+    document.body.dataset.mode = mode;
+    // Watermark
+    let wm = document.getElementById("j-watermark");
+    const meta = MODE_META[mode] || MODE_META.home;
+    if (meta.watermark) {
+      if (!wm) {
+        wm = el("div", { id: "j-watermark", class: "mode-watermark" });
+        document.body.appendChild(wm);
+      }
+      wm.textContent = meta.watermark;
+    } else if (wm) {
+      wm.textContent = "";
+    }
+    // Chapter indicator
+    const ch = document.getElementById("j-rooms-chapter");
+    if (ch && meta.chapter !== "—") {
+      ch.querySelector(".rooms-num").textContent = meta.chapter;
+      ch.querySelector(".rooms-lbl").textContent = meta.label;
+    }
+  };
+
+  /* ───────── Scene card ───────── */
+  Jarvis.showSceneCard = function (chapter, title, duration) {
+    duration = duration || 900;
+    let sc = document.getElementById("j-scene-card");
+    if (!sc) {
+      sc = el("div", { id: "j-scene-card", class: "scene-card" });
+      const inner = el("div", { class: "scene-card-inner" }, [
+        el("div", { class: "scene-card-chapter", id: "j-sc-chapter" }),
+        el("div", { class: "scene-card-title",   id: "j-sc-title" }),
+      ]);
+      sc.appendChild(inner);
+      document.body.appendChild(sc);
+    }
+    sc.querySelector("#j-sc-chapter").textContent = chapter || "";
+    sc.querySelector("#j-sc-title").textContent   = title   || "";
+    sc.classList.add("is-visible");
+    setTimeout(() => {
+      sc.style.transition = "opacity .5s ease";
+      sc.style.opacity = "0";
+      setTimeout(() => { sc.classList.remove("is-visible"); sc.style.opacity = ""; sc.style.transition = ""; }, 520);
+    }, duration);
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Rooms navigation (chapter indicator + subpages editorial sidebar)
+  ───────────────────────────────────────────────────────────────────── */
+  let _roomsOpts = null;
+
+  Jarvis.mountRooms = function (opts) {
+    _roomsOpts = opts;
+    const { mode, pages, activePage, onNav } = opts;
+    document.body.dataset.mode = mode;
+
+    // ── Chapter indicator top-left ──
+    let ch = document.getElementById("j-rooms-chapter");
+    if (!ch) {
+      ch = el("div", { id: "j-rooms-chapter", class: "rooms-chapter" });
+      document.body.appendChild(ch);
+    }
+    const meta = MODE_META[mode] || MODE_META.home;
+    ch.innerHTML = "";
+    ch.appendChild(el("span", { class: "rooms-num", text: meta.chapter }));
+    ch.appendChild(el("span", { class: "rooms-bar" }));
+    ch.appendChild(el("span", { class: "rooms-lbl", text: meta.label }));
+
+    // ── Watermark ──
+    Jarvis.setMode(mode);
+
+    // ── Mission Control trigger bottom-left ──
+    let mc = document.getElementById("j-rooms-mc");
+    if (!mc) {
+      mc = el("button", { id: "j-rooms-mc", class: "rooms-mc", onclick: () => Jarvis.openMissionControl() });
+      mc.appendChild(el("span", { class: "mc-dot" }));
+      mc.appendChild(el("span", { text: "Mission Control" }));
+      const kbd = el("span", { class: "mc-kbd" });
+      kbd.appendChild(el("span", { text: "⌘" }));
+      kbd.appendChild(el("span", { text: "T" }));
+      mc.appendChild(kbd);
+      document.body.appendChild(mc);
+    }
+
+    // ── Subpages nav (editorial sidebar or bottom pill) ──
+    const isEditorial = mode !== "home";
+    if (isEditorial) {
+      document.body.dataset.subpages = "cocoon-wide-display";
+    } else {
+      delete document.body.dataset.subpages;
+    }
+
+    let nav = document.getElementById("j-rooms-pages");
+    if (!nav) {
+      nav = el("div", { id: "j-rooms-pages", class: "rooms-pages" });
+      document.body.appendChild(nav);
+    }
+    nav.dataset.modeLabel = meta.label;
+    nav.innerHTML = "";
+
+    (pages || []).forEach((p, idx) => {
+      const btn = el("button", {
+        dataset: { active: p.id === activePage ? "true" : "false" },
+        onclick: () => {
+          $$(".rooms-pages button", nav).forEach(b => b.dataset.active = "false");
+          btn.dataset.active = "true";
+          onNav && onNav(p.id);
+        },
+      });
+      btn.appendChild(el("span", { class: "num", text: String(idx + 1).padStart(2, "0") }));
+      btn.appendChild(el("span", { class: "lbl", text: p.label }));
+      nav.appendChild(btn);
+    });
+
+    // Keyboard ←/→ for subpage cycling
+    document.addEventListener("keydown", _handleRoomsKey, { once: false });
+  };
+
+  function _handleRoomsKey(e) {
+    if (cmdkOpen || mcOpen) return;
+    if (!_roomsOpts || !_roomsOpts.pages) return;
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    if (document.activeElement && ["INPUT","TEXTAREA"].includes(document.activeElement.tagName)) return;
+
+    const pages = _roomsOpts.pages;
+    const nav = document.getElementById("j-rooms-pages");
+    if (!nav) return;
+    const btns = $$("button", nav);
+    const curIdx = btns.findIndex(b => b.dataset.active === "true");
+    let next = e.key === "ArrowRight" ? curIdx + 1 : curIdx - 1;
+    next = Math.max(0, Math.min(next, pages.length - 1));
+    if (next === curIdx) return;
+    e.preventDefault();
+    btns.forEach(b => b.dataset.active = "false");
+    btns[next].dataset.active = "true";
+    _roomsOpts.onNav && _roomsOpts.onNav(pages[next].id);
+  }
+
+  /* ─────────────────────────────────────────────────────────────────
+     Mission Control overlay (⌘T)
+  ───────────────────────────────────────────────────────────────────── */
+  let mcRoot = null;
+  let mcOpen = false;
+
+  /* ── Mission Control v2 — délégué à mission_control.js ──────────────
+     Les stubs ci-dessous sont surchargés par mission_control.js au boot.
+     Conserver pour ne pas casser les pages qui chargent _shared.js seul.   */
+
+  Jarvis.openMissionControl = function () {
+    window.location.href = '/mc';
+  };
+  Jarvis.closeMissionControl = function () {};
+
+  /* ROOMS reste déclaré ici car utilisé par la palette ⌘K. */
+  const ROOMS = [
+    { mode: "home",      label: "Home",          sub: "Ambient · À l'écoute",             href: "/",             chapter: "—",   pages: [] },
+    { mode: "workspace", label: "Workspace",      sub: "Ce que tu pilotes en ce moment",   href: "/dashboard",    chapter: "I",   pages: ["Aperçu","Initiatives","Missions","Tâches","Analytics"] },
+    { mode: "capacites", label: "Capacités", sub: "Ce que Jarvis sait faire pour toi",href: "/capabilities", chapter: "II",  pages: ["Intégrations","Skills","Routines","Ambiances","Store","Écosystème"] },
+    { mode: "config",    label: "Configuration",  sub: "Tes préférences et ton coffre",    href: "/settings",     chapter: "III", pages: ["Préférences","Modèles & API","Audio & voix","Conso","Système","À propos"] },
+  ];
+
+  /* ── DEAD CODE ci-dessous — conservé pour référence, non exécuté ─────
+  function ensureMissionControl_LEGACY() {
+
+    { mode: "home",      label: "Home",          sub: "Ambient · À l'écoute",                  href: "/",             chapter: "—",   pages: [] },
+    { mode: "workspace", label: "Workspace",      sub: "Ce que tu pilotes en ce moment",         href: "/dashboard",    chapter: "I",   pages: ["Aperçu","Initiatives","Missions","Tâches","Analytics"] },
+    { mode: "capacites", label: "Capacités",      sub: "Ce que Jarvis sait faire pour toi",      href: "/capabilities", chapter: "II",  pages: ["Intégrations","Skills","Routines","Ambiances","Store","Écosystème"] },
+    { mode: "config",    label: "Configuration",  sub: "Tes préférences et ton coffre",           href: "/settings",     chapter: "III", pages: ["Préférences","Modèles & API","Audio & voix","Conso","Système","À propos"] },
+  ];
+
+  function ensureMissionControl() {
+    if (mcRoot) return;
+    mcRoot = el("div", { class: "mission-overlay is-hidden", onclick: (e) => { if (e.target === mcRoot) Jarvis.closeMissionControl(); } });
+
+    // Header bar
+    const header = el("div", { class: "mc-header" });
+    header.appendChild(el("span", { class: "mc-header-title", text: "Mission Control" }));
+    const hint = el("span", { class: "mc-header-hint" });
+    const kbd1 = el("span", { class: "mc-hkbd" });
+    kbd1.appendChild(el("span", { text: "⌘" }));
+    kbd1.appendChild(el("span", { text: "T" }));
+    hint.appendChild(kbd1);
+    hint.appendChild(document.createTextNode(" pour fermer"));
+    hint.appendChild(el("span", { class: "mc-hdot", text: " · " }));
+    hint.appendChild(el("span", { class: "mc-hkbd", text: "ESC" }));
+    header.appendChild(hint);
+    header.appendChild(el("button", { class: "mc-close", onclick: () => Jarvis.closeMissionControl(), text: "×" }));
+    mcRoot.appendChild(header);
+
+    const grid = el("div", { class: "mission-grid" });
+    ROOMS.forEach(r => {
+      const card = el("button", {
+        class: "mission-card",
+        dataset: { mode: r.mode },
+        onclick: () => { Jarvis.closeMissionControl(); Jarvis.navigate(r.href); },
+      });
+      const eyebrow = el("div", { class: "mc-card-eyebrow" });
+      eyebrow.appendChild(el("span", { class: "mc-card-num", text: r.chapter }));
+      if (r.pages.length) eyebrow.appendChild(el("span", { text: r.pages.length + " SECTIONS" }));
+      card.appendChild(eyebrow);
+      card.appendChild(el("div", { class: "mc-card-title", text: r.label }));
+      card.appendChild(el("div", { class: "mc-card-sub",   text: r.sub }));
+      if (r.pages.length) {
+        const pagesEl = el("div", { class: "mc-card-pages" });
+        r.pages.forEach((p, i) => {
+          pagesEl.appendChild(el("span", { class: "mc-card-page" }, [
+            el("span", { class: "mc-pg-num", text: String(i + 1).padStart(2, "0") }),
+            el("span", { class: "mc-pg-lbl", text: p }),
+          ]));
+        });
+        card.appendChild(pagesEl);
+      }
+      grid.appendChild(card);
+    });
+    mcRoot.appendChild(grid);
+    document.body.appendChild(mcRoot);
+  }
+
+  Jarvis.openMissionControl = function () {
+    ensureMissionControl();
+    mcOpen = true;
+    mcRoot.classList.remove("is-hidden");
+  };
+  Jarvis.closeMissionControl = function () {
+    if (!mcRoot) return;
+    mcOpen = false;
+    mcRoot.classList.add("is-hidden");
+  };
+  */ // fin DEAD CODE
+
+
+  /* ───────── Legacy sidebar (still used on pages without rooms nav) ─────────
+     opts: sections, activeId, onNav, footer
+  */
+  Jarvis.mountSidebar = function (opts) {
+    const root = document.getElementById("sidebar") || el("aside", { id: "sidebar" });
+    if (!root.parentNode) document.querySelector(".app").prepend(root);
+    root.className = "sidebar";
+    root.innerHTML = "";
+
+    root.appendChild(el("div", { class: "sb-brand" }, [
+      brandMark(),
+      el("div", { class: "sb-brand-text" }, [
+        el("span", { class: "sb-brand-name", text: "Jarvis" }),
+        el("span", { class: "sb-brand-status", text: "Online · v4.2" }),
+      ]),
+    ]));
+
+    (opts.sections || []).forEach(sec => {
+      root.appendChild(el("div", { class: "sb-section-eyebrow" }, [
+        el("span", { text: sec.label }),
+        sec.right ? el("span", { text: sec.right, style: { color: "var(--fg-2)" } }) : null,
+      ]));
+      const nav = el("div", { class: "sb-nav" });
+      sec.items.forEach(it => {
+        const b = el("button", {
+          class: "sb-item" + (it.id === opts.activeId ? " is-on" : ""),
+          dataset: { id: it.id },
+          onclick: () => opts.onNav && opts.onNav(it.id),
+        }, [
+          el("span", { class: "sb-dot" }),
+          el("span", { text: it.label }),
+          it.meta ? el("span", { class: "sb-meta", text: it.meta }) : el("span"),
+        ]);
+        nav.appendChild(b);
+      });
+      root.appendChild(nav);
+    });
+
+    if (opts.footer) {
+      const f = el("div", { class: "sb-foot" });
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "Spend · 24h" }),
+        el("span", { text: opts.footer.spend || "—" }),
+      ]));
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "CPU" }),
+        el("span", { text: opts.footer.cpu || "—" }),
+      ]));
+      const bar = el("div", { class: "sb-foot-bar" });
+      bar.appendChild(el("div", { style: { width: ((opts.footer.ramPct || 0) * 100) + "%" } }));
+      f.appendChild(bar);
+      root.appendChild(f);
+    }
+    return root;
+  };
+
+  function brandMark() {
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", "26"); svg.setAttribute("height", "26"); svg.setAttribute("viewBox", "0 0 26 26");
+    const c = document.createElementNS(ns, "circle");
+    c.setAttribute("cx", "13"); c.setAttribute("cy", "13"); c.setAttribute("r", "11");
+    c.setAttribute("fill", "none"); c.setAttribute("stroke", "var(--accent)"); c.setAttribute("stroke-width", "1"); c.setAttribute("opacity", "0.8");
+    const c2 = document.createElementNS(ns, "circle");
+    c2.setAttribute("cx", "13"); c2.setAttribute("cy", "13"); c2.setAttribute("r", "5");
+    c2.setAttribute("fill", "var(--accent)"); c2.setAttribute("opacity", "0.18");
+    const c3 = document.createElementNS(ns, "circle");
+    c3.setAttribute("cx", "13"); c3.setAttribute("cy", "13"); c3.setAttribute("r", "1.6"); c3.setAttribute("fill", "var(--accent)");
+    svg.appendChild(c); svg.appendChild(c2); svg.appendChild(c3);
+    return svg;
+  }
+
+  /* ───────── Topbar ───────── */
+  Jarvis.mountTopbar = function (opts) {
+    const root = document.getElementById("topbar") || el("header", { id: "topbar", class: "topbar" });
+    root.className = "topbar";
+    root.innerHTML = "";
+
+    const t = new Date();
+    const tStr = String(t.getHours()).padStart(2, "0") + ":" + String(t.getMinutes()).padStart(2, "0");
+
+    root.appendChild(el("div", { class: "topbar-l" }, [
+      el("span", { class: "topbar-page-title", text: opts.pageTitle || "Dashboard" }),
+      el("span", { class: "topbar-crumb",      text: opts.crumb || "/ control" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-c" }, [
+      el("span", { class: "dot" }),
+      el("span", { text: "Online" }),
+      el("span", { class: "sep" }),
+      el("span", { text: tStr }),
+      el("span", { class: "sep" }),
+      el("span", { text: "Paris" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-r" }, [
+      el("button", { class: "tb-btn", onclick: () => Jarvis.openCmdK() }, [
+        el("span", { text: "Recherche" }),
+        el("span", { class: "kbd", text: "⌘K" }),
+      ]),
+      el("button", { class: "tb-btn", onclick: () => opts.onAsk && opts.onAsk() }, [
+        el("span", { text: "Ask Jarvis" }),
+      ]),
+    ]));
+
+    return root;
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Command palette (⌘K)
+  ───────────────────────────────────────────────────────────────────── */
+  let cmdkRoot = null, cmdkInput = null, cmdkList = null;
+  let cmdkCommands = [], cmdkSelected = 0, cmdkOpen = false;
+
+  // Seed with room navigation commands
+  const _navCmds = ROOMS.map(r => ({
+    kind: "nav", id: "goto-" + r.mode, group: "Aller à",
+    title: r.label, sub: r.href, glyph: "→",
+    run: () => { Jarvis.navigate(r.href); },
+  }));
+  cmdkCommands = _navCmds;
+
+  Jarvis.registerCommands = function (cmds) {
+    const ids = new Set(cmdkCommands.map(c => c.id));
+    cmds.forEach(c => { if (!ids.has(c.id)) cmdkCommands.push(c); });
+  };
+
+  function ensureCmdK() {
+    if (cmdkRoot) return;
+    cmdkRoot = el("div", { class: "cmdk-back is-hidden", onclick: (e) => { if (e.target === cmdkRoot) Jarvis.closeCmdK(); } });
+    const box = el("div", { class: "cmdk" });
+    const inputWrap = el("div", { class: "cmdk-input-wrap" });
+    const prefix = el("span", { class: "cmdk-prefix", text: ">", style: { display: "none" } });
+    cmdkInput = el("input", {
+      class: "cmdk-input",
+      placeholder: "Cherche · navigue · > commandes",
+      autocomplete: "off",
+      oninput: (e) => {
+        const v = e.target.value;
+        const slash = v.startsWith(">");
+        prefix.style.display = slash ? "block" : "none";
+        cmdkInput.classList.toggle("has-prefix", slash);
+        cmdkSelected = 0; renderCmdK(v);
+      },
+      onkeydown: (e) => {
+        if (e.key === "Escape")    { e.preventDefault(); Jarvis.closeCmdK(); }
+        if (e.key === "ArrowDown") { e.preventDefault(); cmdkSelected = Math.min(cmdkSelected + 1, currentResults().length - 1); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "ArrowUp")   { e.preventDefault(); cmdkSelected = Math.max(cmdkSelected - 1, 0); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "Enter")     { e.preventDefault(); execSelected(); }
+      },
+    });
+    inputWrap.appendChild(prefix); inputWrap.appendChild(cmdkInput);
+    cmdkList = el("div", { class: "cmdk-list" });
+    const foot = el("div", { class: "cmdk-foot" }, [
+      el("span", { text: "↑↓ naviguer · ↵ exécuter · esc fermer" }),
+      el("span", { text: "> pour commandes" }),
+    ]);
+    box.appendChild(inputWrap); box.appendChild(cmdkList); box.appendChild(foot);
+    cmdkRoot.appendChild(box);
+    document.body.appendChild(cmdkRoot);
+  }
+
+  Jarvis.openCmdK = function () {
+    ensureCmdK();
+    cmdkOpen = true;
+    cmdkRoot.classList.remove("is-hidden");
+    cmdkInput.value = ""; cmdkSelected = 0;
+    renderCmdK("");
+    setTimeout(() => cmdkInput.focus(), 30);
+  };
+  Jarvis.closeCmdK = function () {
+    if (!cmdkRoot) return;
+    cmdkOpen = false;
+    cmdkRoot.classList.add("is-hidden");
+  };
+
+  function currentResults() {
+    const v = cmdkInput.value.trim();
+    if (v.startsWith(">")) {
+      const q = v.slice(1).trim().toLowerCase();
+      if (q.startsWith("ask ")) {
+        const p = q.slice(4);
+        return [{ kind: "ask", id: "ask", title: 'Demander : "' + p + '"', glyph: "›", group: "Faire", run: () => _askJarvis(p) }];
+      }
+      const slash = cmdkCommands.filter(c => c.kind === "slash");
+      if (!q) return slash;
+      return slash.filter(c => c.title.toLowerCase().includes(q));
+    }
+    const q = v.toLowerCase();
+    const all = cmdkCommands.filter(c => c.kind !== "slash");
+    if (!q) return all;
+    return all.filter(c => (c.title + " " + (c.sub || "")).toLowerCase().includes(q));
+  }
+
+  function renderCmdK(_v, keepFocus) {
+    cmdkList.innerHTML = "";
+    const items = currentResults();
+    if (!items.length) {
+      cmdkList.appendChild(el("div", { class: "cmdk-empty", text: "Aucune commande" }));
+      return;
+    }
+    const groups = {};
+    items.forEach(it => { const g = it.group || "Navigation"; (groups[g] = groups[g] || []).push(it); });
+    let idx = 0;
+    Object.keys(groups).forEach(g => {
+      cmdkList.appendChild(el("div", { class: "cmdk-group-lbl", text: g }));
+      groups[g].forEach(it => {
+        const i = idx++;
+        const row = el("div", {
+          class: "cmdk-item" + (i === cmdkSelected ? " is-on" : ""),
+          onclick: () => { cmdkSelected = i; execSelected(); },
+          onmousemove: () => { if (cmdkSelected !== i) { cmdkSelected = i; renderCmdK(cmdkInput.value, true); } },
+        }, [
+          el("span", { class: "ck-glyph", text: it.glyph || "·" }),
+          el("div", {}, [
+            el("span", { text: it.title }),
+            it.sub ? el("span", { class: "ck-sub", text: it.sub }) : null,
+          ]),
+          it.kbd ? el("span", { class: "ck-kbd" }, it.kbd.split("+").map(k => el("span", { text: k }))) : el("span"),
+        ]);
+        cmdkList.appendChild(row);
+      });
+    });
+    if (keepFocus) cmdkInput.focus();
+  }
+
+  function execSelected() {
+    const it = currentResults()[cmdkSelected];
+    if (!it) return;
+    Jarvis.closeCmdK();
+    if (typeof it.run === "function") it.run();
+  }
+
+  async function _askJarvis(prompt) {
+    Jarvis.notify({ kind: "info", text: "Jarvis · réflexion…" });
+    try {
+      const r = await Jarvis.api.post("/api/agent/ask", { prompt });
+      Jarvis.notify({ kind: "success", text: (r.answer || r.text || "").slice(0, 240) });
+    } catch (err) {
+      Jarvis.notify({ kind: "error", text: "Échec : " + err.message });
+    }
+  }
+
+  /* ───────── Global keyboard shortcuts ───────── */
+  document.addEventListener("keydown", (e) => {
+    // ⌘K — palette
+    if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+      e.preventDefault();
+      cmdkOpen ? Jarvis.closeCmdK() : Jarvis.openCmdK();
+    }
+    // ⌘T — Mission Control
+    if ((e.metaKey || e.ctrlKey) && (e.key === "t" || e.key === "T")) {
+      e.preventDefault();
+      mcOpen ? Jarvis.closeMissionControl() : Jarvis.openMissionControl();
+    }
+    // Escape
+    if (e.key === "Escape") {
+      if (cmdkOpen) Jarvis.closeCmdK();
+      if (mcOpen)   Jarvis.closeMissionControl();
+    }
+  });
+
+  /* ───────── Inspector mode (Alt) ───────── */
+  let inspectHint = null;
+  function setInspect(on) {
+    document.documentElement.classList.toggle("inspect", on);
+    if (on && !inspectHint) {
+      inspectHint = el("div", { class: "inspect-hint" }, [
+        el("span", { class: "dot" }), el("span", { text: "INSPECTOR · ⌥" }),
+      ]);
+      document.body.appendChild(inspectHint);
+    } else if (!on && inspectHint) {
+      inspectHint.remove(); inspectHint = null;
+    }
+  }
+  document.addEventListener("keydown", (e) => { if (e.key === "Alt") setInspect(true); });
+  document.addEventListener("keyup",   (e) => { if (e.key === "Alt") setInspect(false); });
+  window.addEventListener("blur", () => setInspect(false));
+
+  /* ───────── Notification ribbon ───────── */
+  let notifStack = null;
+  Jarvis.notify = function ({ kind = "info", text = "" }) {
+    if (!notifStack) {
+      notifStack = el("div", { class: "notif-stack" });
+      document.body.appendChild(notifStack);
+    }
+    const cls = "notif" + (kind && kind !== "info" ? " notif--" + kind : "");
+    const node = el("div", { class: cls }, [
+      el("span", { class: "notif-mark" }),
+      el("div", { class: "notif-text", text }),
+      el("span", { class: "notif-time", text: "MAINT." }),
+    ]);
+    notifStack.appendChild(node);
+    setTimeout(() => node.remove(), 4400);
+    const sb = document.querySelector(".sidebar");
+    if (sb) {
+      const breath = el("div", { class: "sb-breath" });
+      sb.appendChild(breath);
+      setTimeout(() => breath.remove(), 1700);
+    }
+  };
+
+  /* ───────── Sparkline ───────── */
+  Jarvis.sparkline = function (data, opts) {
+    opts = opts || {};
+    const w = opts.width || 180, h = opts.height || 28;
+    const color = opts.color || "var(--accent)";
+    if (!data || !data.length) return el("svg", { width: w, height: h });
+    const min = Math.min(...data), max = Math.max(...data), range = max - min || 1;
+    const pts = data.map((v, i) => [
+      (i / (data.length - 1)) * w,
+      h - ((v - min) / range) * h * 0.85 - 2,
+    ]);
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", w); svg.setAttribute("height", h);
+    svg.setAttribute("viewBox", "0 0 " + w + " " + h);
+    const path = document.createElementNS(ns, "path");
+    path.setAttribute("d", pts.map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" "));
+    path.setAttribute("fill", "none"); path.setAttribute("stroke", color);
+    path.setAttribute("stroke-width", "1.4"); path.setAttribute("stroke-linecap", "round");
+    svg.appendChild(path);
+    const last = pts[pts.length - 1];
+    const dot = document.createElementNS(ns, "circle");
+    dot.setAttribute("cx", last[0]); dot.setAttribute("cy", last[1]);
+    dot.setAttribute("r", "2"); dot.setAttribute("fill", color);
+    svg.appendChild(dot);
+    return svg;
+  };
+
+  /* ───────── Bottom nav (legacy, conservé pour compat) ───────── */
+  Jarvis.mountBottomNav = function (opts) {
+    const existing = document.getElementById("j-bottom-nav");
+    if (existing) existing.remove();
+    // No-op in v2 — navigation handled by rooms system
+  };
+})();

--- a/src/jarvis/interfaces/ui/static/_shared.js.bak-1782258059
+++ b/src/jarvis/interfaces/ui/static/_shared.js.bak-1782258059
@@ -1,0 +1,784 @@
+/* ─────────────────────────────────────────────────────────────────────
+   JARVIS — Shared runtime v2 (vanilla JS, ES2017+)
+   Public API attached to window.Jarvis :
+
+     Jarvis.mountAtmosphere()
+     Jarvis.setMode(mode)                        → "home"|"workspace"|"capacites"|"config"
+     Jarvis.mountRooms({ mode, pages, activePage, onNav, onMissionControl })
+     Jarvis.mountTopbar({ pageTitle, crumb, onAsk, onCmdK })
+     Jarvis.openCmdK() / .closeCmdK()
+     Jarvis.openMissionControl() / .closeMissionControl()
+     Jarvis.registerCommands(arr)
+     Jarvis.notify({ kind, text })
+     Jarvis.api.get(path) / .post(path, body)
+     Jarvis.fmt.num(v) / .pct(v) / .relTime(d)
+     Jarvis.sparkline(data, opts)
+
+   Depends on _shared.css being loaded first.
+   ───────────────────────────────────────────────────────────────────── */
+
+(function () {
+  "use strict";
+  /* Détection iframe — appliqué avant tout rendu */
+  if (window.self !== window.top) {
+    document.documentElement.classList.add('in-iframe');
+    document.addEventListener('DOMContentLoaded', function () {
+      document.body.classList.add('in-iframe');
+    });
+  }
+
+  const Jarvis = (window.Jarvis = window.Jarvis || {});
+
+  /* ───────── Tiny DOM helpers ───────── */
+  function el(tag, attrs, children) {
+    const node = document.createElement(tag);
+    if (attrs) {
+      for (const k in attrs) {
+        const v = attrs[k];
+        if (v == null || v === false) continue;
+        if (k === "class")        node.className = v;
+        else if (k === "html")    node.innerHTML = v;
+        else if (k === "text")    node.textContent = v;
+        else if (k === "style" && typeof v === "object") Object.assign(node.style, v);
+        else if (k.startsWith("on") && typeof v === "function") node.addEventListener(k.slice(2).toLowerCase(), v);
+        else if (k === "dataset" && typeof v === "object") for (const dk in v) node.dataset[dk] = v[dk];
+        else node.setAttribute(k, v === true ? "" : v);
+      }
+    }
+    if (children != null) {
+      const arr = Array.isArray(children) ? children : [children];
+      for (const c of arr) {
+        if (c == null || c === false) continue;
+        node.appendChild(c.nodeType ? c : document.createTextNode(String(c)));
+      }
+    }
+    return node;
+  }
+  function $(sel, root) { return (root || document).querySelector(sel); }
+  function $$(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
+  Jarvis.el = el; Jarvis.$ = $; Jarvis.$$ = $$;
+
+  /* ───────── Formatting ───────── */
+  Jarvis.fmt = {
+    num(v) {
+      if (v == null) return "—";
+      const n = Number(v);
+      if (!isFinite(n)) return String(v);
+      if (Math.abs(n) >= 1000) return n.toLocaleString("en-US", { maximumFractionDigits: 1 });
+      return n.toString();
+    },
+    pct(v, digits = 1) {
+      if (v == null) return "—";
+      return Number(v).toFixed(digits) + "%";
+    },
+    relTime(date) {
+      const d = date instanceof Date ? date : new Date(date);
+      const s = Math.round((Date.now() - d.getTime()) / 1000);
+      if (s < 60)   return "à l'instant";
+      if (s < 3600) return Math.floor(s / 60) + " min";
+      if (s < 86400) return Math.floor(s / 3600) + " h";
+      return Math.floor(s / 86400) + " j";
+    },
+  };
+
+  /* ───────── View registry ───────── */
+  Jarvis.views = {
+    _registry: {},
+    _active: null,
+
+    register(id, { meta, show, hide, command, gestures }) {
+      this._registry[id] = { meta: meta || {}, show, hide, command, gestures: gestures || null };
+    },
+
+    list() {
+      return Object.entries(this._registry).map(([id, v]) => ({ id, ...v.meta }));
+    },
+
+    activate(id, params) {
+      const view = this._registry[id];
+      if (!view) return;
+      if (this._active && this._active !== id) this.deactivate(this._active);
+      this._active = id;
+      view.show(params || {});
+    },
+
+    deactivate(id) {
+      const target = id || this._active;
+      if (!target) return;
+      const view = this._registry[target];
+      if (view) view.hide();
+      if (this._active === target) this._active = null;
+    },
+
+    dispatch(id, cmd, params) {
+      const view = this._registry[id];
+      if (view?.command) view.command(cmd, params || {});
+    },
+  };
+
+  /* ───────── API wrapper ───────── */
+  function authHeaders(extra) {
+    const headers = Object.assign({}, extra || {});
+    const token = window.JARVIS_API_TOKEN;
+    if (token) headers.Authorization = "Bearer " + token;
+    return headers;
+  }
+
+  Jarvis.api = {
+    base: window.JARVIS_API_BASE || "",
+    async get(path) {
+      const r = await fetch(this.base + path, {
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("GET " + path + " → " + r.status);
+      return r.json();
+    },
+    async post(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "POST", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("POST " + path + " → " + r.status);
+      return r.json();
+    },
+    async put(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PUT", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PUT " + path + " → " + r.status);
+      return r.json();
+    },
+    async patch(path, body) {
+      const r = await fetch(this.base + path, {
+        method: "PATCH", credentials: "same-origin",
+        headers: authHeaders({ "Content-Type": "application/json" }),
+        body: body == null ? null : JSON.stringify(body),
+      });
+      if (!r.ok) throw new Error("PATCH " + path + " → " + r.status);
+      return r.json();
+    },
+    async delete(path) {
+      const r = await fetch(this.base + path, {
+        method: "DELETE",
+        credentials: "same-origin",
+        headers: authHeaders(),
+      });
+      if (!r.ok) throw new Error("DELETE " + path + " → " + r.status);
+      return r.json();
+    },
+  };
+  Jarvis.authHeaders = authHeaders;
+
+  /* ───────── Navigation (iframe-aware) ───────── */
+  Jarvis.navigate = function (url) {
+    // Si on tourne dans l'iframe, déléguer au shell parent
+    if (window !== window.top && window.top.Jarvis?.navigateFrame) {
+      window.top.Jarvis.navigateFrame(url);
+      return;
+    }
+    // Si le shell home a enregistré un handler iframe
+    if (typeof Jarvis.navigateFrame === "function") {
+      Jarvis.navigateFrame(url);
+      return;
+    }
+    window.location.href = url;
+  };
+
+  /* ───────── Atmosphere ───────── */
+  Jarvis.mountAtmosphere = function () {
+    if (document.querySelector(".atmo--vignette")) return;
+    document.body.appendChild(el("div", { class: "spotlight", id: "j-spotlight" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--aurora" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--vignette" }));
+    document.body.appendChild(el("div", { class: "atmo atmo--grain" }));
+    document.body.appendChild(el("div", { class: "mode-glow" }));
+
+    // Spotlight mouse tracking
+    document.addEventListener("mousemove", (e) => {
+      const sp = document.getElementById("j-spotlight");
+      if (sp) {
+        sp.style.setProperty("--mx", e.clientX + "px");
+        sp.style.setProperty("--my", e.clientY + "px");
+      }
+    }, { passive: true });
+  };
+
+  /* ───────── Mode system ───────── */
+  const MODE_META = {
+    home:       { chapter: "—",  num: "00", label: "JARVIS",        watermark: "" },
+    workspace:  { chapter: "I",  num: "01", label: "PILOTAGE",      watermark: "Pilotage" },
+    capacites:  { chapter: "II", num: "02", label: "ATELIER",       watermark: "Atelier" },
+    config:     { chapter: "III",num: "03", label: "RÉGLAGES",      watermark: "Réglages" },
+  };
+
+  Jarvis.setMode = function (mode) {
+    document.body.dataset.mode = mode;
+    // Watermark
+    let wm = document.getElementById("j-watermark");
+    const meta = MODE_META[mode] || MODE_META.home;
+    if (meta.watermark) {
+      if (!wm) {
+        wm = el("div", { id: "j-watermark", class: "mode-watermark" });
+        document.body.appendChild(wm);
+      }
+      wm.textContent = meta.watermark;
+    } else if (wm) {
+      wm.textContent = "";
+    }
+    // Chapter indicator
+    const ch = document.getElementById("j-rooms-chapter");
+    if (ch && meta.chapter !== "—") {
+      ch.querySelector(".rooms-num").textContent = meta.chapter;
+      ch.querySelector(".rooms-lbl").textContent = meta.label;
+    }
+  };
+
+  /* ───────── Scene card ───────── */
+  Jarvis.showSceneCard = function (chapter, title, duration) {
+    duration = duration || 900;
+    let sc = document.getElementById("j-scene-card");
+    if (!sc) {
+      sc = el("div", { id: "j-scene-card", class: "scene-card" });
+      const inner = el("div", { class: "scene-card-inner" }, [
+        el("div", { class: "scene-card-chapter", id: "j-sc-chapter" }),
+        el("div", { class: "scene-card-title",   id: "j-sc-title" }),
+      ]);
+      sc.appendChild(inner);
+      document.body.appendChild(sc);
+    }
+    sc.querySelector("#j-sc-chapter").textContent = chapter || "";
+    sc.querySelector("#j-sc-title").textContent   = title   || "";
+    sc.classList.add("is-visible");
+    setTimeout(() => {
+      sc.style.transition = "opacity .5s ease";
+      sc.style.opacity = "0";
+      setTimeout(() => { sc.classList.remove("is-visible"); sc.style.opacity = ""; sc.style.transition = ""; }, 520);
+    }, duration);
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Rooms navigation (chapter indicator + subpages editorial sidebar)
+  ───────────────────────────────────────────────────────────────────── */
+  let _roomsOpts = null;
+
+  Jarvis.mountRooms = function (opts) {
+    _roomsOpts = opts;
+    const { mode, pages, activePage, onNav } = opts;
+    document.body.dataset.mode = mode;
+
+    // ── Chapter indicator top-left ──
+    let ch = document.getElementById("j-rooms-chapter");
+    if (!ch) {
+      ch = el("div", { id: "j-rooms-chapter", class: "rooms-chapter" });
+      document.body.appendChild(ch);
+    }
+    const meta = MODE_META[mode] || MODE_META.home;
+    ch.innerHTML = "";
+    ch.appendChild(el("span", { class: "rooms-num", text: meta.chapter }));
+    ch.appendChild(el("span", { class: "rooms-bar" }));
+    ch.appendChild(el("span", { class: "rooms-lbl", text: meta.label }));
+
+    // ── Watermark ──
+    Jarvis.setMode(mode);
+
+    // ── Mission Control trigger bottom-left ──
+    let mc = document.getElementById("j-rooms-mc");
+    if (!mc) {
+      mc = el("button", { id: "j-rooms-mc", class: "rooms-mc", onclick: () => Jarvis.openMissionControl() });
+      mc.appendChild(el("span", { class: "mc-dot" }));
+      mc.appendChild(el("span", { text: "Mission Control" }));
+      const kbd = el("span", { class: "mc-kbd" });
+      kbd.appendChild(el("span", { text: "⌘" }));
+      kbd.appendChild(el("span", { text: "T" }));
+      mc.appendChild(kbd);
+      document.body.appendChild(mc);
+    }
+
+    // ── Subpages nav (editorial sidebar or bottom pill) ──
+    const isEditorial = mode !== "home";
+    if (isEditorial) {
+      document.body.dataset.subpages = "cocoon-wide-display";
+    } else {
+      delete document.body.dataset.subpages;
+    }
+
+    let nav = document.getElementById("j-rooms-pages");
+    if (!nav) {
+      nav = el("div", { id: "j-rooms-pages", class: "rooms-pages" });
+      document.body.appendChild(nav);
+    }
+    nav.dataset.modeLabel = meta.label;
+    nav.innerHTML = "";
+
+    (pages || []).forEach((p, idx) => {
+      const btn = el("button", {
+        dataset: { active: p.id === activePage ? "true" : "false" },
+        onclick: () => {
+          $$(".rooms-pages button", nav).forEach(b => b.dataset.active = "false");
+          btn.dataset.active = "true";
+          onNav && onNav(p.id);
+        },
+      });
+      btn.appendChild(el("span", { class: "num", text: String(idx + 1).padStart(2, "0") }));
+      btn.appendChild(el("span", { class: "lbl", text: p.label }));
+      nav.appendChild(btn);
+    });
+
+    // Keyboard ←/→ for subpage cycling
+    document.addEventListener("keydown", _handleRoomsKey, { once: false });
+  };
+
+  function _handleRoomsKey(e) {
+    if (cmdkOpen || mcOpen) return;
+    if (!_roomsOpts || !_roomsOpts.pages) return;
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    if (document.activeElement && ["INPUT","TEXTAREA"].includes(document.activeElement.tagName)) return;
+
+    const pages = _roomsOpts.pages;
+    const nav = document.getElementById("j-rooms-pages");
+    if (!nav) return;
+    const btns = $$("button", nav);
+    const curIdx = btns.findIndex(b => b.dataset.active === "true");
+    let next = e.key === "ArrowRight" ? curIdx + 1 : curIdx - 1;
+    next = Math.max(0, Math.min(next, pages.length - 1));
+    if (next === curIdx) return;
+    e.preventDefault();
+    btns.forEach(b => b.dataset.active = "false");
+    btns[next].dataset.active = "true";
+    _roomsOpts.onNav && _roomsOpts.onNav(pages[next].id);
+  }
+
+  /* ─────────────────────────────────────────────────────────────────
+     Mission Control overlay (⌘T)
+  ───────────────────────────────────────────────────────────────────── */
+  let mcRoot = null;
+  let mcOpen = false;
+
+  /* ── Mission Control v2 — délégué à mission_control.js ──────────────
+     Les stubs ci-dessous sont surchargés par mission_control.js au boot.
+     Conserver pour ne pas casser les pages qui chargent _shared.js seul.   */
+
+  Jarvis.openMissionControl = function () {
+    window.location.href = '/mc';
+  };
+  Jarvis.closeMissionControl = function () {};
+
+  /* ROOMS reste déclaré ici car utilisé par la palette ⌘K. */
+  const ROOMS = [
+    { mode: "home",      label: "Home",          sub: "Ambient · À l'écoute",             href: "/",             chapter: "—",   pages: [] },
+    { mode: "workspace", label: "Workspace",      sub: "Ce que tu pilotes en ce moment",   href: "/dashboard",    chapter: "I",   pages: ["Aperçu","Initiatives","Missions","Tâches","Analytics"] },
+    { mode: "capacites", label: "Capacités", sub: "Ce que Jarvis sait faire pour toi",href: "/capabilities", chapter: "II",  pages: ["Intégrations","Skills","Routines","Ambiances","Store","Écosystème"] },
+    { mode: "config",    label: "Configuration",  sub: "Tes préférences et ton coffre",    href: "/settings",     chapter: "III", pages: ["Préférences","Modèles & API","Audio & voix","Conso","Système","À propos"] },
+  ];
+
+  /* ── DEAD CODE ci-dessous — conservé pour référence, non exécuté ─────
+  function ensureMissionControl_LEGACY() {
+
+    { mode: "home",      label: "Home",          sub: "Ambient · À l'écoute",                  href: "/",             chapter: "—",   pages: [] },
+    { mode: "workspace", label: "Workspace",      sub: "Ce que tu pilotes en ce moment",         href: "/dashboard",    chapter: "I",   pages: ["Aperçu","Initiatives","Missions","Tâches","Analytics"] },
+    { mode: "capacites", label: "Capacités",      sub: "Ce que Jarvis sait faire pour toi",      href: "/capabilities", chapter: "II",  pages: ["Intégrations","Skills","Routines","Ambiances","Store","Écosystème"] },
+    { mode: "config",    label: "Configuration",  sub: "Tes préférences et ton coffre",           href: "/settings",     chapter: "III", pages: ["Préférences","Modèles & API","Audio & voix","Conso","Système","À propos"] },
+  ];
+
+  function ensureMissionControl() {
+    if (mcRoot) return;
+    mcRoot = el("div", { class: "mission-overlay is-hidden", onclick: (e) => { if (e.target === mcRoot) Jarvis.closeMissionControl(); } });
+
+    // Header bar
+    const header = el("div", { class: "mc-header" });
+    header.appendChild(el("span", { class: "mc-header-title", text: "Mission Control" }));
+    const hint = el("span", { class: "mc-header-hint" });
+    const kbd1 = el("span", { class: "mc-hkbd" });
+    kbd1.appendChild(el("span", { text: "⌘" }));
+    kbd1.appendChild(el("span", { text: "T" }));
+    hint.appendChild(kbd1);
+    hint.appendChild(document.createTextNode(" pour fermer"));
+    hint.appendChild(el("span", { class: "mc-hdot", text: " · " }));
+    hint.appendChild(el("span", { class: "mc-hkbd", text: "ESC" }));
+    header.appendChild(hint);
+    header.appendChild(el("button", { class: "mc-close", onclick: () => Jarvis.closeMissionControl(), text: "×" }));
+    mcRoot.appendChild(header);
+
+    const grid = el("div", { class: "mission-grid" });
+    ROOMS.forEach(r => {
+      const card = el("button", {
+        class: "mission-card",
+        dataset: { mode: r.mode },
+        onclick: () => { Jarvis.closeMissionControl(); Jarvis.navigate(r.href); },
+      });
+      const eyebrow = el("div", { class: "mc-card-eyebrow" });
+      eyebrow.appendChild(el("span", { class: "mc-card-num", text: r.chapter }));
+      if (r.pages.length) eyebrow.appendChild(el("span", { text: r.pages.length + " SECTIONS" }));
+      card.appendChild(eyebrow);
+      card.appendChild(el("div", { class: "mc-card-title", text: r.label }));
+      card.appendChild(el("div", { class: "mc-card-sub",   text: r.sub }));
+      if (r.pages.length) {
+        const pagesEl = el("div", { class: "mc-card-pages" });
+        r.pages.forEach((p, i) => {
+          pagesEl.appendChild(el("span", { class: "mc-card-page" }, [
+            el("span", { class: "mc-pg-num", text: String(i + 1).padStart(2, "0") }),
+            el("span", { class: "mc-pg-lbl", text: p }),
+          ]));
+        });
+        card.appendChild(pagesEl);
+      }
+      grid.appendChild(card);
+    });
+    mcRoot.appendChild(grid);
+    document.body.appendChild(mcRoot);
+  }
+
+  Jarvis.openMissionControl = function () {
+    ensureMissionControl();
+    mcOpen = true;
+    mcRoot.classList.remove("is-hidden");
+  };
+  Jarvis.closeMissionControl = function () {
+    if (!mcRoot) return;
+    mcOpen = false;
+    mcRoot.classList.add("is-hidden");
+  };
+  */ // fin DEAD CODE
+
+
+  /* ───────── Legacy sidebar (still used on pages without rooms nav) ─────────
+     opts: sections, activeId, onNav, footer
+  */
+  Jarvis.mountSidebar = function (opts) {
+    const root = document.getElementById("sidebar") || el("aside", { id: "sidebar" });
+    if (!root.parentNode) document.querySelector(".app").prepend(root);
+    root.className = "sidebar";
+    root.innerHTML = "";
+
+    root.appendChild(el("div", { class: "sb-brand" }, [
+      brandMark(),
+      el("div", { class: "sb-brand-text" }, [
+        el("span", { class: "sb-brand-name", text: "Jarvis" }),
+        el("span", { class: "sb-brand-status", text: "Online · v4.2" }),
+      ]),
+    ]));
+
+    (opts.sections || []).forEach(sec => {
+      root.appendChild(el("div", { class: "sb-section-eyebrow" }, [
+        el("span", { text: sec.label }),
+        sec.right ? el("span", { text: sec.right, style: { color: "var(--fg-2)" } }) : null,
+      ]));
+      const nav = el("div", { class: "sb-nav" });
+      sec.items.forEach(it => {
+        const b = el("button", {
+          class: "sb-item" + (it.id === opts.activeId ? " is-on" : ""),
+          dataset: { id: it.id },
+          onclick: () => opts.onNav && opts.onNav(it.id),
+        }, [
+          el("span", { class: "sb-dot" }),
+          el("span", { text: it.label }),
+          it.meta ? el("span", { class: "sb-meta", text: it.meta }) : el("span"),
+        ]);
+        nav.appendChild(b);
+      });
+      root.appendChild(nav);
+    });
+
+    if (opts.footer) {
+      const f = el("div", { class: "sb-foot" });
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "Spend · 24h" }),
+        el("span", { text: opts.footer.spend || "—" }),
+      ]));
+      f.appendChild(el("div", { class: "sb-foot-row" }, [
+        el("span", { text: "CPU" }),
+        el("span", { text: opts.footer.cpu || "—" }),
+      ]));
+      const bar = el("div", { class: "sb-foot-bar" });
+      bar.appendChild(el("div", { style: { width: ((opts.footer.ramPct || 0) * 100) + "%" } }));
+      f.appendChild(bar);
+      root.appendChild(f);
+    }
+    return root;
+  };
+
+  function brandMark() {
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", "26"); svg.setAttribute("height", "26"); svg.setAttribute("viewBox", "0 0 26 26");
+    const c = document.createElementNS(ns, "circle");
+    c.setAttribute("cx", "13"); c.setAttribute("cy", "13"); c.setAttribute("r", "11");
+    c.setAttribute("fill", "none"); c.setAttribute("stroke", "var(--accent)"); c.setAttribute("stroke-width", "1"); c.setAttribute("opacity", "0.8");
+    const c2 = document.createElementNS(ns, "circle");
+    c2.setAttribute("cx", "13"); c2.setAttribute("cy", "13"); c2.setAttribute("r", "5");
+    c2.setAttribute("fill", "var(--accent)"); c2.setAttribute("opacity", "0.18");
+    const c3 = document.createElementNS(ns, "circle");
+    c3.setAttribute("cx", "13"); c3.setAttribute("cy", "13"); c3.setAttribute("r", "1.6"); c3.setAttribute("fill", "var(--accent)");
+    svg.appendChild(c); svg.appendChild(c2); svg.appendChild(c3);
+    return svg;
+  }
+
+  /* ───────── Topbar ───────── */
+  Jarvis.mountTopbar = function (opts) {
+    const root = document.getElementById("topbar") || el("header", { id: "topbar", class: "topbar" });
+    root.className = "topbar";
+    root.innerHTML = "";
+
+    const t = new Date();
+    const tStr = String(t.getHours()).padStart(2, "0") + ":" + String(t.getMinutes()).padStart(2, "0");
+
+    root.appendChild(el("div", { class: "topbar-l" }, [
+      el("span", { class: "topbar-page-title", text: opts.pageTitle || "Dashboard" }),
+      el("span", { class: "topbar-crumb",      text: opts.crumb || "/ control" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-c" }, [
+      el("span", { class: "dot" }),
+      el("span", { text: "Online" }),
+      el("span", { class: "sep" }),
+      el("span", { text: tStr }),
+      el("span", { class: "sep" }),
+      el("span", { text: "Paris" }),
+    ]));
+
+    root.appendChild(el("div", { class: "topbar-r" }, [
+      el("button", { class: "tb-btn", onclick: () => Jarvis.openCmdK() }, [
+        el("span", { text: "Recherche" }),
+        el("span", { class: "kbd", text: "⌘K" }),
+      ]),
+      el("button", { class: "tb-btn", onclick: () => opts.onAsk && opts.onAsk() }, [
+        el("span", { text: "Ask Jarvis" }),
+      ]),
+    ]));
+
+    return root;
+  };
+
+  /* ─────────────────────────────────────────────────────────────────
+     Command palette (⌘K)
+  ───────────────────────────────────────────────────────────────────── */
+  let cmdkRoot = null, cmdkInput = null, cmdkList = null;
+  let cmdkCommands = [], cmdkSelected = 0, cmdkOpen = false;
+
+  // Seed with room navigation commands
+  const _navCmds = ROOMS.map(r => ({
+    kind: "nav", id: "goto-" + r.mode, group: "Aller à",
+    title: r.label, sub: r.href, glyph: "→",
+    run: () => { Jarvis.navigate(r.href); },
+  }));
+  cmdkCommands = _navCmds;
+
+  Jarvis.registerCommands = function (cmds) {
+    const ids = new Set(cmdkCommands.map(c => c.id));
+    cmds.forEach(c => { if (!ids.has(c.id)) cmdkCommands.push(c); });
+  };
+
+  function ensureCmdK() {
+    if (cmdkRoot) return;
+    cmdkRoot = el("div", { class: "cmdk-back is-hidden", onclick: (e) => { if (e.target === cmdkRoot) Jarvis.closeCmdK(); } });
+    const box = el("div", { class: "cmdk" });
+    const inputWrap = el("div", { class: "cmdk-input-wrap" });
+    const prefix = el("span", { class: "cmdk-prefix", text: ">", style: { display: "none" } });
+    cmdkInput = el("input", {
+      class: "cmdk-input",
+      placeholder: "Cherche · navigue · > commandes",
+      autocomplete: "off",
+      oninput: (e) => {
+        const v = e.target.value;
+        const slash = v.startsWith(">");
+        prefix.style.display = slash ? "block" : "none";
+        cmdkInput.classList.toggle("has-prefix", slash);
+        cmdkSelected = 0; renderCmdK(v);
+      },
+      onkeydown: (e) => {
+        if (e.key === "Escape")    { e.preventDefault(); Jarvis.closeCmdK(); }
+        if (e.key === "ArrowDown") { e.preventDefault(); cmdkSelected = Math.min(cmdkSelected + 1, currentResults().length - 1); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "ArrowUp")   { e.preventDefault(); cmdkSelected = Math.max(cmdkSelected - 1, 0); renderCmdK(cmdkInput.value, true); }
+        if (e.key === "Enter")     { e.preventDefault(); execSelected(); }
+      },
+    });
+    inputWrap.appendChild(prefix); inputWrap.appendChild(cmdkInput);
+    cmdkList = el("div", { class: "cmdk-list" });
+    const foot = el("div", { class: "cmdk-foot" }, [
+      el("span", { text: "↑↓ naviguer · ↵ exécuter · esc fermer" }),
+      el("span", { text: "> pour commandes" }),
+    ]);
+    box.appendChild(inputWrap); box.appendChild(cmdkList); box.appendChild(foot);
+    cmdkRoot.appendChild(box);
+    document.body.appendChild(cmdkRoot);
+  }
+
+  Jarvis.openCmdK = function () {
+    ensureCmdK();
+    cmdkOpen = true;
+    cmdkRoot.classList.remove("is-hidden");
+    cmdkInput.value = ""; cmdkSelected = 0;
+    renderCmdK("");
+    setTimeout(() => cmdkInput.focus(), 30);
+  };
+  Jarvis.closeCmdK = function () {
+    if (!cmdkRoot) return;
+    cmdkOpen = false;
+    cmdkRoot.classList.add("is-hidden");
+  };
+
+  function currentResults() {
+    const v = cmdkInput.value.trim();
+    if (v.startsWith(">")) {
+      const q = v.slice(1).trim().toLowerCase();
+      if (q.startsWith("ask ")) {
+        const p = q.slice(4);
+        return [{ kind: "ask", id: "ask", title: 'Demander : "' + p + '"', glyph: "›", group: "Faire", run: () => _askJarvis(p) }];
+      }
+      const slash = cmdkCommands.filter(c => c.kind === "slash");
+      if (!q) return slash;
+      return slash.filter(c => c.title.toLowerCase().includes(q));
+    }
+    const q = v.toLowerCase();
+    const all = cmdkCommands.filter(c => c.kind !== "slash");
+    if (!q) return all;
+    return all.filter(c => (c.title + " " + (c.sub || "")).toLowerCase().includes(q));
+  }
+
+  function renderCmdK(_v, keepFocus) {
+    cmdkList.innerHTML = "";
+    const items = currentResults();
+    if (!items.length) {
+      cmdkList.appendChild(el("div", { class: "cmdk-empty", text: "Aucune commande" }));
+      return;
+    }
+    const groups = {};
+    items.forEach(it => { const g = it.group || "Navigation"; (groups[g] = groups[g] || []).push(it); });
+    let idx = 0;
+    Object.keys(groups).forEach(g => {
+      cmdkList.appendChild(el("div", { class: "cmdk-group-lbl", text: g }));
+      groups[g].forEach(it => {
+        const i = idx++;
+        const row = el("div", {
+          class: "cmdk-item" + (i === cmdkSelected ? " is-on" : ""),
+          onclick: () => { cmdkSelected = i; execSelected(); },
+          onmousemove: () => { if (cmdkSelected !== i) { cmdkSelected = i; renderCmdK(cmdkInput.value, true); } },
+        }, [
+          el("span", { class: "ck-glyph", text: it.glyph || "·" }),
+          el("div", {}, [
+            el("span", { text: it.title }),
+            it.sub ? el("span", { class: "ck-sub", text: it.sub }) : null,
+          ]),
+          it.kbd ? el("span", { class: "ck-kbd" }, it.kbd.split("+").map(k => el("span", { text: k }))) : el("span"),
+        ]);
+        cmdkList.appendChild(row);
+      });
+    });
+    if (keepFocus) cmdkInput.focus();
+  }
+
+  function execSelected() {
+    const it = currentResults()[cmdkSelected];
+    if (!it) return;
+    Jarvis.closeCmdK();
+    if (typeof it.run === "function") it.run();
+  }
+
+  async function _askJarvis(prompt) {
+    Jarvis.notify({ kind: "info", text: "Jarvis · réflexion…" });
+    try {
+      const r = await Jarvis.api.post("/api/agent/ask", { prompt });
+      Jarvis.notify({ kind: "success", text: (r.answer || r.text || "").slice(0, 240) });
+    } catch (err) {
+      Jarvis.notify({ kind: "error", text: "Échec : " + err.message });
+    }
+  }
+
+  /* ───────── Global keyboard shortcuts ───────── */
+  document.addEventListener("keydown", (e) => {
+    // ⌘K — palette
+    if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+      e.preventDefault();
+      cmdkOpen ? Jarvis.closeCmdK() : Jarvis.openCmdK();
+    }
+    // ⌘T — Mission Control
+    if ((e.metaKey || e.ctrlKey) && (e.key === "t" || e.key === "T")) {
+      e.preventDefault();
+      mcOpen ? Jarvis.closeMissionControl() : Jarvis.openMissionControl();
+    }
+    // Escape
+    if (e.key === "Escape") {
+      if (cmdkOpen) Jarvis.closeCmdK();
+      if (mcOpen)   Jarvis.closeMissionControl();
+    }
+  });
+
+  /* ───────── Inspector mode (Alt) ───────── */
+  let inspectHint = null;
+  function setInspect(on) {
+    document.documentElement.classList.toggle("inspect", on);
+    if (on && !inspectHint) {
+      inspectHint = el("div", { class: "inspect-hint" }, [
+        el("span", { class: "dot" }), el("span", { text: "INSPECTOR · ⌥" }),
+      ]);
+      document.body.appendChild(inspectHint);
+    } else if (!on && inspectHint) {
+      inspectHint.remove(); inspectHint = null;
+    }
+  }
+  document.addEventListener("keydown", (e) => { if (e.key === "Alt") setInspect(true); });
+  document.addEventListener("keyup",   (e) => { if (e.key === "Alt") setInspect(false); });
+  window.addEventListener("blur", () => setInspect(false));
+
+  /* ───────── Notification ribbon ───────── */
+  let notifStack = null;
+  Jarvis.notify = function ({ kind = "info", text = "" }) {
+    if (!notifStack) {
+      notifStack = el("div", { class: "notif-stack" });
+      document.body.appendChild(notifStack);
+    }
+    const cls = "notif" + (kind && kind !== "info" ? " notif--" + kind : "");
+    const node = el("div", { class: cls }, [
+      el("span", { class: "notif-mark" }),
+      el("div", { class: "notif-text", text }),
+      el("span", { class: "notif-time", text: "MAINT." }),
+    ]);
+    notifStack.appendChild(node);
+    setTimeout(() => node.remove(), 4400);
+    const sb = document.querySelector(".sidebar");
+    if (sb) {
+      const breath = el("div", { class: "sb-breath" });
+      sb.appendChild(breath);
+      setTimeout(() => breath.remove(), 1700);
+    }
+  };
+
+  /* ───────── Sparkline ───────── */
+  Jarvis.sparkline = function (data, opts) {
+    opts = opts || {};
+    const w = opts.width || 180, h = opts.height || 28;
+    const color = opts.color || "var(--accent)";
+    if (!data || !data.length) return el("svg", { width: w, height: h });
+    const min = Math.min(...data), max = Math.max(...data), range = max - min || 1;
+    const pts = data.map((v, i) => [
+      (i / (data.length - 1)) * w,
+      h - ((v - min) / range) * h * 0.85 - 2,
+    ]);
+    const ns = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(ns, "svg");
+    svg.setAttribute("width", w); svg.setAttribute("height", h);
+    svg.setAttribute("viewBox", "0 0 " + w + " " + h);
+    const path = document.createElementNS(ns, "path");
+    path.setAttribute("d", pts.map((p, i) => (i ? "L" : "M") + p[0].toFixed(1) + " " + p[1].toFixed(1)).join(" "));
+    path.setAttribute("fill", "none"); path.setAttribute("stroke", color);
+    path.setAttribute("stroke-width", "1.4"); path.setAttribute("stroke-linecap", "round");
+    svg.appendChild(path);
+    const last = pts[pts.length - 1];
+    const dot = document.createElementNS(ns, "circle");
+    dot.setAttribute("cx", last[0]); dot.setAttribute("cy", last[1]);
+    dot.setAttribute("r", "2"); dot.setAttribute("fill", color);
+    svg.appendChild(dot);
+    return svg;
+  };
+
+  /* ───────── Bottom nav (legacy, conservé pour compat) ───────── */
+  Jarvis.mountBottomNav = function (opts) {
+    const existing = document.getElementById("j-bottom-nav");
+    if (existing) existing.remove();
+    // No-op in v2 — navigation handled by rooms system
+  };
+})();

--- a/src/jarvis/interfaces/ui/static/admin.html
+++ b/src/jarvis/interfaces/ui/static/admin.html
@@ -756,5 +756,16 @@
   Promise.all([loadSessions(), loadMemory(), loadNotifications()]);
   setInterval(loadNotifications, 30_000);
 </script>
+<style>
+.jmc-home-btn-standalone{position:fixed;bottom:24px;left:24px;z-index:9000;
+background:rgba(15,20,31,0.9);border:0.5px solid rgba(220,232,255,0.10);
+border-radius:8px;color:rgba(220,232,255,0.5);width:36px;height:36px;
+display:flex;align-items:center;justify-content:center;
+text-decoration:none;opacity:.55;transition:opacity .15s,border-color .15s,color .15s;}
+.jmc-home-btn-standalone:hover{opacity:1;border-color:#4A9EFF;color:#4A9EFF;}
+</style>
+<a href="/" class="jmc-home-btn-standalone" title="Retour Home">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12L12 3l9 9"/><path d="M9 21V12h6v9"/></svg>
+</a>
 </body>
 </html>

--- a/src/jarvis/interfaces/ui/static/admin.html.bak-1782249020
+++ b/src/jarvis/interfaces/ui/static/admin.html.bak-1782249020
@@ -1,0 +1,760 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jarvis — Admin</title>
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:ital,wght@0,400;0,500;0,600&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:       #06080D;
+      --blue:     #2D7DD2;
+      --b1:       #4A9EFF;
+      --b2:       rgba(74,158,255,0.55);
+      --b3:       rgba(74,158,255,0.18);
+      --b4:       rgba(74,158,255,0.08);
+      --text:     #DCE8FF;
+      --dim:      rgba(170,195,230,0.55);
+      --muted:    rgba(100,130,175,0.40);
+      --green:    #36D399;
+      --red:      #F87171;
+      --panel:    rgba(5,8,22,0.78);
+      --glass:    rgba(8,13,32,0.72);
+    }
+
+    html, body {
+      width: 100%; height: 100%;
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'DM Sans', sans-serif;
+      font-size: 13px;
+      overflow: hidden;
+    }
+
+    /* grid */
+    body {
+      display: grid;
+      grid-template-rows: 56px 1fr;
+      grid-template-columns: 240px 1fr 292px;
+      grid-template-areas: "hd hd hd" "sb main rt";
+    }
+
+    /* subtle noise overlay */
+    body::before {
+      content: '';
+      position: fixed; inset: 0; z-index: 0; pointer-events: none;
+      opacity: 0.028;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+      background-size: 160px;
+    }
+
+    /* scrollbar */
+    ::-webkit-scrollbar { width: 3px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--b3); border-radius: 99px; }
+    * { scrollbar-width: thin; scrollbar-color: var(--b3) transparent; }
+
+    /* ═══ HEADER ════════════════════════════════════════════════ */
+    header {
+      grid-area: hd;
+      position: relative; z-index: 10;
+      display: flex; align-items: center; gap: 16px;
+      padding: 0 24px;
+      background: rgba(4,6,16,0.90);
+      border-bottom: 1px solid var(--b3);
+      backdrop-filter: blur(24px);
+    }
+
+    .brand {
+      font: 800 15px/1 'Syne', sans-serif;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: #fff;
+      text-shadow: 0 0 28px rgba(74,158,255,0.45);
+    }
+    .brand em {
+      font-style: normal;
+      color: var(--b1);
+    }
+
+    .hd-rule { flex: 0 0 1px; height: 20px; background: var(--b3); }
+
+    header a {
+      font: 500 10px/1 'DM Mono', monospace;
+      letter-spacing: 0.22em; text-transform: uppercase;
+      color: var(--muted); text-decoration: none;
+      transition: color .15s;
+    }
+    header a:hover { color: var(--b1); }
+
+    .pill-badge {
+      font: 500 10px/1 'DM Mono', monospace;
+      letter-spacing: 0.08em;
+      color: var(--b1);
+      background: var(--b4);
+      border: 1px solid var(--b3);
+      border-radius: 99px;
+      padding: 4px 12px;
+    }
+
+    /* ═══ SIDEBAR ════════════════════════════════════════════════ */
+    #sidebar {
+      grid-area: sb;
+      display: flex; flex-direction: column; overflow: hidden;
+      background: var(--panel);
+      border-right: 1px solid var(--b3);
+      backdrop-filter: blur(20px);
+    }
+
+    .col-hd {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 18px 18px 14px;
+      flex-shrink: 0;
+    }
+    .col-label {
+      font: 700 11px/1 'Syne', sans-serif;
+      letter-spacing: 0.22em; text-transform: uppercase;
+      color: var(--b1);
+    }
+    .col-rule {
+      height: 1px; background: var(--b3); margin: 0 18px 10px; flex-shrink: 0;
+    }
+
+    #session-list { flex: 1; overflow-y: auto; padding: 6px 10px 10px; display: flex; flex-direction: column; gap: 4px; }
+
+    .session-item {
+      padding: 11px 14px 10px;
+      border-radius: 12px;
+      border: 1px solid transparent;
+      cursor: pointer;
+      transition: background .15s, border-color .15s, box-shadow .15s;
+      background: transparent;
+    }
+    .session-item:hover {
+      background: var(--b4);
+      border-color: var(--b3);
+    }
+    .session-item.active {
+      background: rgba(45,125,210,0.10);
+      border-color: rgba(74,158,255,0.32);
+      box-shadow: 0 0 0 1px rgba(74,158,255,0.08) inset, 0 4px 20px rgba(74,158,255,0.06);
+    }
+    .s-date {
+      font: 600 12px/1 'DM Sans', sans-serif;
+      color: var(--text);
+    }
+    .s-id {
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--muted);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      margin-top: 4px;
+    }
+    .s-count {
+      display: inline-flex; align-items: center; gap: 5px;
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--b2);
+      margin-top: 5px;
+    }
+    .s-count::before {
+      content: '';
+      width: 4px; height: 4px; border-radius: 50%;
+      background: var(--b1); opacity: .5; flex-shrink: 0;
+    }
+
+    /* ═══ MAIN ═══════════════════════════════════════════════════ */
+    #main {
+      grid-area: main;
+      display: flex; flex-direction: column; overflow: hidden;
+      background: rgba(3,5,14,0.55);
+    }
+
+    /* tabs */
+    .tabs {
+      flex-shrink: 0;
+      display: flex; align-items: center;
+      padding: 12px 20px 0;
+      gap: 4px;
+      border-bottom: 1px solid var(--b3);
+      background: rgba(4,6,18,0.60);
+    }
+    .tab-btn {
+      padding: 8px 18px 10px;
+      background: none; border: none; outline: none;
+      border-radius: 10px 10px 0 0;
+      font: 600 10px/1 'DM Mono', monospace;
+      letter-spacing: 0.20em; text-transform: uppercase;
+      color: var(--muted);
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      transition: color .15s, border-color .15s, background .15s;
+    }
+    .tab-btn:hover:not(.active) { color: var(--dim); background: var(--b4); }
+    .tab-btn.active {
+      color: var(--b1);
+      border-bottom-color: var(--b1);
+      background: rgba(74,158,255,0.05);
+    }
+
+    .tab-content { display: none; flex: 1; overflow: hidden; min-height: 0; }
+    .tab-content.active { display: flex; flex-direction: column; }
+
+    /* placeholder */
+    #session-placeholder {
+      flex: 1; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 12px;
+    }
+    .placeholder-icon {
+      font-size: 32px; opacity: .15;
+    }
+    #session-placeholder p {
+      font: 500 10px/1 'DM Mono', monospace;
+      letter-spacing: 0.24em; text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    /* session view */
+    #session-view {
+      flex: 1; overflow-y: auto;
+      padding: 20px 24px;
+      display: flex; flex-direction: column; gap: 14px;
+    }
+
+    .msg-row { display: flex; flex-direction: column; gap: 5px; }
+    .msg-meta {
+      display: flex; align-items: center; gap: 8px;
+      padding: 0 4px;
+    }
+    .msg-role-tag {
+      font: 500 9px/1 'DM Mono', monospace;
+      letter-spacing: 0.20em; text-transform: uppercase;
+      color: var(--muted);
+    }
+    .msg-time {
+      font: 400 9px/1 'DM Mono', monospace;
+      color: var(--muted); opacity: .7;
+    }
+    .msg-content {
+      background: var(--glass);
+      border: 1px solid rgba(74,158,255,0.09);
+      border-radius: 14px;
+      padding: 12px 16px;
+      white-space: pre-wrap; word-break: break-word;
+      font: 400 12.5px/1.65 'DM Sans', sans-serif;
+      color: var(--text);
+    }
+    .msg-row.user .msg-role-tag { color: var(--b2); }
+    .msg-row.user .msg-content {
+      background: rgba(45,125,210,0.07);
+      border-color: rgba(74,158,255,0.20);
+    }
+
+    /* ── Memory tab ─────────────────────────────────────────── */
+    #memory-tab { overflow-y: auto; flex-direction: column; padding: 20px 24px; gap: 24px; min-height: 0; }
+
+    .mem-block { display: flex; flex-direction: column; gap: 10px; }
+
+    .mem-block-hd {
+      display: flex; align-items: center; gap: 10px;
+    }
+    .mem-block-label {
+      font: 700 10px/1 'Syne', sans-serif;
+      letter-spacing: 0.26em; text-transform: uppercase;
+      color: var(--b1);
+    }
+    .mem-block-rule { flex: 1; height: 1px; background: var(--b3); }
+
+    textarea.mem-editor {
+      width: 100%;
+      background: var(--glass);
+      border: 1px solid var(--b3);
+      border-radius: 14px;
+      padding: 14px 16px;
+      color: var(--text);
+      font: 400 12px/1.65 'DM Mono', monospace;
+      resize: vertical; min-height: 100px;
+      outline: none;
+      transition: border-color .18s, box-shadow .18s;
+      box-sizing: border-box;
+    }
+    textarea.mem-editor:focus {
+      border-color: rgba(74,158,255,0.42);
+      box-shadow: 0 0 0 3px rgba(74,158,255,0.06);
+    }
+
+    .btn-row { display: flex; gap: 8px; }
+
+    .btn {
+      font: 600 9px/1 'DM Mono', monospace;
+      letter-spacing: 0.20em; text-transform: uppercase;
+      border: 1px solid var(--b3);
+      border-radius: 99px;
+      padding: 7px 18px;
+      background: var(--b4);
+      color: var(--dim);
+      cursor: pointer;
+      transition: all .15s;
+    }
+    .btn:hover { border-color: var(--b1); color: var(--b1); background: rgba(74,158,255,0.10); }
+    .btn.primary {
+      background: rgba(45,125,210,0.16);
+      border-color: rgba(74,158,255,0.36);
+      color: var(--b1);
+    }
+    .btn.primary:hover {
+      background: rgba(45,125,210,0.28);
+      border-color: var(--b1);
+      color: #fff;
+      box-shadow: 0 0 18px rgba(74,158,255,0.14);
+    }
+
+    .topic-row {
+      display: flex; align-items: center; gap: 8px;
+      padding: 9px 14px;
+      border-radius: 10px;
+      border: 1px solid transparent;
+      transition: background .12s, border-color .12s;
+    }
+    .topic-row:hover { background: var(--b4); border-color: var(--b3); }
+    .topic-name { flex: 1; font: 500 12px/1 'DM Sans', sans-serif; color: var(--text); }
+    .topic-meta { font: 400 10px/1 'DM Mono', monospace; color: var(--muted); }
+
+    .topic-editor-wrap {
+      display: none;
+      padding: 0 14px 12px;
+      flex-direction: column; gap: 8px;
+    }
+    .topic-editor-wrap.open { display: flex; }
+
+    /* buttons */
+    .btn-sm { font: 600 9px/1 'DM Mono', monospace; letter-spacing: 0.18em; text-transform: uppercase; border: 1px solid var(--b3); border-radius: 99px; padding: 6px 16px; background: var(--b4); color: var(--dim); cursor: pointer; transition: all .15s; white-space: nowrap; }
+    .btn-sm:hover { border-color: var(--b1); color: var(--b1); background: rgba(74,158,255,0.10); }
+    .btn-save { background: rgba(45,125,210,0.16); border-color: rgba(74,158,255,0.36); color: var(--b1); }
+    .btn-save:hover { background: rgba(45,125,210,0.28); border-color: var(--b1); color: #fff; }
+
+    .btn-icon {
+      width: 28px; height: 28px;
+      padding: 0; display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0;
+      font-size: 14px; letter-spacing: 0;
+    }
+    .btn-del {
+      border-color: rgba(255,80,80,0.20);
+      color: rgba(255,100,100,0.50);
+      background: transparent;
+    }
+    .btn-del:hover {
+      border-color: rgba(255,80,80,0.55);
+      color: rgba(255,100,100,1);
+      background: rgba(255,60,60,0.08);
+    }
+
+    .topic-actions { display: flex; gap: 6px; align-items: center; flex-shrink: 0; }
+
+    /* ── Tasks tab ──────────────────────────────────────────── */
+    #tasks-tab { overflow-y: auto; flex-direction: column; padding: 20px 24px; gap: 24px; }
+
+    .mem-section { display: flex; flex-direction: column; gap: 12px; }
+    .mem-section h3 {
+      display: flex; align-items: center; gap: 10px;
+      font: 700 10px/1 'Syne', sans-serif;
+      letter-spacing: 0.26em; text-transform: uppercase;
+      color: var(--b1);
+    }
+    .mem-section h3::after { content: ''; flex: 1; height: 1px; background: var(--b3); }
+
+    .job-card {
+      background: var(--glass);
+      border: 1px solid var(--b3);
+      border-radius: 14px;
+      padding: 14px 18px;
+      display: flex; flex-direction: column; gap: 4px;
+    }
+    .job-name { font: 600 13px/1 'DM Sans', sans-serif; color: var(--text); }
+    .job-meta { font: 400 11px/1.4 'DM Sans', sans-serif; color: var(--dim); }
+    .job-next { font: 400 10px/1 'DM Mono', monospace; color: var(--green); margin-top: 2px; }
+
+    .history-row {
+      display: grid; grid-template-columns: 1fr auto;
+      gap: 4px 12px;
+      padding: 11px 14px;
+      border-radius: 10px;
+      border: 1px solid transparent;
+      transition: background .12s, border-color .12s;
+    }
+    .history-row:hover { background: var(--b4); border-color: var(--b3); }
+    .history-instr { font: 500 12px/1 'DM Sans', sans-serif; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .history-time  { font: 400 10px/1 'DM Mono', monospace; color: var(--muted); text-align: right; }
+    .history-result { grid-column: 1/-1; font: 400 11px/1.5 'DM Sans', sans-serif; color: var(--dim); white-space: pre-wrap; }
+    .history-err   { color: var(--red); }
+    .notif-empty   { font: 400 10px/1 'DM Mono', monospace; letter-spacing: .18em; text-transform: uppercase; color: var(--muted); text-align: center; padding: 28px 0; }
+
+    /* ═══ RIGHT PANEL ════════════════════════════════════════════ */
+    #right {
+      grid-area: rt;
+      display: flex; flex-direction: column; overflow: hidden;
+      background: var(--panel);
+      border-left: 1px solid var(--b3);
+      backdrop-filter: blur(20px);
+    }
+
+    #notif-list {
+      flex: 1; overflow-y: auto;
+      padding: 10px 12px;
+      display: flex; flex-direction: column; gap: 6px;
+    }
+
+    .notif-card {
+      background: var(--glass);
+      border: 1px solid rgba(74,158,255,0.09);
+      border-radius: 12px;
+      padding: 11px 14px;
+    }
+    .notif-card p { font: 400 12px/1.5 'DM Sans', sans-serif; color: var(--text); }
+    .notif-time { font: 400 9px/1 'DM Mono', monospace; color: var(--muted); margin-top: 5px; }
+
+    .refresh-btn {
+      background: none; border: none;
+      color: var(--muted); font-size: 15px;
+      cursor: pointer; padding: 2px 4px; line-height: 1;
+      transition: color .15s, transform .2s;
+    }
+    .refresh-btn:hover { color: var(--b1); transform: rotate(60deg); }
+  </style>
+</head>
+<body>
+
+<header>
+  <span class="brand">Jarvis <em>Admin</em></span>
+  <div class="hd-rule"></div>
+  <a href="/">← Chat</a>
+  <span class="pill-badge" id="session-count">0 sessions</span>
+  <span class="pill-badge" id="topic-count">0 topics</span>
+</header>
+
+<nav id="sidebar">
+  <div class="col-hd">
+    <span class="col-label">Sessions</span>
+  </div>
+  <div class="col-rule"></div>
+  <div id="session-list"></div>
+</nav>
+
+<main id="main">
+  <div class="tabs">
+    <button class="tab-btn active" data-tab="sessions-tab">Session</button>
+    <button class="tab-btn" data-tab="memory-tab">Mémoire</button>
+    <button class="tab-btn" data-tab="tasks-tab">Tâches</button>
+  </div>
+
+  <div class="tab-content active" id="sessions-tab">
+    <div id="session-placeholder">
+      <div class="placeholder-icon">◈</div>
+      <p>Sélectionne une session</p>
+    </div>
+    <div id="session-view" style="display:none"></div>
+  </div>
+
+  <div class="tab-content" id="memory-tab">
+    <div class="mem-block">
+      <div class="mem-block-hd">
+        <span class="mem-block-label">Memory.md</span>
+        <div class="mem-block-rule"></div>
+      </div>
+      <textarea class="mem-editor" id="index-editor" rows="7"></textarea>
+      <div><button class="btn-sm btn-save" id="save-index">Sauvegarder</button></div>
+    </div>
+    <div class="mem-block">
+      <div class="mem-block-hd">
+        <span class="mem-block-label">Préférences</span>
+        <div class="mem-block-rule"></div>
+      </div>
+      <textarea class="mem-editor" id="prefs-editor" rows="5"></textarea>
+      <div><button class="btn-sm btn-save" id="save-prefs">Sauvegarder</button></div>
+    </div>
+    <div class="mem-block">
+      <div class="mem-block-hd">
+        <span class="mem-block-label">Fichiers thématiques</span>
+        <div class="mem-block-rule"></div>
+      </div>
+      <div id="topic-list"></div>
+    </div>
+  </div>
+
+  <div class="tab-content" id="tasks-tab">
+    <div style="padding:20px 24px;overflow-y:auto;flex:1;display:flex;flex-direction:column;gap:20px;">
+      <div class="mem-section">
+        <h3>Jobs planifiés</h3>
+        <div id="scheduler-list"></div>
+      </div>
+      <div class="mem-section">
+        <h3>Historique background</h3>
+        <div id="history-list"></div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<aside id="right">
+  <div class="col-hd">
+    <span class="col-label">Notifications</span>
+    <button class="refresh-btn" id="refresh-notifs" title="Rafraîchir">↻</button>
+  </div>
+  <div class="col-rule"></div>
+  <div id="notif-list"></div>
+</aside>
+
+<script>
+  const API = '/admin/api';
+
+  async function api(path, opts = {}) {
+    const res = await fetch(API + path, opts);
+    if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+    return res.json();
+  }
+
+  function fmtTime(iso) {
+    if (!iso) return '—';
+    try { return new Date(iso).toLocaleString('fr-FR', { hour:'2-digit', minute:'2-digit', day:'2-digit', month:'2-digit' }); }
+    catch { return iso; }
+  }
+
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+      btn.classList.add('active');
+      document.getElementById(btn.dataset.tab).classList.add('active');
+      if (btn.dataset.tab === 'tasks-tab') loadTasks();
+    });
+  });
+
+  let currentSessionId = null;
+
+  async function loadSessions() {
+    const sessions = await api('/sessions');
+    document.getElementById('session-count').textContent = sessions.length + ' sessions';
+    const list = document.getElementById('session-list');
+    list.innerHTML = '';
+    sessions.forEach(s => {
+      const div = document.createElement('div');
+      div.className = 'session-item';
+      div.dataset.id = s.session_id;
+      div.innerHTML = `
+        <div class="s-date">${s.date}</div>
+        <div class="s-id">${s.session_id.slice(0, 16)}…</div>
+        <div class="s-count">${s.message_count} messages</div>
+      `;
+      div.addEventListener('click', () => openSession(s.session_id, div));
+      list.appendChild(div);
+    });
+  }
+
+  async function openSession(sessionId, el) {
+    currentSessionId = sessionId;
+    document.querySelectorAll('.session-item').forEach(i => i.classList.remove('active'));
+    el.classList.add('active');
+    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+    document.querySelector('[data-tab="sessions-tab"]').classList.add('active');
+    document.getElementById('sessions-tab').classList.add('active');
+
+    const messages = await api(`/sessions/${sessionId}`);
+    const placeholder = document.getElementById('session-placeholder');
+    const view = document.getElementById('session-view');
+    placeholder.style.display = 'none';
+    view.style.display = 'flex';
+    view.innerHTML = '';
+    messages.forEach(m => {
+      const row = document.createElement('div');
+      row.className = `msg-row ${m.role}`;
+      row.innerHTML = `
+        <div class="msg-meta">
+          <span class="msg-role-tag">${m.role}</span>
+          <span class="msg-time">${fmtTime(m.ts)}</span>
+        </div>
+        <div class="msg-content">${escHtml(m.content)}</div>
+      `;
+      view.appendChild(row);
+    });
+    view.scrollTop = view.scrollHeight;
+  }
+
+  async function loadMemory() {
+    const data = await api('/memory');
+    document.getElementById('topic-count').textContent = data.topics.length + ' topics';
+    document.getElementById('index-editor').value = data.index;
+    document.getElementById('prefs-editor').value = data.user_prefs;
+
+    const list = document.getElementById('topic-list');
+    list.innerHTML = '';
+    data.topics.forEach(t => {
+      const wrap = document.createElement('div');
+      wrap.dataset.topic = t.name;
+      wrap.innerHTML = `
+        <div class="topic-row">
+          <span class="topic-name">${escHtml(t.name)}</span>
+          <span class="topic-meta">${escHtml(t.mtime)} · ${t.size}o</span>
+          <div class="topic-actions">
+            <button class="btn-sm topic-edit-btn" data-name="${escHtml(t.name)}">Éditer</button>
+            <button class="btn-sm btn-icon btn-del topic-del-btn" data-name="${escHtml(t.name)}" title="Supprimer">✕</button>
+          </div>
+        </div>
+        <div class="topic-editor-wrap" id="editor-${cssId(t.name)}">
+          <textarea class="mem-editor topic-ta" rows="12" data-name="${escHtml(t.name)}"></textarea>
+          <div class="btn-row">
+            <button class="btn-sm btn-save topic-save-btn" data-name="${escHtml(t.name)}">Sauvegarder</button>
+            <button class="btn-sm topic-close-btn" data-name="${escHtml(t.name)}">Fermer</button>
+          </div>
+        </div>
+      `;
+      list.appendChild(wrap);
+
+      const editBtn = wrap.querySelector('.topic-edit-btn');
+      const closeBtn = wrap.querySelector('.topic-close-btn');
+      const delBtn = wrap.querySelector('.topic-del-btn');
+      const saveBtn = wrap.querySelector('.topic-save-btn');
+      const editorWrap = wrap.querySelector('.topic-editor-wrap');
+      const ta = wrap.querySelector('.topic-ta');
+
+      editBtn.addEventListener('click', async () => {
+        if (editorWrap.classList.contains('open')) {
+          editorWrap.classList.remove('open');
+          editBtn.textContent = 'Éditer';
+          return;
+        }
+        editBtn.textContent = '…';
+        editBtn.disabled = true;
+        try {
+          const { content } = await api('/memory/topics/' + encodeURIComponent(t.name));
+          ta.value = content;
+          editorWrap.classList.add('open');
+          editBtn.textContent = 'Éditer';
+          setTimeout(() => editorWrap.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), 50);
+        } catch (e) {
+          editBtn.textContent = 'Erreur';
+          setTimeout(() => { editBtn.textContent = 'Éditer'; editBtn.disabled = false; }, 2000);
+          return;
+        }
+        editBtn.disabled = false;
+      });
+
+      closeBtn.addEventListener('click', () => {
+        editorWrap.classList.remove('open');
+        editBtn.textContent = 'Éditer';
+      });
+
+      saveBtn.addEventListener('click', async () => {
+        saveBtn.textContent = '…';
+        saveBtn.disabled = true;
+        try {
+          await api('/memory/topics/' + encodeURIComponent(t.name), {
+            method: 'PUT', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ content: ta.value }),
+          });
+          saveBtn.textContent = '✓ Sauvegardé';
+        } catch {
+          saveBtn.textContent = '✗ Erreur';
+        }
+        setTimeout(() => { saveBtn.textContent = 'Sauvegarder'; saveBtn.disabled = false; }, 2000);
+      });
+
+      delBtn.addEventListener('click', async () => {
+        if (!confirm(`Supprimer "${t.name}" définitivement ?`)) return;
+        delBtn.disabled = true;
+        try {
+          await api('/memory/topics/' + encodeURIComponent(t.name), { method: 'DELETE' });
+          wrap.remove();
+          const topicCount = document.getElementById('topic-count');
+          const current = parseInt(topicCount.textContent) || 0;
+          topicCount.textContent = Math.max(0, current - 1) + ' topics';
+        } catch {
+          delBtn.disabled = false;
+          alert('Erreur lors de la suppression.');
+        }
+      });
+    });
+  }
+
+  async function saveWithFeedback(btn, fn) {
+    const orig = btn.textContent;
+    btn.textContent = '…'; btn.disabled = true;
+    try { await fn(); btn.textContent = '✓ Sauvegardé'; }
+    catch { btn.textContent = '✗ Erreur'; }
+    setTimeout(() => { btn.textContent = orig; btn.disabled = false; }, 2000);
+  }
+
+  document.getElementById('save-index').addEventListener('click', function() {
+    saveWithFeedback(this, () => api('/memory/index', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: document.getElementById('index-editor').value }),
+    }));
+  });
+
+  document.getElementById('save-prefs').addEventListener('click', function() {
+    saveWithFeedback(this, () => api('/memory/prefs', {
+      method: 'PUT', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: document.getElementById('prefs-editor').value }),
+    }));
+  });
+
+  async function loadTasks() {
+    const data = await api('/tasks');
+    const sched = document.getElementById('scheduler-list');
+    sched.innerHTML = '';
+    (data.scheduler || []).forEach(job => {
+      const card = document.createElement('div');
+      card.className = 'job-card';
+      card.innerHTML = `
+        <div class="job-name">${job.name}</div>
+        <div class="job-meta">${job.description} · ${job.interval}</div>
+        ${job.next_run ? `<div class="job-next">Prochain : ${fmtTime(job.next_run)}</div>` : ''}
+      `;
+      sched.appendChild(card);
+    });
+
+    const hist = document.getElementById('history-list');
+    hist.innerHTML = '';
+    if (!data.history || !data.history.length) {
+      hist.innerHTML = '<div class="notif-empty">Aucune tâche exécutée.</div>'; return;
+    }
+    data.history.forEach(r => {
+      const row = document.createElement('div');
+      row.className = 'history-row';
+      row.innerHTML = `
+        <div class="history-instr">${escHtml(r.instruction)}</div>
+        <div class="history-time">${fmtTime(r.started_at)}</div>
+        <div class="history-result ${r.error ? 'history-err' : ''}">${escHtml(r.error || r.result || '—')}</div>
+      `;
+      hist.appendChild(row);
+    });
+  }
+
+  async function loadNotifications() {
+    const data = await api('/notifications');
+    const list = document.getElementById('notif-list');
+    list.innerHTML = '';
+    if (!data.pending || !data.pending.length) {
+      list.innerHTML = '<div class="notif-empty">Aucune notification.</div>'; return;
+    }
+    data.pending.forEach(n => {
+      const card = document.createElement('div');
+      card.className = 'notif-card';
+      card.innerHTML = `<p>${escHtml(n.content)}</p><div class="notif-time">${fmtTime(n.created_at)}</div>`;
+      list.appendChild(card);
+    });
+  }
+
+  document.getElementById('refresh-notifs').addEventListener('click', loadNotifications);
+
+  function escHtml(s) { return String(s||'').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+  function cssId(s) { return s.replace(/[^a-z0-9]/gi,'_'); }
+
+  Promise.all([loadSessions(), loadMemory(), loadNotifications()]);
+  setInterval(loadNotifications, 30_000);
+</script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/budget.html
+++ b/src/jarvis/interfaces/ui/static/budget.html
@@ -400,5 +400,16 @@
 
   load();
 </script>
+<style>
+.jmc-home-btn-standalone{position:fixed;bottom:24px;left:24px;z-index:9000;
+background:rgba(15,20,31,0.9);border:0.5px solid rgba(220,232,255,0.10);
+border-radius:8px;color:rgba(220,232,255,0.5);width:36px;height:36px;
+display:flex;align-items:center;justify-content:center;
+text-decoration:none;opacity:.55;transition:opacity .15s,border-color .15s,color .15s;}
+.jmc-home-btn-standalone:hover{opacity:1;border-color:#4A9EFF;color:#4A9EFF;}
+</style>
+<a href="/" class="jmc-home-btn-standalone" title="Retour Home">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12L12 3l9 9"/><path d="M9 21V12h6v9"/></svg>
+</a>
 </body>
 </html>

--- a/src/jarvis/interfaces/ui/static/budget.html.bak-1782249020
+++ b/src/jarvis/interfaces/ui/static/budget.html.bak-1782249020
@@ -1,0 +1,404 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jarvis — Budget</title>
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:ital,wght@0,400;0,500;0,600&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:    #06080D;
+      --b1:    #4A9EFF;
+      --b2:    rgba(74,158,255,0.55);
+      --b3:    rgba(74,158,255,0.18);
+      --b4:    rgba(74,158,255,0.08);
+      --text:  #DCE8FF;
+      --dim:   rgba(170,195,230,0.55);
+      --muted: rgba(100,130,175,0.40);
+      --green: #36D399;
+      --amber: #FBBF24;
+      --red:   #F87171;
+      --panel: rgba(5,8,22,0.78);
+      --glass: rgba(8,13,32,0.72);
+    }
+
+    html, body {
+      width: 100%; min-height: 100%;
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'DM Sans', sans-serif;
+      font-size: 13px;
+    }
+
+    body::before {
+      content: '';
+      position: fixed; inset: 0; z-index: 0; pointer-events: none;
+      opacity: 0.028;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+      background-size: 160px;
+    }
+
+    ::-webkit-scrollbar { width: 3px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--b3); border-radius: 99px; }
+    * { scrollbar-width: thin; scrollbar-color: var(--b3) transparent; }
+
+    /* ── Header ─────────────────────────────────────────────── */
+    header {
+      position: sticky; top: 0; z-index: 10;
+      display: flex; align-items: center; gap: 16px;
+      padding: 0 28px;
+      height: 56px;
+      background: rgba(4,6,16,0.92);
+      border-bottom: 1px solid var(--b3);
+      backdrop-filter: blur(24px);
+    }
+
+    .brand {
+      font: 800 14px/1 'Syne', sans-serif;
+      letter-spacing: 0.18em; text-transform: uppercase;
+      color: #fff;
+      text-shadow: 0 0 28px rgba(74,158,255,0.45);
+    }
+    .brand em { font-style: normal; color: var(--b1); }
+
+    .hd-rule { flex: 0 0 1px; height: 20px; background: var(--b3); }
+
+    header a {
+      font: 500 10px/1 'DM Mono', monospace;
+      letter-spacing: 0.22em; text-transform: uppercase;
+      color: var(--muted); text-decoration: none;
+      transition: color .15s;
+    }
+    header a:hover { color: var(--b1); }
+
+    header a.active { color: var(--b1); }
+
+    .hd-spacer { flex: 1; }
+
+    .hd-refresh {
+      display: flex; align-items: center; gap: 6px;
+      font: 500 10px/1 'DM Mono', monospace;
+      letter-spacing: 0.16em; text-transform: uppercase;
+      color: var(--muted);
+      background: var(--b4);
+      border: 1px solid var(--b3);
+      border-radius: 99px;
+      padding: 6px 14px;
+      cursor: pointer;
+      transition: color .15s, border-color .15s;
+    }
+    .hd-refresh:hover { color: var(--b1); border-color: var(--b2); }
+
+    /* ── Layout ─────────────────────────────────────────────── */
+    main {
+      position: relative; z-index: 1;
+      max-width: 860px; margin: 0 auto;
+      padding: 36px 28px 60px;
+      display: flex; flex-direction: column; gap: 28px;
+    }
+
+    /* ── Section header ─────────────────────────────────────── */
+    .sec-hd {
+      display: flex; align-items: center; gap: 12px;
+      margin-bottom: 16px;
+    }
+    .sec-label {
+      font: 700 10px/1 'Syne', sans-serif;
+      letter-spacing: 0.26em; text-transform: uppercase;
+      color: var(--b1);
+      flex-shrink: 0;
+    }
+    .sec-rule { flex: 1; height: 1px; background: var(--b3); }
+
+    /* ── Card ───────────────────────────────────────────────── */
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--b3);
+      border-radius: 16px;
+      padding: 20px 24px;
+      backdrop-filter: blur(16px);
+    }
+
+    .card-title {
+      font: 600 11px/1 'DM Mono', monospace;
+      letter-spacing: 0.18em; text-transform: uppercase;
+      color: var(--dim);
+      margin-bottom: 14px;
+    }
+
+    /* ── Stats row ──────────────────────────────────────────── */
+    .stats-row {
+      display: flex; gap: 24px; flex-wrap: wrap;
+      margin-bottom: 18px;
+    }
+    .stat { display: flex; flex-direction: column; gap: 4px; }
+    .stat-val {
+      font: 500 22px/1 'DM Mono', monospace;
+      color: var(--text);
+    }
+    .stat-lbl {
+      font: 400 10px/1 'DM Mono', monospace;
+      letter-spacing: 0.14em; text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    /* ── Progress bar ───────────────────────────────────────── */
+    .prog-wrap {
+      position: relative;
+      height: 6px;
+      background: var(--b4);
+      border-radius: 99px;
+      overflow: hidden;
+      margin-bottom: 8px;
+    }
+    .prog-fill {
+      position: absolute; top: 0; left: 0; height: 100%;
+      border-radius: 99px;
+      transition: width .4s ease;
+      background: var(--b1);
+    }
+    .prog-fill.warning { background: var(--amber); }
+    .prog-fill.hard_stop { background: var(--red); }
+
+    .prog-labels {
+      display: flex; justify-content: space-between;
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--muted);
+    }
+
+    /* ── Status badge ───────────────────────────────────────── */
+    .badge {
+      display: inline-flex; align-items: center; gap: 5px;
+      font: 500 10px/1 'DM Mono', monospace;
+      letter-spacing: 0.12em; text-transform: uppercase;
+      padding: 4px 10px;
+      border-radius: 99px;
+      border: 1px solid;
+    }
+    .badge::before {
+      content: '';
+      width: 5px; height: 5px; border-radius: 50%;
+      background: currentColor;
+      flex-shrink: 0;
+    }
+    .badge.ok    { color: var(--green); border-color: rgba(54,211,153,0.28); background: rgba(54,211,153,0.06); }
+    .badge.warning { color: var(--amber); border-color: rgba(251,191,36,0.28); background: rgba(251,191,36,0.06); }
+    .badge.hard_stop { color: var(--red); border-color: rgba(248,113,113,0.28); background: rgba(248,113,113,0.06); }
+
+    /* ── Projects grid ──────────────────────────────────────── */
+    .proj-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 12px;
+    }
+
+    .proj-card {
+      background: var(--glass);
+      border: 1px solid var(--b3);
+      border-radius: 12px;
+      padding: 14px 16px;
+    }
+
+    .proj-name {
+      font: 500 11px/1 'DM Mono', monospace;
+      color: var(--text);
+      margin-bottom: 10px;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+
+    /* ── Disabled / empty state ─────────────────────────────── */
+    .empty-state {
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      gap: 12px;
+      padding: 80px 0;
+    }
+    .empty-icon {
+      font-size: 36px; opacity: .12;
+    }
+    .empty-title {
+      font: 700 11px/1 'Syne', sans-serif;
+      letter-spacing: 0.26em; text-transform: uppercase;
+      color: var(--muted);
+    }
+    .empty-sub {
+      font: 400 11px/1.6 'DM Sans', sans-serif;
+      color: var(--muted);
+      text-align: center; max-width: 280px;
+    }
+
+    /* ── Timestamp ──────────────────────────────────────────── */
+    .ts {
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <span class="brand">JARVIS <em>OS</em></span>
+  <span class="hd-rule"></span>
+  <a href="/admin.html">Admin</a>
+  <a href="/settings.html">Réglages</a>
+  <a href="/budget.html" class="active">Budget</a>
+  <a href="/routines.html">Routines</a>
+  <span class="hd-spacer"></span>
+  <button class="hd-refresh" onclick="load()">↺ Actualiser</button>
+</header>
+
+<main id="main">
+  <div class="empty-state">
+    <div class="empty-icon">⧗</div>
+    <div class="empty-title">Chargement…</div>
+  </div>
+</main>
+
+<script>
+  async function load() {
+    const main = document.getElementById('main');
+    try {
+      const res = await fetch('/api/budget/status');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      render(main, data);
+    } catch (err) {
+      main.innerHTML = `
+        <div class="empty-state">
+          <div class="empty-icon">⚠</div>
+          <div class="empty-title">Erreur de chargement</div>
+          <div class="empty-sub">${err.message}</div>
+        </div>`;
+    }
+  }
+
+  function fmt(usd) {
+    if (usd == null) return '—';
+    if (usd === null) return '—';
+    return `$${Number(usd).toFixed(4)}`;
+  }
+
+  function pct(spent, limit) {
+    if (!limit || limit <= 0) return 0;
+    return Math.min(100, (spent / limit) * 100);
+  }
+
+  function statusLabel(s) {
+    if (s === 'ok') return 'OK';
+    if (s === 'warning') return 'Alerte';
+    if (s === 'hard_stop') return 'Bloqué';
+    return s || '—';
+  }
+
+  function progBar(spent, limit, status) {
+    const p = pct(spent, limit);
+    return `
+      <div class="prog-wrap">
+        <div class="prog-fill ${status || 'ok'}" style="width:${p}%"></div>
+      </div>
+      <div class="prog-labels">
+        <span>${fmt(spent)} dépensé</span>
+        <span>${p.toFixed(1)}%</span>
+        <span>/ ${fmt(limit)}</span>
+      </div>`;
+  }
+
+  function render(main, data) {
+    if (!data.enabled) {
+      main.innerHTML = `
+        <div class="empty-state">
+          <div class="empty-icon">💰</div>
+          <div class="empty-title">Budget désactivé</div>
+          <div class="empty-sub">
+            Activez <code>BUDGET_ENABLED=true</code> dans votre .env pour
+            activer le suivi de coûts.
+          </div>
+        </div>`;
+      return;
+    }
+
+    const g = data.global || {};
+    const projects = data.projects || {};
+    const projKeys = Object.keys(projects);
+
+    const ts = new Date().toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+
+    let html = `
+      <div>
+        <div class="sec-hd">
+          <span class="sec-label">Budget mensuel global</span>
+          <span class="sec-rule"></span>
+          <span class="ts">Mis à jour ${ts}</span>
+        </div>
+        <div class="card">
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;">
+            <div class="card-title">Consommation du mois</div>
+            <span class="badge ${g.status || 'ok'}">${statusLabel(g.status)}</span>
+          </div>
+          <div class="stats-row">
+            <div class="stat">
+              <div class="stat-val">${fmt(g.spent_usd)}</div>
+              <div class="stat-lbl">Dépensé</div>
+            </div>
+            <div class="stat">
+              <div class="stat-val">${fmt(g.remaining_usd)}</div>
+              <div class="stat-lbl">Restant</div>
+            </div>
+            <div class="stat">
+              <div class="stat-val">${fmt(g.limit_usd)}</div>
+              <div class="stat-lbl">Plafond</div>
+            </div>
+            <div class="stat">
+              <div class="stat-val">${(g.utilization_pct ?? 0).toFixed(1)} %</div>
+              <div class="stat-lbl">Utilisation</div>
+            </div>
+          </div>
+          ${progBar(g.spent_usd, g.limit_usd, g.status)}
+        </div>
+      </div>`;
+
+    if (projKeys.length > 0) {
+      html += `
+        <div>
+          <div class="sec-hd">
+            <span class="sec-label">Par projet</span>
+            <span class="sec-rule"></span>
+            <span class="ts">${projKeys.length} projet${projKeys.length > 1 ? 's' : ''}</span>
+          </div>
+          <div class="proj-grid">`;
+
+      for (const pid of projKeys) {
+        const p = projects[pid];
+        html += `
+            <div class="proj-card">
+              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">
+                <div class="proj-name" title="${pid}">${pid}</div>
+                <span class="badge ${p.status || 'ok'}" style="font-size:9px;padding:3px 8px;">${statusLabel(p.status)}</span>
+              </div>
+              ${progBar(p.spent_usd, p.limit_usd, p.status)}
+            </div>`;
+      }
+
+      html += `
+          </div>
+        </div>`;
+    } else {
+      html += `
+        <div class="card" style="text-align:center;padding:32px 24px;">
+          <div class="empty-title" style="margin-bottom:8px;">Aucun projet actif</div>
+          <div class="empty-sub">Les dépenses par mission apparaîtront ici lors de l'exécution d'un projet agent.</div>
+        </div>`;
+    }
+
+    main.innerHTML = html;
+  }
+
+  load();
+</script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/capabilities.css
+++ b/src/jarvis/interfaces/ui/static/capabilities.css
@@ -23,22 +23,22 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 .cn-dot.expired { background: var(--amber);  box-shadow: 0 0 6px var(--amber); }
 
 .cn-info { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
-.cn-name { font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
-.cn-sub  { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.08em; }
+.cn-name { font-size: 0.8125rem; color: var(--fg-0); letter-spacing: -0.005em; }
+.cn-sub  { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); letter-spacing: 0.08em; }
 
 .cn-right { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
 
 .cn-badge {
-  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.12em; text-transform: uppercase;
   padding: 3px 9px; border-radius: 4px;
 }
-.cn-badge.on      { color: var(--green); background: var(--green-soft); border: 0.5px solid rgba(54,211,153,.3); }
+.cn-badge.on      { color: var(--green); background: var(--green-soft); border: 0.5px solid rgba(var(--c-green), .3); }
 .cn-badge.expired { color: var(--amber); background: rgba(230,180,60,.08); border: 0.5px solid rgba(230,180,60,.3); }
 
 .cn-btn {
   appearance: none; background: none;
   border: 0.5px solid var(--line-2); border-radius: 8px;
-  color: var(--fg-2); font-family: var(--mono); font-size: 10px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.1em; text-transform: uppercase;
   padding: 7px 14px; cursor: pointer; white-space: nowrap;
   transition: border-color .15s, color .15s;
@@ -55,25 +55,25 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 
 
 .cn-field { display: flex; flex-direction: column; gap: 6px; }
-.cn-field-label { font-size: 11.5px; color: var(--fg-2); }
+.cn-field-label { font-size: 0.7188rem; color: var(--fg-2); }
 .cn-field-input {
   width: 100%; max-width: 420px; box-sizing: border-box;
   background: var(--bg-0); border: 0.5px solid var(--line-2);
   border-radius: 8px; padding: 9px 12px;
-  font-family: var(--mono); font-size: 12px; color: var(--fg-1);
+  font-family: var(--mono); font-size: 0.75rem; color: var(--fg-1);
   outline: none; transition: border-color .15s;
 }
 .cn-field-input:focus { border-color: var(--gold); }
 
 .cn-save-btn {
   appearance: none; background: var(--gold-soft);
-  border: 0.5px solid rgba(184,150,62,.32); border-radius: 8px;
-  color: var(--gold); font-family: var(--mono); font-size: 10px;
+  border: 0.5px solid rgba(var(--c-gold), .32); border-radius: 8px;
+  color: var(--gold); font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.12em; text-transform: uppercase;
   padding: 8px 16px; cursor: pointer; transition: all .15s;
   align-self: flex-start; margin-top: 4px;
 }
-.cn-save-btn:hover { background: rgba(184,150,62,.22); }
+.cn-save-btn:hover { background: rgba(var(--c-gold), .22); }
 .cn-save-btn:disabled { opacity: .5; cursor: default; }
 
 /* ── Skills (Tools) ── */
@@ -89,22 +89,22 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   cursor: pointer; transition: border-color .15s, background .15s;
   min-height: 130px;
 }
-.skill-card:hover { border-color: var(--gold-soft); background: rgba(184,150,62,0.04); }
+.skill-card:hover { border-color: var(--gold-soft); background: rgba(var(--c-gold), 0.04); }
 .skill-glyph {
   width: 44px; height: 44px; border-radius: 10px;
-  background: var(--gold-soft); border: 0.5px solid rgba(184,150,62,.32);
+  background: var(--gold-soft); border: 0.5px solid rgba(var(--c-gold), .32);
   display: grid; place-items: center;
-  font-family: var(--mono); font-size: 14px;
+  font-family: var(--mono); font-size: 0.875rem;
   color: var(--gold); font-weight: 500;
   flex-shrink: 0;
 }
-.skill-name { font-size: 14px; color: var(--fg-0); line-height: 1.3; }
-.skill-desc { font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
+.skill-name { font-size: 0.875rem; color: var(--fg-0); line-height: 1.3; }
+.skill-desc { font-family: var(--mono); font-size: 0.6562rem; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
 
 .skill-install-btn {
   appearance: none; background: transparent;
   border: 0.5px solid var(--line-2); border-radius: 6px;
-  color: var(--fg-2); font-family: var(--mono); font-size: 10px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.12em; text-transform: uppercase;
   padding: 6px 12px; cursor: pointer;
   transition: border-color .15s, color .15s, background .15s;
@@ -118,7 +118,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 
 .skill-installed-badge {
   display: inline-flex; align-items: center; gap: 5px;
-  font-family: var(--mono); font-size: 10px;
+  font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.1em; text-transform: uppercase;
   color: var(--green);
 }
@@ -136,20 +136,20 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   cursor: pointer; transition: border-color .15s, background .15s;
   min-height: 130px;
 }
-.routine-card:hover { border-color: var(--line-2); background: rgba(74,158,255,0.03); }
+.routine-card:hover { border-color: var(--line-2); background: rgba(var(--c-accent), 0.03); }
 .routine-glyph {
   width: 44px; height: 44px; border-radius: 10px;
-  background: rgba(74,158,255,0.08); border: 0.5px solid rgba(74,158,255,.25);
+  background: rgba(var(--c-accent), 0.08); border: 0.5px solid rgba(var(--c-accent), .25);
   display: grid; place-items: center;
-  font-family: var(--mono); font-size: 14px;
+  font-family: var(--mono); font-size: 0.875rem;
   color: var(--accent); font-weight: 500;
   flex-shrink: 0;
 }
-.routine-name { font-size: 14px; color: var(--fg-0); line-height: 1.3; }
-.routine-desc { font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
+.routine-name { font-size: 0.875rem; color: var(--fg-0); line-height: 1.3; }
+.routine-desc { font-family: var(--mono); font-size: 0.6562rem; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
 .routine-platforms { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 2px; }
 .view-glyph {
-  background: rgba(54,211,153,0.08); border-color: rgba(54,211,153,.25);
+  background: rgba(var(--c-green), 0.08); border-color: rgba(var(--c-green), .25);
   color: var(--green);
 }
 
@@ -166,22 +166,22 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   cursor: pointer; transition: border-color .15s, background .15s;
   min-height: 130px;
 }
-.ambiance-card:hover { border-color: var(--line-2); background: rgba(54,211,153,0.03); }
+.ambiance-card:hover { border-color: var(--line-2); background: rgba(var(--c-green), 0.03); }
 .ambiance-glyph {
   width: 44px; height: 44px; border-radius: 10px;
-  background: rgba(54,211,153,0.08); border: 0.5px solid rgba(54,211,153,.25);
+  background: rgba(var(--c-green), 0.08); border: 0.5px solid rgba(var(--c-green), .25);
   display: grid; place-items: center;
-  font-family: var(--mono); font-size: 14px;
+  font-family: var(--mono); font-size: 0.875rem;
   color: var(--green); font-weight: 500;
   flex-shrink: 0;
 }
-.ambiance-name { font-size: 14px; color: var(--fg-0); line-height: 1.3; }
-.ambiance-desc { font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
+.ambiance-name { font-size: 0.875rem; color: var(--fg-0); line-height: 1.3; }
+.ambiance-desc { font-family: var(--mono); font-size: 0.6562rem; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
 
 /* ── Presets legacy ── */
 .preset-platforms { display: flex; gap: 5px; }
 .preset-platform {
-  font-family: var(--mono); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase;
+  font-family: var(--mono); font-size: 0.5625rem; letter-spacing: 0.1em; text-transform: uppercase;
   padding: 2px 6px; border: 0.5px solid var(--line-2); border-radius: 4px; color: var(--fg-3);
 }
 
@@ -227,7 +227,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   border: 0.5px solid var(--line-2); border-radius: 8px;
   width: 32px; height: 32px; flex-shrink: 0;
   display: grid; place-items: center;
-  color: var(--fg-3); cursor: pointer; font-size: 13px;
+  color: var(--fg-3); cursor: pointer; font-size: 0.8125rem;
   transition: border-color .15s, color .15s;
 }
 .panel-close:hover { border-color: var(--fg-2); color: var(--fg-1); }
@@ -235,15 +235,15 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 .panel-glyph {
   width: 52px; height: 52px; border-radius: 13px; flex-shrink: 0;
   display: grid; place-items: center;
-  font-family: var(--mono); font-size: 16px; font-weight: 500;
+  font-family: var(--mono); font-size: 1rem; font-weight: 500;
 }
-.panel-glyph.skill    { background: var(--gold-soft); border: 0.5px solid rgba(184,150,62,.32); color: var(--gold); }
-.panel-glyph.routine  { background: rgba(74,158,255,0.08); border: 0.5px solid rgba(74,158,255,.25); color: var(--accent); }
-.panel-glyph.ambiance { background: rgba(54,211,153,0.08); border: 0.5px solid rgba(54,211,153,.25); color: var(--green); }
+.panel-glyph.skill    { background: var(--gold-soft); border: 0.5px solid rgba(var(--c-gold), .32); color: var(--gold); }
+.panel-glyph.routine  { background: rgba(var(--c-accent), 0.08); border: 0.5px solid rgba(var(--c-accent), .25); color: var(--accent); }
+.panel-glyph.ambiance { background: rgba(var(--c-green), 0.08); border: 0.5px solid rgba(var(--c-green), .25); color: var(--green); }
 
-.panel-name { font-size: 17px; color: var(--fg-0); line-height: 1.2; letter-spacing: -0.01em; }
+.panel-name { font-size: 1.0625rem; color: var(--fg-0); line-height: 1.2; letter-spacing: -0.01em; }
 .panel-type-badge {
-  font-family: var(--mono); font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase;
+  font-family: var(--mono); font-size: 0.5625rem; letter-spacing: 0.16em; text-transform: uppercase;
   margin-top: 5px; color: var(--fg-3);
 }
 .panel-type-badge.routine  { color: var(--accent); }
@@ -255,7 +255,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 }
 
 .panel-desc {
-  font-size: 13px; color: var(--fg-2); line-height: 1.7;
+  font-size: 0.8125rem; color: var(--fg-2); line-height: 1.7;
 }
 
 .panel-section {
@@ -263,7 +263,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 }
 
 .panel-section-title {
-  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.16em;
   text-transform: uppercase; color: var(--fg-3);
   padding-bottom: 12px;
   border-bottom: 0.5px solid var(--line-1);
@@ -274,12 +274,12 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   display: flex; align-items: center; justify-content: space-between;
   padding: 10px 0; border-bottom: 0.5px solid var(--line-1);
 }
-.panel-check-label { font-size: 13px; color: var(--fg-1); }
+.panel-check-label { font-size: 0.8125rem; color: var(--fg-1); }
 .panel-check-status {
-  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.12em; text-transform: uppercase;
   padding: 3px 8px; border-radius: 4px;
 }
-.panel-check-status.ok { color: var(--green); background: var(--green-soft); border: 0.5px solid rgba(54,211,153,.3); }
+.panel-check-status.ok { color: var(--green); background: var(--green-soft); border: 0.5px solid rgba(var(--c-green), .3); }
 .panel-check-status.ko { color: var(--fg-3); background: var(--bg-1); border: 0.5px solid var(--line-2); }
 
 .panel-field {
@@ -287,37 +287,37 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   margin-bottom: 14px;
 }
 .panel-field-label {
-  font-size: 12px; color: var(--fg-2);
+  font-size: 0.75rem; color: var(--fg-2);
 }
 .panel-field-input {
   width: 100%; box-sizing: border-box;
   background: var(--bg-1); border: 0.5px solid var(--line-2);
   border-radius: 8px; padding: 10px 13px;
-  font-family: var(--mono); font-size: 12px; color: var(--fg-1);
+  font-family: var(--mono); font-size: 0.75rem; color: var(--fg-1);
   outline: none; transition: border-color .15s;
 }
 .panel-field-input:focus { border-color: var(--gold); }
 
 .panel-save-btn {
   appearance: none; background: var(--gold-soft);
-  border: 0.5px solid rgba(184,150,62,.32); border-radius: 8px;
-  color: var(--gold); font-family: var(--mono); font-size: 10px;
+  border: 0.5px solid rgba(var(--c-gold), .32); border-radius: 8px;
+  color: var(--gold); font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.12em; text-transform: uppercase;
   padding: 9px 16px; cursor: pointer; transition: all .15s;
   margin-top: 6px; align-self: flex-start;
 }
-.panel-save-btn:hover { background: rgba(184,150,62,.22); }
+.panel-save-btn:hover { background: rgba(var(--c-gold), .22); }
 .panel-save-btn:disabled { opacity: .5; cursor: default; }
 
 .panel-run-btn {
-  appearance: none; background: rgba(74,158,255,0.08);
-  border: 0.5px solid rgba(74,158,255,.25); border-radius: 8px;
-  color: var(--accent); font-family: var(--mono); font-size: 10px;
+  appearance: none; background: rgba(var(--c-accent), 0.08);
+  border: 0.5px solid rgba(var(--c-accent), .25); border-radius: 8px;
+  color: var(--accent); font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.12em; text-transform: uppercase;
   padding: 9px 16px; cursor: pointer; transition: all .15s;
   align-self: flex-start;
 }
-.panel-run-btn:hover { background: rgba(74,158,255,.15); }
+.panel-run-btn:hover { background: rgba(var(--c-accent), .15); }
 .panel-run-btn:disabled { opacity: .5; cursor: default; }
 
 /* ── Appareils v2 — grandes cartes avec modèles 3D ── */
@@ -343,7 +343,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 
 /* ── Carte inactive — assombrie ── */
 .dv-card--dim {
-  border-color: rgba(220, 232, 255, 0.04);
+  border-color: rgba(var(--c-fg), 0.04);
 }
 .dv-card--dim .dv-scene-wrap {
   filter: brightness(0.40) saturate(0.25);
@@ -352,45 +352,45 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   opacity: 0.48;
 }
 .dv-card--dim:hover {
-  border-color: rgba(220, 232, 255, 0.10);
+  border-color: rgba(var(--c-fg), 0.10);
   box-shadow: 0 16px 48px -16px rgba(0,0,0,.6);
 }
 
 /* ── Carte active — halo bleu pulsant ── */
 .dv-card--glow-green {
-  border-color: rgba(74, 158, 255, 0.30);
+  border-color: rgba(var(--c-accent), 0.30);
   animation: cardGlowBlue 3.2s ease-in-out infinite;
 }
 @keyframes cardGlowBlue {
-  0%, 100% { box-shadow: 0 0 0 1px rgba(74,158,255,.08), 0 0 24px -6px rgba(74,158,255,.18), 0 20px 64px -16px rgba(0,0,0,.65); }
-  50%       { box-shadow: 0 0 0 1px rgba(74,158,255,.16), 0 0 40px -4px rgba(74,158,255,.30), 0 20px 64px -16px rgba(0,0,0,.65); }
+  0%, 100% { box-shadow: 0 0 0 1px rgba(var(--c-accent), .08), 0 0 24px -6px rgba(var(--c-accent), .18), 0 20px 64px -16px rgba(0,0,0,.65); }
+  50%       { box-shadow: 0 0 0 1px rgba(var(--c-accent), .16), 0 0 40px -4px rgba(var(--c-accent), .30), 0 20px 64px -16px rgba(0,0,0,.65); }
 }
 .dv-card--glow-green:hover {
-  border-color: rgba(74, 158, 255, 0.48);
+  border-color: rgba(var(--c-accent), 0.48);
   animation: none;
-  box-shadow: 0 0 0 1px rgba(74,158,255,.20), 0 0 48px -4px rgba(74,158,255,.36), 0 24px 72px -12px rgba(0,0,0,.72);
+  box-shadow: 0 0 0 1px rgba(var(--c-accent), .20), 0 0 48px -4px rgba(var(--c-accent), .36), 0 24px 72px -12px rgba(0,0,0,.72);
 }
 
 /* ── Carte nearby/bootloader — halo bleu ── */
 .dv-card--glow-accent {
-  border-color: rgba(74, 158, 255, 0.28);
+  border-color: rgba(var(--c-accent), 0.28);
   animation: cardGlowAccent 3.2s ease-in-out infinite;
 }
 @keyframes cardGlowAccent {
-  0%, 100% { box-shadow: 0 0 0 1px rgba(74,158,255,.08), 0 0 24px -6px rgba(74,158,255,.18), 0 20px 64px -16px rgba(0,0,0,.65); }
-  50%       { box-shadow: 0 0 0 1px rgba(74,158,255,.16), 0 0 40px -4px rgba(74,158,255,.30), 0 20px 64px -16px rgba(0,0,0,.65); }
+  0%, 100% { box-shadow: 0 0 0 1px rgba(var(--c-accent), .08), 0 0 24px -6px rgba(var(--c-accent), .18), 0 20px 64px -16px rgba(0,0,0,.65); }
+  50%       { box-shadow: 0 0 0 1px rgba(var(--c-accent), .16), 0 0 40px -4px rgba(var(--c-accent), .30), 0 20px 64px -16px rgba(0,0,0,.65); }
 }
 .dv-card--glow-accent:hover {
-  border-color: rgba(74, 158, 255, 0.46);
+  border-color: rgba(var(--c-accent), 0.46);
   animation: none;
-  box-shadow: 0 0 0 1px rgba(74,158,255,.20), 0 0 48px -4px rgba(74,158,255,.36), 0 24px 72px -12px rgba(0,0,0,.72);
+  box-shadow: 0 0 0 1px rgba(var(--c-accent), .20), 0 0 48px -4px rgba(var(--c-accent), .36), 0 24px 72px -12px rgba(0,0,0,.72);
 }
 
 /* Zone scène 3D */
 .dv-scene-wrap {
   height: 200px;
   position: relative;
-  background: radial-gradient(ellipse at 50% 42%, rgba(74,158,255,.05) 0%, transparent 70%);
+  background: radial-gradient(ellipse at 50% 42%, rgba(var(--c-accent), .05) 0%, transparent 70%);
   border-bottom: 0.5px solid var(--line-1);
   overflow: hidden;
 }
@@ -402,7 +402,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   bottom: 18px; left: 50%;
   transform: translateX(-50%);
   width: 110px; height: 16px;
-  background: rgba(74,158,255,.10);
+  background: rgba(var(--c-accent), .10);
   border-radius: 50%;
   filter: blur(10px);
   pointer-events: none;
@@ -434,7 +434,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 }
 
 .dv-name-v2 {
-  font-size: 15px;
+  font-size: 0.9375rem;
   color: var(--fg-0);
   letter-spacing: -.01em;
   line-height: 1.2;
@@ -446,7 +446,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 
 .dv-badge {
   font-family: var(--mono);
-  font-size: 9px;
+  font-size: 0.5625rem;
   letter-spacing: .12em;
   text-transform: uppercase;
   padding: 3px 8px;
@@ -454,13 +454,13 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   flex-shrink: 0;
 }
 
-.dv-badge.green  { color: var(--green);  background: var(--green-soft);  border: 0.5px solid rgba(54,211,153,.3); }
+.dv-badge.green  { color: var(--green);  background: var(--green-soft);  border: 0.5px solid rgba(var(--c-green), .3); }
 .dv-badge.muted  { color: var(--fg-3);   background: transparent;         border: 0.5px solid var(--line-2); }
 .dv-badge.accent { color: var(--accent); background: var(--accent-soft);  border: 0.5px solid var(--accent-line); }
 
 .dv-sub-v2 {
   font-family: var(--mono);
-  font-size: 9.5px;
+  font-size: 0.5938rem;
   color: var(--fg-3);
   letter-spacing: .08em;
 }
@@ -478,7 +478,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 
 .dv-meta-k-v2 {
   font-family: var(--mono);
-  font-size: 8px;
+  font-size: 0.5rem;
   letter-spacing: .12em;
   text-transform: uppercase;
   color: var(--fg-4);
@@ -486,7 +486,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 
 .dv-meta-v-v2 {
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: 0.75rem;
   color: var(--fg-1);
   letter-spacing: .04em;
 }
@@ -502,7 +502,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 
 .coming-soon-msg {
   font-family: var(--mono);
-  font-size: 12px;
+  font-size: 0.75rem;
   letter-spacing: .22em;
   text-transform: uppercase;
   color: var(--fg-3);
@@ -514,9 +514,9 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   align-items: center; gap: 14px;
   padding: 13px 0; border-bottom: 0.5px solid var(--line-1);
 }
-.sess-id { font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; color: var(--fg-3); }
-.sess-preview { font-size: 12.5px; color: var(--fg-1); line-height: 1.3; }
-.sess-date { font-family: var(--mono); font-size: 10px; color: var(--fg-3); white-space: nowrap; }
+.sess-id { font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.06em; color: var(--fg-3); }
+.sess-preview { font-size: 0.7812rem; color: var(--fg-1); line-height: 1.3; }
+.sess-date { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); white-space: nowrap; }
 
 .sess-rename-editor {
   display: none; flex-direction: column; gap: 10px;
@@ -528,7 +528,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   width: 100%; box-sizing: border-box;
   background: var(--bg-1); border: 0.5px solid var(--line-2);
   border-radius: 8px; padding: 9px 12px;
-  font-family: var(--mono); font-size: 12px; color: var(--fg-1);
+  font-family: var(--mono); font-size: 0.75rem; color: var(--fg-1);
   outline: none; transition: border-color .15s;
 }
 .sess-rename-input:focus { border-color: var(--gold); }
@@ -555,22 +555,22 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 }
 .sess-bubble--user {
   align-self: flex-end;
-  background: rgba(184,150,62,.07); border-color: rgba(184,150,62,.2);
+  background: rgba(var(--c-gold), .07); border-color: rgba(var(--c-gold), .2);
 }
 .sess-bubble--assistant {
   align-self: flex-start;
   background: var(--bg-1);
 }
 .sess-bubble-role {
-  font-family: var(--mono); font-size: 9px; letter-spacing: 0.08em;
+  font-family: var(--mono); font-size: 0.5625rem; letter-spacing: 0.08em;
   text-transform: uppercase; color: var(--fg-3);
 }
 .sess-bubble--user .sess-bubble-role { color: var(--gold); opacity: .7; }
 .sess-bubble-body {
-  font-size: 12.5px; color: var(--fg-1); line-height: 1.55;
+  font-size: 0.7812rem; color: var(--fg-1); line-height: 1.55;
   white-space: pre-wrap; word-break: break-word;
 }
-.sess-msg-empty { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+.sess-msg-empty { font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-3); }
 
 /* ── Mémoire ── */
 .memory-row {
@@ -578,15 +578,15 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   align-items: center; gap: 14px;
   padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
 }
-.mem-name { font-size: 12.5px; color: var(--fg-1); }
-.mem-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); text-align: right; }
+.mem-name { font-size: 0.7812rem; color: var(--fg-1); }
+.mem-meta { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); text-align: right; }
 
 .mem-btn-row { display: flex; gap: 6px; align-items: center; flex-shrink: 0; }
 
 .m-btn {
   appearance: none; background: transparent;
   border: 0.5px solid var(--line-2); border-radius: 6px;
-  color: var(--fg-2); font-family: var(--mono); font-size: 10px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.10em; text-transform: uppercase;
   padding: 5px 11px; cursor: pointer; white-space: nowrap;
   transition: border-color .15s, color .15s, background .15s;
@@ -595,17 +595,17 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 .m-btn:disabled { opacity: 0.4; cursor: default; }
 
 .m-btn--save {
-  color: var(--gold); border-color: rgba(184,150,62,.32);
+  color: var(--gold); border-color: rgba(var(--c-gold), .32);
   background: var(--gold-soft);
 }
-.m-btn--save:hover:not(:disabled) { background: rgba(184,150,62,.22); border-color: var(--gold); }
+.m-btn--save:hover:not(:disabled) { background: rgba(var(--c-gold), .22); border-color: var(--gold); }
 
 .m-btn--danger {
-  color: rgba(229,72,77,.55); border-color: rgba(229,72,77,.18);
+  color: rgba(var(--c-red), .55); border-color: rgba(var(--c-red), .18);
   background: transparent; padding: 5px 9px;
 }
 .m-btn--danger:hover:not(:disabled) {
-  color: var(--red); border-color: rgba(229,72,77,.55);
+  color: var(--red); border-color: rgba(var(--c-red), .55);
   background: var(--red-soft);
 }
 
@@ -620,7 +620,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
   width: 100%; box-sizing: border-box;
   background: var(--bg-1); border: 0.5px solid var(--line-2);
   border-radius: 10px; padding: 12px 14px;
-  font-family: var(--mono); font-size: 11.5px; color: var(--fg-1);
+  font-family: var(--mono); font-size: 0.7188rem; color: var(--fg-1);
   line-height: 1.6; resize: vertical; min-height: 120px;
   outline: none; transition: border-color .15s;
 }
@@ -629,7 +629,7 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 /* ── Messagerie — éléments supplémentaires ────────────────────────────────── */
 .cn-section-sep {
   padding: 18px 0 6px;
-  font-size: 10px; font-weight: 600; letter-spacing: .08em;
+  font-size: 0.625rem; font-weight: 600; letter-spacing: .08em;
   color: var(--fg-3); text-transform: uppercase;
   border-top: 0.5px solid var(--line-1);
   margin-top: 10px;
@@ -637,13 +637,13 @@ body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
 
 .cn-stub-note {
   padding: 10px 14px;
-  font-size: 12px; color: var(--fg-3);
+  font-size: 0.75rem; color: var(--fg-3);
   background: var(--bg-1); border-radius: 8px;
   border: 0.5px solid var(--line-1);
 }
 
 .cn-field-hint {
-  font-size: 10.5px; color: var(--fg-3);
+  font-size: 0.6562rem; color: var(--fg-3);
   margin-top: 2px; margin-bottom: 4px;
   font-family: var(--mono);
 }

--- a/src/jarvis/interfaces/ui/static/capabilities.css.bak-1782254922
+++ b/src/jarvis/interfaces/ui/static/capabilities.css.bak-1782254922
@@ -1,0 +1,672 @@
+/* capabilities.css — Atelier (Capacités) v2 */
+
+body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
+
+/* ── Integrations / Connectors (liste) ── */
+.cn-list { display: flex; flex-direction: column; }
+
+.cn-row {
+  display: grid;
+  grid-template-columns: 10px 1fr auto;
+  align-items: center; gap: 18px;
+  padding: 14px 0;
+  border-bottom: 0.5px solid var(--line-1);
+  transition: background .12s;
+}
+.cn-row:first-of-type { border-top: 0.5px solid var(--line-1); }
+
+.cn-dot {
+  width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+}
+.cn-dot.on      { background: var(--green);  box-shadow: 0 0 6px var(--green); }
+.cn-dot.off     { background: var(--fg-4); }
+.cn-dot.expired { background: var(--amber);  box-shadow: 0 0 6px var(--amber); }
+
+.cn-info { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.cn-name { font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.cn-sub  { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.08em; }
+
+.cn-right { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
+
+.cn-badge {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 9px; border-radius: 4px;
+}
+.cn-badge.on      { color: var(--green); background: var(--green-soft); border: 0.5px solid rgba(54,211,153,.3); }
+.cn-badge.expired { color: var(--amber); background: rgba(230,180,60,.08); border: 0.5px solid rgba(230,180,60,.3); }
+
+.cn-btn {
+  appearance: none; background: none;
+  border: 0.5px solid var(--line-2); border-radius: 8px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 7px 14px; cursor: pointer; white-space: nowrap;
+  transition: border-color .15s, color .15s;
+}
+.cn-btn:hover { border-color: var(--fg-2); color: var(--fg-0); }
+
+/* Zone d'expansion (clé API / CLI) */
+.cn-expand {
+  display: none; flex-direction: column; gap: 12px;
+  padding: 16px 28px 20px;
+  background: var(--bg-1); border-bottom: 0.5px solid var(--line-1);
+}
+.cn-expand.open { display: flex; }
+
+
+.cn-field { display: flex; flex-direction: column; gap: 6px; }
+.cn-field-label { font-size: 11.5px; color: var(--fg-2); }
+.cn-field-input {
+  width: 100%; max-width: 420px; box-sizing: border-box;
+  background: var(--bg-0); border: 0.5px solid var(--line-2);
+  border-radius: 8px; padding: 9px 12px;
+  font-family: var(--mono); font-size: 12px; color: var(--fg-1);
+  outline: none; transition: border-color .15s;
+}
+.cn-field-input:focus { border-color: var(--gold); }
+
+.cn-save-btn {
+  appearance: none; background: var(--gold-soft);
+  border: 0.5px solid rgba(184,150,62,.32); border-radius: 8px;
+  color: var(--gold); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 8px 16px; cursor: pointer; transition: all .15s;
+  align-self: flex-start; margin-top: 4px;
+}
+.cn-save-btn:hover { background: rgba(184,150,62,.22); }
+.cn-save-btn:disabled { opacity: .5; cursor: default; }
+
+/* ── Skills (Tools) ── */
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(clamp(240px, 28vw, 360px), 1fr));
+  gap: 12px;
+}
+.skill-card {
+  background: var(--bg-1); border: 0.5px solid var(--line-1);
+  border-radius: 14px; padding: 22px 24px;
+  display: flex; flex-direction: column; gap: 12px;
+  cursor: pointer; transition: border-color .15s, background .15s;
+  min-height: 130px;
+}
+.skill-card:hover { border-color: var(--gold-soft); background: rgba(184,150,62,0.04); }
+.skill-glyph {
+  width: 44px; height: 44px; border-radius: 10px;
+  background: var(--gold-soft); border: 0.5px solid rgba(184,150,62,.32);
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 14px;
+  color: var(--gold); font-weight: 500;
+  flex-shrink: 0;
+}
+.skill-name { font-size: 14px; color: var(--fg-0); line-height: 1.3; }
+.skill-desc { font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
+
+.skill-install-btn {
+  appearance: none; background: transparent;
+  border: 0.5px solid var(--line-2); border-radius: 6px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 6px 12px; cursor: pointer;
+  transition: border-color .15s, color .15s, background .15s;
+}
+.skill-install-btn:hover:not(:disabled) {
+  border-color: var(--gold);
+  color: var(--gold);
+  background: var(--gold-soft);
+}
+.skill-install-btn:disabled { opacity: 0.4; cursor: default; }
+
+.skill-installed-badge {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--green);
+}
+
+/* ── Routines (cards) ── */
+.routine-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(clamp(240px, 28vw, 360px), 1fr));
+  gap: 12px;
+}
+.routine-card {
+  background: var(--bg-1); border: 0.5px solid var(--line-1);
+  border-radius: 14px; padding: 22px 24px;
+  display: flex; flex-direction: column; gap: 12px;
+  cursor: pointer; transition: border-color .15s, background .15s;
+  min-height: 130px;
+}
+.routine-card:hover { border-color: var(--line-2); background: rgba(74,158,255,0.03); }
+.routine-glyph {
+  width: 44px; height: 44px; border-radius: 10px;
+  background: rgba(74,158,255,0.08); border: 0.5px solid rgba(74,158,255,.25);
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 14px;
+  color: var(--accent); font-weight: 500;
+  flex-shrink: 0;
+}
+.routine-name { font-size: 14px; color: var(--fg-0); line-height: 1.3; }
+.routine-desc { font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
+.routine-platforms { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 2px; }
+.view-glyph {
+  background: rgba(54,211,153,0.08); border-color: rgba(54,211,153,.25);
+  color: var(--green);
+}
+
+/* ── Ambiances (cards) ── */
+.ambiance-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(clamp(240px, 28vw, 360px), 1fr));
+  gap: 12px;
+}
+.ambiance-card {
+  background: var(--bg-1); border: 0.5px solid var(--line-1);
+  border-radius: 14px; padding: 22px 24px;
+  display: flex; flex-direction: column; gap: 12px;
+  cursor: pointer; transition: border-color .15s, background .15s;
+  min-height: 130px;
+}
+.ambiance-card:hover { border-color: var(--line-2); background: rgba(54,211,153,0.03); }
+.ambiance-glyph {
+  width: 44px; height: 44px; border-radius: 10px;
+  background: rgba(54,211,153,0.08); border: 0.5px solid rgba(54,211,153,.25);
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 14px;
+  color: var(--green); font-weight: 500;
+  flex-shrink: 0;
+}
+.ambiance-name { font-size: 14px; color: var(--fg-0); line-height: 1.3; }
+.ambiance-desc { font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
+
+/* ── Presets legacy ── */
+.preset-platforms { display: flex; gap: 5px; }
+.preset-platform {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 2px 6px; border: 0.5px solid var(--line-2); border-radius: 4px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────
+   DETAIL PANEL
+───────────────────────────────────────── */
+#detail-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 900;
+  opacity: 0; pointer-events: none;
+  transition: opacity .25s ease;
+}
+#detail-overlay.open { opacity: 1; pointer-events: auto; }
+
+#detail-panel {
+  position: fixed; right: 0; top: 0;
+  height: 100dvh; width: 480px; max-width: 100vw;
+  background: var(--bg-0);
+  border-left: 0.5px solid var(--line-1);
+  z-index: 901;
+  overflow-y: auto;
+  transform: translateX(100%);
+  transition: transform .28s cubic-bezier(.32, .72, 0, 1);
+}
+#detail-panel.open { transform: translateX(0); }
+
+.panel-header {
+  display: flex; align-items: center;
+  justify-content: space-between;
+  padding: 28px 28px 24px;
+  border-bottom: 0.5px solid var(--line-1);
+  position: sticky; top: 0;
+  background: var(--bg-0);
+  z-index: 1;
+}
+.panel-header-left {
+  display: flex; align-items: center; gap: 16px;
+}
+
+.panel-close {
+  appearance: none; background: none;
+  border: 0.5px solid var(--line-2); border-radius: 8px;
+  width: 32px; height: 32px; flex-shrink: 0;
+  display: grid; place-items: center;
+  color: var(--fg-3); cursor: pointer; font-size: 13px;
+  transition: border-color .15s, color .15s;
+}
+.panel-close:hover { border-color: var(--fg-2); color: var(--fg-1); }
+
+.panel-glyph {
+  width: 52px; height: 52px; border-radius: 13px; flex-shrink: 0;
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 16px; font-weight: 500;
+}
+.panel-glyph.skill    { background: var(--gold-soft); border: 0.5px solid rgba(184,150,62,.32); color: var(--gold); }
+.panel-glyph.routine  { background: rgba(74,158,255,0.08); border: 0.5px solid rgba(74,158,255,.25); color: var(--accent); }
+.panel-glyph.ambiance { background: rgba(54,211,153,0.08); border: 0.5px solid rgba(54,211,153,.25); color: var(--green); }
+
+.panel-name { font-size: 17px; color: var(--fg-0); line-height: 1.2; letter-spacing: -0.01em; }
+.panel-type-badge {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase;
+  margin-top: 5px; color: var(--fg-3);
+}
+.panel-type-badge.routine  { color: var(--accent); }
+.panel-type-badge.ambiance { color: var(--green); }
+
+.panel-body {
+  padding: 24px 28px;
+  display: flex; flex-direction: column; gap: 24px;
+}
+
+.panel-desc {
+  font-size: 13px; color: var(--fg-2); line-height: 1.7;
+}
+
+.panel-section {
+  display: flex; flex-direction: column; gap: 0;
+}
+
+.panel-section-title {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--fg-3);
+  padding-bottom: 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 14px;
+}
+
+.panel-check-row {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.panel-check-label { font-size: 13px; color: var(--fg-1); }
+.panel-check-status {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 8px; border-radius: 4px;
+}
+.panel-check-status.ok { color: var(--green); background: var(--green-soft); border: 0.5px solid rgba(54,211,153,.3); }
+.panel-check-status.ko { color: var(--fg-3); background: var(--bg-1); border: 0.5px solid var(--line-2); }
+
+.panel-field {
+  display: flex; flex-direction: column; gap: 7px;
+  margin-bottom: 14px;
+}
+.panel-field-label {
+  font-size: 12px; color: var(--fg-2);
+}
+.panel-field-input {
+  width: 100%; box-sizing: border-box;
+  background: var(--bg-1); border: 0.5px solid var(--line-2);
+  border-radius: 8px; padding: 10px 13px;
+  font-family: var(--mono); font-size: 12px; color: var(--fg-1);
+  outline: none; transition: border-color .15s;
+}
+.panel-field-input:focus { border-color: var(--gold); }
+
+.panel-save-btn {
+  appearance: none; background: var(--gold-soft);
+  border: 0.5px solid rgba(184,150,62,.32); border-radius: 8px;
+  color: var(--gold); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 9px 16px; cursor: pointer; transition: all .15s;
+  margin-top: 6px; align-self: flex-start;
+}
+.panel-save-btn:hover { background: rgba(184,150,62,.22); }
+.panel-save-btn:disabled { opacity: .5; cursor: default; }
+
+.panel-run-btn {
+  appearance: none; background: rgba(74,158,255,0.08);
+  border: 0.5px solid rgba(74,158,255,.25); border-radius: 8px;
+  color: var(--accent); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 9px 16px; cursor: pointer; transition: all .15s;
+  align-self: flex-start;
+}
+.panel-run-btn:hover { background: rgba(74,158,255,.15); }
+.panel-run-btn:disabled { opacity: .5; cursor: default; }
+
+/* ── Appareils v2 — grandes cartes avec modèles 3D ── */
+.device-grid-v2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.dv-card-v2 {
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-1);
+  border-radius: 20px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: border-color .22s, box-shadow .22s, transform .22s;
+}
+
+.dv-card-v2:hover {
+  transform: translateY(-3px);
+}
+
+/* ── Carte inactive — assombrie ── */
+.dv-card--dim {
+  border-color: rgba(220, 232, 255, 0.04);
+}
+.dv-card--dim .dv-scene-wrap {
+  filter: brightness(0.40) saturate(0.25);
+}
+.dv-card--dim .dv-body-v2 {
+  opacity: 0.48;
+}
+.dv-card--dim:hover {
+  border-color: rgba(220, 232, 255, 0.10);
+  box-shadow: 0 16px 48px -16px rgba(0,0,0,.6);
+}
+
+/* ── Carte active — halo bleu pulsant ── */
+.dv-card--glow-green {
+  border-color: rgba(74, 158, 255, 0.30);
+  animation: cardGlowBlue 3.2s ease-in-out infinite;
+}
+@keyframes cardGlowBlue {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(74,158,255,.08), 0 0 24px -6px rgba(74,158,255,.18), 0 20px 64px -16px rgba(0,0,0,.65); }
+  50%       { box-shadow: 0 0 0 1px rgba(74,158,255,.16), 0 0 40px -4px rgba(74,158,255,.30), 0 20px 64px -16px rgba(0,0,0,.65); }
+}
+.dv-card--glow-green:hover {
+  border-color: rgba(74, 158, 255, 0.48);
+  animation: none;
+  box-shadow: 0 0 0 1px rgba(74,158,255,.20), 0 0 48px -4px rgba(74,158,255,.36), 0 24px 72px -12px rgba(0,0,0,.72);
+}
+
+/* ── Carte nearby/bootloader — halo bleu ── */
+.dv-card--glow-accent {
+  border-color: rgba(74, 158, 255, 0.28);
+  animation: cardGlowAccent 3.2s ease-in-out infinite;
+}
+@keyframes cardGlowAccent {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(74,158,255,.08), 0 0 24px -6px rgba(74,158,255,.18), 0 20px 64px -16px rgba(0,0,0,.65); }
+  50%       { box-shadow: 0 0 0 1px rgba(74,158,255,.16), 0 0 40px -4px rgba(74,158,255,.30), 0 20px 64px -16px rgba(0,0,0,.65); }
+}
+.dv-card--glow-accent:hover {
+  border-color: rgba(74, 158, 255, 0.46);
+  animation: none;
+  box-shadow: 0 0 0 1px rgba(74,158,255,.20), 0 0 48px -4px rgba(74,158,255,.36), 0 24px 72px -12px rgba(0,0,0,.72);
+}
+
+/* Zone scène 3D */
+.dv-scene-wrap {
+  height: 200px;
+  position: relative;
+  background: radial-gradient(ellipse at 50% 42%, rgba(74,158,255,.05) 0%, transparent 70%);
+  border-bottom: 0.5px solid var(--line-1);
+  overflow: hidden;
+}
+
+/* Halo sol (au-dessus du canvas WebGL) */
+.dv-scene-wrap::after {
+  content: '';
+  position: absolute;
+  bottom: 18px; left: 50%;
+  transform: translateX(-50%);
+  width: 110px; height: 16px;
+  background: rgba(74,158,255,.10);
+  border-radius: 50%;
+  filter: blur(10px);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Canvas Three.js — plein cadre */
+.dv-scene-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+}
+
+/* ─── Card info zone ─── */
+.dv-body-v2 {
+  padding: 18px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dv-name-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.dv-name-v2 {
+  font-size: 15px;
+  color: var(--fg-0);
+  letter-spacing: -.01em;
+  line-height: 1.2;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dv-badge {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.dv-badge.green  { color: var(--green);  background: var(--green-soft);  border: 0.5px solid rgba(54,211,153,.3); }
+.dv-badge.muted  { color: var(--fg-3);   background: transparent;         border: 0.5px solid var(--line-2); }
+.dv-badge.accent { color: var(--accent); background: var(--accent-soft);  border: 0.5px solid var(--accent-line); }
+
+.dv-sub-v2 {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--fg-3);
+  letter-spacing: .08em;
+}
+
+.dv-meta-v2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 0.5px solid var(--line-1);
+}
+
+.dv-meta-item-v2 { display: flex; flex-direction: column; gap: 2px; }
+
+.dv-meta-k-v2 {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--fg-4);
+}
+
+.dv-meta-v-v2 {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-1);
+  letter-spacing: .04em;
+}
+
+/* ── À venir (Écosystème) ── */
+.coming-soon-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 48px 0 32px;
+}
+
+.coming-soon-msg {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: .22em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+
+/* ── Sessions (Fils) ── */
+.session-row {
+  display: grid; grid-template-columns: 60px 1fr auto auto;
+  align-items: center; gap: 14px;
+  padding: 13px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.sess-id { font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; color: var(--fg-3); }
+.sess-preview { font-size: 12.5px; color: var(--fg-1); line-height: 1.3; }
+.sess-date { font-family: var(--mono); font-size: 10px; color: var(--fg-3); white-space: nowrap; }
+
+.sess-rename-editor {
+  display: none; flex-direction: column; gap: 10px;
+  padding: 10px 0 16px;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.sess-rename-editor.open { display: flex; }
+.sess-rename-input {
+  width: 100%; box-sizing: border-box;
+  background: var(--bg-1); border: 0.5px solid var(--line-2);
+  border-radius: 8px; padding: 9px 12px;
+  font-family: var(--mono); font-size: 12px; color: var(--fg-1);
+  outline: none; transition: border-color .15s;
+}
+.sess-rename-input:focus { border-color: var(--gold); }
+
+.sess-viewer {
+  display: none; flex-direction: column; gap: 14px;
+  padding: 14px 0 20px;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.sess-viewer.open { display: flex; }
+
+.sess-msg-list {
+  display: flex; flex-direction: column; gap: 10px;
+  max-height: 480px; overflow-y: auto;
+  padding-right: 4px;
+}
+.sess-msg-list::-webkit-scrollbar { width: 3px; }
+.sess-msg-list::-webkit-scrollbar-thumb { background: var(--line-2); border-radius: 2px; }
+
+.sess-bubble {
+  display: flex; flex-direction: column; gap: 4px;
+  max-width: 82%; padding: 10px 13px;
+  border-radius: 12px; border: 0.5px solid var(--line-1);
+}
+.sess-bubble--user {
+  align-self: flex-end;
+  background: rgba(184,150,62,.07); border-color: rgba(184,150,62,.2);
+}
+.sess-bubble--assistant {
+  align-self: flex-start;
+  background: var(--bg-1);
+}
+.sess-bubble-role {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--fg-3);
+}
+.sess-bubble--user .sess-bubble-role { color: var(--gold); opacity: .7; }
+.sess-bubble-body {
+  font-size: 12.5px; color: var(--fg-1); line-height: 1.55;
+  white-space: pre-wrap; word-break: break-word;
+}
+.sess-msg-empty { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+
+/* ── Mémoire ── */
+.memory-row {
+  display: grid; grid-template-columns: 1fr 60px 80px auto;
+  align-items: center; gap: 14px;
+  padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.mem-name { font-size: 12.5px; color: var(--fg-1); }
+.mem-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); text-align: right; }
+
+.mem-btn-row { display: flex; gap: 6px; align-items: center; flex-shrink: 0; }
+
+.m-btn {
+  appearance: none; background: transparent;
+  border: 0.5px solid var(--line-2); border-radius: 6px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 5px 11px; cursor: pointer; white-space: nowrap;
+  transition: border-color .15s, color .15s, background .15s;
+}
+.m-btn:hover:not(:disabled) { border-color: var(--fg-2); color: var(--fg-0); }
+.m-btn:disabled { opacity: 0.4; cursor: default; }
+
+.m-btn--save {
+  color: var(--gold); border-color: rgba(184,150,62,.32);
+  background: var(--gold-soft);
+}
+.m-btn--save:hover:not(:disabled) { background: rgba(184,150,62,.22); border-color: var(--gold); }
+
+.m-btn--danger {
+  color: rgba(229,72,77,.55); border-color: rgba(229,72,77,.18);
+  background: transparent; padding: 5px 9px;
+}
+.m-btn--danger:hover:not(:disabled) {
+  color: var(--red); border-color: rgba(229,72,77,.55);
+  background: var(--red-soft);
+}
+
+.mem-topic-editor {
+  display: none; flex-direction: column; gap: 10px;
+  padding: 14px 0 20px;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.mem-topic-editor.open { display: flex; }
+
+.mem-textarea {
+  width: 100%; box-sizing: border-box;
+  background: var(--bg-1); border: 0.5px solid var(--line-2);
+  border-radius: 10px; padding: 12px 14px;
+  font-family: var(--mono); font-size: 11.5px; color: var(--fg-1);
+  line-height: 1.6; resize: vertical; min-height: 120px;
+  outline: none; transition: border-color .15s;
+}
+.mem-textarea:focus { border-color: var(--gold); }
+
+/* ── Messagerie — éléments supplémentaires ────────────────────────────────── */
+.cn-section-sep {
+  padding: 18px 0 6px;
+  font-size: 10px; font-weight: 600; letter-spacing: .08em;
+  color: var(--fg-3); text-transform: uppercase;
+  border-top: 0.5px solid var(--line-1);
+  margin-top: 10px;
+}
+
+.cn-stub-note {
+  padding: 10px 14px;
+  font-size: 12px; color: var(--fg-3);
+  background: var(--bg-1); border-radius: 8px;
+  border: 0.5px solid var(--line-1);
+}
+
+.cn-field-hint {
+  font-size: 10.5px; color: var(--fg-3);
+  margin-top: 2px; margin-bottom: 4px;
+  font-family: var(--mono);
+}
+
+/* Toggle inline dans les forms de connecteurs */
+.cn-toggle {
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--line-2); cursor: pointer;
+  transition: background .15s; position: relative; flex-shrink: 0;
+  margin-top: 4px;
+}
+.cn-toggle::after {
+  content: ""; position: absolute;
+  top: 3px; left: 3px;
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3); transition: transform .15s, background .15s;
+}
+.cn-toggle.on { background: var(--green); }
+.cn-toggle.on::after { transform: translateX(16px); background: #fff; }
+
+/* Badge "Bientôt" (sans modificateur .on ou .expired) */
+.cn-badge:not(.on):not(.expired) {
+  color: var(--fg-3);
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-1);
+}

--- a/src/jarvis/interfaces/ui/static/capabilities.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/capabilities.css.bak-1782259625
@@ -1,0 +1,672 @@
+/* capabilities.css — Atelier (Capacités) v2 */
+
+body[data-mode="capacites"] { overflow-y: auto; overflow-x: hidden; }
+
+/* ── Integrations / Connectors (liste) ── */
+.cn-list { display: flex; flex-direction: column; }
+
+.cn-row {
+  display: grid;
+  grid-template-columns: 10px 1fr auto;
+  align-items: center; gap: 18px;
+  padding: 14px 0;
+  border-bottom: 0.5px solid var(--line-1);
+  transition: background .12s;
+}
+.cn-row:first-of-type { border-top: 0.5px solid var(--line-1); }
+
+.cn-dot {
+  width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+}
+.cn-dot.on      { background: var(--green);  box-shadow: 0 0 6px var(--green); }
+.cn-dot.off     { background: var(--fg-4); }
+.cn-dot.expired { background: var(--amber);  box-shadow: 0 0 6px var(--amber); }
+
+.cn-info { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.cn-name { font-size: 13px; color: var(--fg-0); letter-spacing: -0.005em; }
+.cn-sub  { font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.08em; }
+
+.cn-right { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
+
+.cn-badge {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 9px; border-radius: 4px;
+}
+.cn-badge.on      { color: var(--green); background: var(--green-soft); border: 0.5px solid rgba(var(--c-green), .3); }
+.cn-badge.expired { color: var(--amber); background: rgba(230,180,60,.08); border: 0.5px solid rgba(230,180,60,.3); }
+
+.cn-btn {
+  appearance: none; background: none;
+  border: 0.5px solid var(--line-2); border-radius: 8px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 7px 14px; cursor: pointer; white-space: nowrap;
+  transition: border-color .15s, color .15s;
+}
+.cn-btn:hover { border-color: var(--fg-2); color: var(--fg-0); }
+
+/* Zone d'expansion (clé API / CLI) */
+.cn-expand {
+  display: none; flex-direction: column; gap: 12px;
+  padding: 16px 28px 20px;
+  background: var(--bg-1); border-bottom: 0.5px solid var(--line-1);
+}
+.cn-expand.open { display: flex; }
+
+
+.cn-field { display: flex; flex-direction: column; gap: 6px; }
+.cn-field-label { font-size: 11.5px; color: var(--fg-2); }
+.cn-field-input {
+  width: 100%; max-width: 420px; box-sizing: border-box;
+  background: var(--bg-0); border: 0.5px solid var(--line-2);
+  border-radius: 8px; padding: 9px 12px;
+  font-family: var(--mono); font-size: 12px; color: var(--fg-1);
+  outline: none; transition: border-color .15s;
+}
+.cn-field-input:focus { border-color: var(--gold); }
+
+.cn-save-btn {
+  appearance: none; background: var(--gold-soft);
+  border: 0.5px solid rgba(var(--c-gold), .32); border-radius: 8px;
+  color: var(--gold); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 8px 16px; cursor: pointer; transition: all .15s;
+  align-self: flex-start; margin-top: 4px;
+}
+.cn-save-btn:hover { background: rgba(var(--c-gold), .22); }
+.cn-save-btn:disabled { opacity: .5; cursor: default; }
+
+/* ── Skills (Tools) ── */
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(clamp(240px, 28vw, 360px), 1fr));
+  gap: 12px;
+}
+.skill-card {
+  background: var(--bg-1); border: 0.5px solid var(--line-1);
+  border-radius: 14px; padding: 22px 24px;
+  display: flex; flex-direction: column; gap: 12px;
+  cursor: pointer; transition: border-color .15s, background .15s;
+  min-height: 130px;
+}
+.skill-card:hover { border-color: var(--gold-soft); background: rgba(var(--c-gold), 0.04); }
+.skill-glyph {
+  width: 44px; height: 44px; border-radius: 10px;
+  background: var(--gold-soft); border: 0.5px solid rgba(var(--c-gold), .32);
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 14px;
+  color: var(--gold); font-weight: 500;
+  flex-shrink: 0;
+}
+.skill-name { font-size: 14px; color: var(--fg-0); line-height: 1.3; }
+.skill-desc { font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
+
+.skill-install-btn {
+  appearance: none; background: transparent;
+  border: 0.5px solid var(--line-2); border-radius: 6px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 6px 12px; cursor: pointer;
+  transition: border-color .15s, color .15s, background .15s;
+}
+.skill-install-btn:hover:not(:disabled) {
+  border-color: var(--gold);
+  color: var(--gold);
+  background: var(--gold-soft);
+}
+.skill-install-btn:disabled { opacity: 0.4; cursor: default; }
+
+.skill-installed-badge {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--green);
+}
+
+/* ── Routines (cards) ── */
+.routine-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(clamp(240px, 28vw, 360px), 1fr));
+  gap: 12px;
+}
+.routine-card {
+  background: var(--bg-1); border: 0.5px solid var(--line-1);
+  border-radius: 14px; padding: 22px 24px;
+  display: flex; flex-direction: column; gap: 12px;
+  cursor: pointer; transition: border-color .15s, background .15s;
+  min-height: 130px;
+}
+.routine-card:hover { border-color: var(--line-2); background: rgba(var(--c-accent), 0.03); }
+.routine-glyph {
+  width: 44px; height: 44px; border-radius: 10px;
+  background: rgba(var(--c-accent), 0.08); border: 0.5px solid rgba(var(--c-accent), .25);
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 14px;
+  color: var(--accent); font-weight: 500;
+  flex-shrink: 0;
+}
+.routine-name { font-size: 14px; color: var(--fg-0); line-height: 1.3; }
+.routine-desc { font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
+.routine-platforms { display: flex; gap: 5px; flex-wrap: wrap; margin-top: 2px; }
+.view-glyph {
+  background: rgba(var(--c-green), 0.08); border-color: rgba(var(--c-green), .25);
+  color: var(--green);
+}
+
+/* ── Ambiances (cards) ── */
+.ambiance-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(clamp(240px, 28vw, 360px), 1fr));
+  gap: 12px;
+}
+.ambiance-card {
+  background: var(--bg-1); border: 0.5px solid var(--line-1);
+  border-radius: 14px; padding: 22px 24px;
+  display: flex; flex-direction: column; gap: 12px;
+  cursor: pointer; transition: border-color .15s, background .15s;
+  min-height: 130px;
+}
+.ambiance-card:hover { border-color: var(--line-2); background: rgba(var(--c-green), 0.03); }
+.ambiance-glyph {
+  width: 44px; height: 44px; border-radius: 10px;
+  background: rgba(var(--c-green), 0.08); border: 0.5px solid rgba(var(--c-green), .25);
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 14px;
+  color: var(--green); font-weight: 500;
+  flex-shrink: 0;
+}
+.ambiance-name { font-size: 14px; color: var(--fg-0); line-height: 1.3; }
+.ambiance-desc { font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); letter-spacing: 0.04em; line-height: 1.55; }
+
+/* ── Presets legacy ── */
+.preset-platforms { display: flex; gap: 5px; }
+.preset-platform {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 2px 6px; border: 0.5px solid var(--line-2); border-radius: 4px; color: var(--fg-3);
+}
+
+/* ─────────────────────────────────────────
+   DETAIL PANEL
+───────────────────────────────────────── */
+#detail-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 900;
+  opacity: 0; pointer-events: none;
+  transition: opacity .25s ease;
+}
+#detail-overlay.open { opacity: 1; pointer-events: auto; }
+
+#detail-panel {
+  position: fixed; right: 0; top: 0;
+  height: 100dvh; width: 480px; max-width: 100vw;
+  background: var(--bg-0);
+  border-left: 0.5px solid var(--line-1);
+  z-index: 901;
+  overflow-y: auto;
+  transform: translateX(100%);
+  transition: transform .28s cubic-bezier(.32, .72, 0, 1);
+}
+#detail-panel.open { transform: translateX(0); }
+
+.panel-header {
+  display: flex; align-items: center;
+  justify-content: space-between;
+  padding: 28px 28px 24px;
+  border-bottom: 0.5px solid var(--line-1);
+  position: sticky; top: 0;
+  background: var(--bg-0);
+  z-index: 1;
+}
+.panel-header-left {
+  display: flex; align-items: center; gap: 16px;
+}
+
+.panel-close {
+  appearance: none; background: none;
+  border: 0.5px solid var(--line-2); border-radius: 8px;
+  width: 32px; height: 32px; flex-shrink: 0;
+  display: grid; place-items: center;
+  color: var(--fg-3); cursor: pointer; font-size: 13px;
+  transition: border-color .15s, color .15s;
+}
+.panel-close:hover { border-color: var(--fg-2); color: var(--fg-1); }
+
+.panel-glyph {
+  width: 52px; height: 52px; border-radius: 13px; flex-shrink: 0;
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 16px; font-weight: 500;
+}
+.panel-glyph.skill    { background: var(--gold-soft); border: 0.5px solid rgba(var(--c-gold), .32); color: var(--gold); }
+.panel-glyph.routine  { background: rgba(var(--c-accent), 0.08); border: 0.5px solid rgba(var(--c-accent), .25); color: var(--accent); }
+.panel-glyph.ambiance { background: rgba(var(--c-green), 0.08); border: 0.5px solid rgba(var(--c-green), .25); color: var(--green); }
+
+.panel-name { font-size: 17px; color: var(--fg-0); line-height: 1.2; letter-spacing: -0.01em; }
+.panel-type-badge {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase;
+  margin-top: 5px; color: var(--fg-3);
+}
+.panel-type-badge.routine  { color: var(--accent); }
+.panel-type-badge.ambiance { color: var(--green); }
+
+.panel-body {
+  padding: 24px 28px;
+  display: flex; flex-direction: column; gap: 24px;
+}
+
+.panel-desc {
+  font-size: 13px; color: var(--fg-2); line-height: 1.7;
+}
+
+.panel-section {
+  display: flex; flex-direction: column; gap: 0;
+}
+
+.panel-section-title {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--fg-3);
+  padding-bottom: 12px;
+  border-bottom: 0.5px solid var(--line-1);
+  margin-bottom: 14px;
+}
+
+.panel-check-row {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.panel-check-label { font-size: 13px; color: var(--fg-1); }
+.panel-check-status {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 3px 8px; border-radius: 4px;
+}
+.panel-check-status.ok { color: var(--green); background: var(--green-soft); border: 0.5px solid rgba(var(--c-green), .3); }
+.panel-check-status.ko { color: var(--fg-3); background: var(--bg-1); border: 0.5px solid var(--line-2); }
+
+.panel-field {
+  display: flex; flex-direction: column; gap: 7px;
+  margin-bottom: 14px;
+}
+.panel-field-label {
+  font-size: 12px; color: var(--fg-2);
+}
+.panel-field-input {
+  width: 100%; box-sizing: border-box;
+  background: var(--bg-1); border: 0.5px solid var(--line-2);
+  border-radius: 8px; padding: 10px 13px;
+  font-family: var(--mono); font-size: 12px; color: var(--fg-1);
+  outline: none; transition: border-color .15s;
+}
+.panel-field-input:focus { border-color: var(--gold); }
+
+.panel-save-btn {
+  appearance: none; background: var(--gold-soft);
+  border: 0.5px solid rgba(var(--c-gold), .32); border-radius: 8px;
+  color: var(--gold); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 9px 16px; cursor: pointer; transition: all .15s;
+  margin-top: 6px; align-self: flex-start;
+}
+.panel-save-btn:hover { background: rgba(var(--c-gold), .22); }
+.panel-save-btn:disabled { opacity: .5; cursor: default; }
+
+.panel-run-btn {
+  appearance: none; background: rgba(var(--c-accent), 0.08);
+  border: 0.5px solid rgba(var(--c-accent), .25); border-radius: 8px;
+  color: var(--accent); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 9px 16px; cursor: pointer; transition: all .15s;
+  align-self: flex-start;
+}
+.panel-run-btn:hover { background: rgba(var(--c-accent), .15); }
+.panel-run-btn:disabled { opacity: .5; cursor: default; }
+
+/* ── Appareils v2 — grandes cartes avec modèles 3D ── */
+.device-grid-v2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.dv-card-v2 {
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-1);
+  border-radius: 20px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: border-color .22s, box-shadow .22s, transform .22s;
+}
+
+.dv-card-v2:hover {
+  transform: translateY(-3px);
+}
+
+/* ── Carte inactive — assombrie ── */
+.dv-card--dim {
+  border-color: rgba(var(--c-fg), 0.04);
+}
+.dv-card--dim .dv-scene-wrap {
+  filter: brightness(0.40) saturate(0.25);
+}
+.dv-card--dim .dv-body-v2 {
+  opacity: 0.48;
+}
+.dv-card--dim:hover {
+  border-color: rgba(var(--c-fg), 0.10);
+  box-shadow: 0 16px 48px -16px rgba(0,0,0,.6);
+}
+
+/* ── Carte active — halo bleu pulsant ── */
+.dv-card--glow-green {
+  border-color: rgba(var(--c-accent), 0.30);
+  animation: cardGlowBlue 3.2s ease-in-out infinite;
+}
+@keyframes cardGlowBlue {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(var(--c-accent), .08), 0 0 24px -6px rgba(var(--c-accent), .18), 0 20px 64px -16px rgba(0,0,0,.65); }
+  50%       { box-shadow: 0 0 0 1px rgba(var(--c-accent), .16), 0 0 40px -4px rgba(var(--c-accent), .30), 0 20px 64px -16px rgba(0,0,0,.65); }
+}
+.dv-card--glow-green:hover {
+  border-color: rgba(var(--c-accent), 0.48);
+  animation: none;
+  box-shadow: 0 0 0 1px rgba(var(--c-accent), .20), 0 0 48px -4px rgba(var(--c-accent), .36), 0 24px 72px -12px rgba(0,0,0,.72);
+}
+
+/* ── Carte nearby/bootloader — halo bleu ── */
+.dv-card--glow-accent {
+  border-color: rgba(var(--c-accent), 0.28);
+  animation: cardGlowAccent 3.2s ease-in-out infinite;
+}
+@keyframes cardGlowAccent {
+  0%, 100% { box-shadow: 0 0 0 1px rgba(var(--c-accent), .08), 0 0 24px -6px rgba(var(--c-accent), .18), 0 20px 64px -16px rgba(0,0,0,.65); }
+  50%       { box-shadow: 0 0 0 1px rgba(var(--c-accent), .16), 0 0 40px -4px rgba(var(--c-accent), .30), 0 20px 64px -16px rgba(0,0,0,.65); }
+}
+.dv-card--glow-accent:hover {
+  border-color: rgba(var(--c-accent), 0.46);
+  animation: none;
+  box-shadow: 0 0 0 1px rgba(var(--c-accent), .20), 0 0 48px -4px rgba(var(--c-accent), .36), 0 24px 72px -12px rgba(0,0,0,.72);
+}
+
+/* Zone scène 3D */
+.dv-scene-wrap {
+  height: 200px;
+  position: relative;
+  background: radial-gradient(ellipse at 50% 42%, rgba(var(--c-accent), .05) 0%, transparent 70%);
+  border-bottom: 0.5px solid var(--line-1);
+  overflow: hidden;
+}
+
+/* Halo sol (au-dessus du canvas WebGL) */
+.dv-scene-wrap::after {
+  content: '';
+  position: absolute;
+  bottom: 18px; left: 50%;
+  transform: translateX(-50%);
+  width: 110px; height: 16px;
+  background: rgba(var(--c-accent), .10);
+  border-radius: 50%;
+  filter: blur(10px);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Canvas Three.js — plein cadre */
+.dv-scene-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+}
+
+/* ─── Card info zone ─── */
+.dv-body-v2 {
+  padding: 18px 20px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dv-name-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.dv-name-v2 {
+  font-size: 15px;
+  color: var(--fg-0);
+  letter-spacing: -.01em;
+  line-height: 1.2;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dv-badge {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.dv-badge.green  { color: var(--green);  background: var(--green-soft);  border: 0.5px solid rgba(var(--c-green), .3); }
+.dv-badge.muted  { color: var(--fg-3);   background: transparent;         border: 0.5px solid var(--line-2); }
+.dv-badge.accent { color: var(--accent); background: var(--accent-soft);  border: 0.5px solid var(--accent-line); }
+
+.dv-sub-v2 {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--fg-3);
+  letter-spacing: .08em;
+}
+
+.dv-meta-v2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 0.5px solid var(--line-1);
+}
+
+.dv-meta-item-v2 { display: flex; flex-direction: column; gap: 2px; }
+
+.dv-meta-k-v2 {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--fg-4);
+}
+
+.dv-meta-v-v2 {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-1);
+  letter-spacing: .04em;
+}
+
+/* ── À venir (Écosystème) ── */
+.coming-soon-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 48px 0 32px;
+}
+
+.coming-soon-msg {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: .22em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+
+/* ── Sessions (Fils) ── */
+.session-row {
+  display: grid; grid-template-columns: 60px 1fr auto auto;
+  align-items: center; gap: 14px;
+  padding: 13px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.sess-id { font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; color: var(--fg-3); }
+.sess-preview { font-size: 12.5px; color: var(--fg-1); line-height: 1.3; }
+.sess-date { font-family: var(--mono); font-size: 10px; color: var(--fg-3); white-space: nowrap; }
+
+.sess-rename-editor {
+  display: none; flex-direction: column; gap: 10px;
+  padding: 10px 0 16px;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.sess-rename-editor.open { display: flex; }
+.sess-rename-input {
+  width: 100%; box-sizing: border-box;
+  background: var(--bg-1); border: 0.5px solid var(--line-2);
+  border-radius: 8px; padding: 9px 12px;
+  font-family: var(--mono); font-size: 12px; color: var(--fg-1);
+  outline: none; transition: border-color .15s;
+}
+.sess-rename-input:focus { border-color: var(--gold); }
+
+.sess-viewer {
+  display: none; flex-direction: column; gap: 14px;
+  padding: 14px 0 20px;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.sess-viewer.open { display: flex; }
+
+.sess-msg-list {
+  display: flex; flex-direction: column; gap: 10px;
+  max-height: 480px; overflow-y: auto;
+  padding-right: 4px;
+}
+.sess-msg-list::-webkit-scrollbar { width: 3px; }
+.sess-msg-list::-webkit-scrollbar-thumb { background: var(--line-2); border-radius: 2px; }
+
+.sess-bubble {
+  display: flex; flex-direction: column; gap: 4px;
+  max-width: 82%; padding: 10px 13px;
+  border-radius: 12px; border: 0.5px solid var(--line-1);
+}
+.sess-bubble--user {
+  align-self: flex-end;
+  background: rgba(var(--c-gold), .07); border-color: rgba(var(--c-gold), .2);
+}
+.sess-bubble--assistant {
+  align-self: flex-start;
+  background: var(--bg-1);
+}
+.sess-bubble-role {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--fg-3);
+}
+.sess-bubble--user .sess-bubble-role { color: var(--gold); opacity: .7; }
+.sess-bubble-body {
+  font-size: 12.5px; color: var(--fg-1); line-height: 1.55;
+  white-space: pre-wrap; word-break: break-word;
+}
+.sess-msg-empty { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+
+/* ── Mémoire ── */
+.memory-row {
+  display: grid; grid-template-columns: 1fr 60px 80px auto;
+  align-items: center; gap: 14px;
+  padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.mem-name { font-size: 12.5px; color: var(--fg-1); }
+.mem-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-3); text-align: right; }
+
+.mem-btn-row { display: flex; gap: 6px; align-items: center; flex-shrink: 0; }
+
+.m-btn {
+  appearance: none; background: transparent;
+  border: 0.5px solid var(--line-2); border-radius: 6px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 5px 11px; cursor: pointer; white-space: nowrap;
+  transition: border-color .15s, color .15s, background .15s;
+}
+.m-btn:hover:not(:disabled) { border-color: var(--fg-2); color: var(--fg-0); }
+.m-btn:disabled { opacity: 0.4; cursor: default; }
+
+.m-btn--save {
+  color: var(--gold); border-color: rgba(var(--c-gold), .32);
+  background: var(--gold-soft);
+}
+.m-btn--save:hover:not(:disabled) { background: rgba(var(--c-gold), .22); border-color: var(--gold); }
+
+.m-btn--danger {
+  color: rgba(var(--c-red), .55); border-color: rgba(var(--c-red), .18);
+  background: transparent; padding: 5px 9px;
+}
+.m-btn--danger:hover:not(:disabled) {
+  color: var(--red); border-color: rgba(var(--c-red), .55);
+  background: var(--red-soft);
+}
+
+.mem-topic-editor {
+  display: none; flex-direction: column; gap: 10px;
+  padding: 14px 0 20px;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.mem-topic-editor.open { display: flex; }
+
+.mem-textarea {
+  width: 100%; box-sizing: border-box;
+  background: var(--bg-1); border: 0.5px solid var(--line-2);
+  border-radius: 10px; padding: 12px 14px;
+  font-family: var(--mono); font-size: 11.5px; color: var(--fg-1);
+  line-height: 1.6; resize: vertical; min-height: 120px;
+  outline: none; transition: border-color .15s;
+}
+.mem-textarea:focus { border-color: var(--gold); }
+
+/* ── Messagerie — éléments supplémentaires ────────────────────────────────── */
+.cn-section-sep {
+  padding: 18px 0 6px;
+  font-size: 10px; font-weight: 600; letter-spacing: .08em;
+  color: var(--fg-3); text-transform: uppercase;
+  border-top: 0.5px solid var(--line-1);
+  margin-top: 10px;
+}
+
+.cn-stub-note {
+  padding: 10px 14px;
+  font-size: 12px; color: var(--fg-3);
+  background: var(--bg-1); border-radius: 8px;
+  border: 0.5px solid var(--line-1);
+}
+
+.cn-field-hint {
+  font-size: 10.5px; color: var(--fg-3);
+  margin-top: 2px; margin-bottom: 4px;
+  font-family: var(--mono);
+}
+
+/* Toggle inline dans les forms de connecteurs */
+.cn-toggle {
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--line-2); cursor: pointer;
+  transition: background .15s; position: relative; flex-shrink: 0;
+  margin-top: 4px;
+}
+.cn-toggle::after {
+  content: ""; position: absolute;
+  top: 3px; left: 3px;
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3); transition: transform .15s, background .15s;
+}
+.cn-toggle.on { background: var(--green); }
+.cn-toggle.on::after { transform: translateX(16px); background: #fff; }
+
+/* Badge "Bientôt" (sans modificateur .on ou .expired) */
+.cn-badge:not(.on):not(.expired) {
+  color: var(--fg-3);
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-1);
+}

--- a/src/jarvis/interfaces/ui/static/capabilities.html
+++ b/src/jarvis/interfaces/ui/static/capabilities.html
@@ -9,12 +9,14 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
 <link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
 <link rel="stylesheet" href="/capabilities.css" />
 </head>
 <body data-mode="capacites">
 <div id="page-root"></div>
 <script src="/three.min.js"></script>
 <script src="/_shared.js"></script>
+<script src="/mission_control.js"></script>
 <script src="/capabilities.js"></script>
 </body>
 </html>

--- a/src/jarvis/interfaces/ui/static/capabilities.html.bak-1782249020
+++ b/src/jarvis/interfaces/ui/static/capabilities.html.bak-1782249020
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Atelier</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/capabilities.css" />
+</head>
+<body data-mode="capacites">
+<div id="page-root"></div>
+<script src="/three.min.js"></script>
+<script src="/_shared.js"></script>
+<script src="/capabilities.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/capabilities.js.bak-1782165579
+++ b/src/jarvis/interfaces/ui/static/capabilities.js.bak-1782165579
@@ -1,0 +1,1682 @@
+/* capabilities.js — Atelier (Capacités) v2
+ * 9 sous-pages : Intégrations · Skills · Routines · Vues · Store · Écosystème · Appareils · Fils · Mémoire
+ */
+(function () {
+  "use strict";
+  const J = window.Jarvis, el = J.el;
+
+  const PAGES = [
+    { id: "integrations", label: "Intégrations" },
+    { id: "skills",       label: "Skills" },
+    { id: "routines",     label: "Routines" },
+    { id: "vues",         label: "Vues" },
+    { id: "store",        label: "Store" },
+    { id: "ecosysteme",   label: "Écosystème" },
+    { id: "appareils",    label: "Appareils" },
+    { id: "fils",         label: "Fils" },
+    { id: "memoire",      label: "Mémoire" },
+  ];
+
+  let _activePage = "integrations";
+  const root = document.getElementById("page-root");
+
+  /* ─── Config des connecteurs ─── */
+  const CONNECTOR_CONFIG = {
+    "Gmail":              { kind: "oauth_key", url: "/api/google/auth/gmail", keys: [
+      { key: "GOOGLE_CLIENT_ID",     label: "Client ID",     secret: false, hint: "console.cloud.google.com · OAuth client type « Web » · Redirect URIs : http://127.0.0.1:8000/api/google/callback/gmail + .../calendar" },
+      { key: "GOOGLE_CLIENT_SECRET", label: "Client Secret", secret: true },
+    ]},
+    "Google Calendar":    { kind: "oauth_key", url: "/api/google/auth/calendar", keys: [
+      { key: "GOOGLE_CLIENT_ID",     label: "Client ID",     secret: false, hint: "Mêmes identifiants que Gmail (partagés) · OAuth client type « Web »" },
+      { key: "GOOGLE_CLIENT_SECRET", label: "Client Secret", secret: true },
+    ]},
+    "Spotify":            { kind: "oauth_key", url: "/api/spotify/auth", keys: [
+      { key: "SPOTIFY_CLIENT_ID",     label: "Client ID",     secret: false, hint: "developer.spotify.com/dashboard · Redirect URI : http://127.0.0.1:8000/api/spotify/callback" },
+      { key: "SPOTIFY_CLIENT_SECRET", label: "Client Secret", secret: true },
+    ]},
+    "Deezer":             { kind: "oauth_key", url: "/api/deezer/auth", keys: [
+      { key: "DEEZER_APP_ID",     label: "App ID",     secret: false, hint: "developers.deezer.com/myapps · Redirect URL : http://127.0.0.1:8000/api/deezer/callback" },
+      { key: "DEEZER_APP_SECRET", label: "Secret Key", secret: true },
+    ]},
+    "Notion":             { kind: "key",   keys: [{ key: "NOTION_TOKEN",         label: "Token d'intégration", secret: true }] },
+    "Anthropic (Claude)": { kind: "key",   keys: [{ key: "ANTHROPIC_API_KEY",    label: "Clé API Anthropic",   secret: true }] },
+    "ElevenLabs":         { kind: "key",   keys: [{ key: "ELEVENLABS_API_KEY",   label: "Clé API ElevenLabs",  secret: true }] },
+    "OpenAI":             { kind: "key",   keys: [{ key: "OPENAI_API_KEY",       label: "Clé API OpenAI",      secret: true }] },
+    "Google (API Key)":   { kind: "key",   keys: [{ key: "GOOGLE_API_KEY",       label: "Clé API Google",      secret: true }] },
+    "LiveKit":            { kind: "key",   keys: [
+      { key: "LIVEKIT_URL",        label: "URL",        secret: false },
+      { key: "LIVEKIT_API_KEY",    label: "API Key",    secret: true },
+      { key: "LIVEKIT_API_SECRET", label: "API Secret", secret: true },
+    ]},
+    "Deepgram":           { kind: "key",   keys: [{ key: "DEEPGRAM_API_KEY",     label: "Clé API Deepgram",    secret: true }] },
+    "Mistral":            { kind: "key",   keys: [{ key: "MISTRAL_API_KEY",      label: "Clé API Mistral",     secret: true }] },
+    // ── Messagerie ───────────────────────────────────────────────────────────
+    "Telegram":           { kind: "messaging", keys: [
+      { key: "TELEGRAM_BOT_TOKEN", label: "Bot Token",              secret: true,  hint: "@BotFather → /newbot" },
+      { key: "TELEGRAM_OWNER_ID",  label: "Ton User ID",            secret: false, hint: "@userinfobot → envoie un message" },
+      { key: "TELEGRAM_ENABLED",   label: "Activer le bot",         secret: false, type: "toggle" },
+    ]},
+    "Discord":            { kind: "messaging", keys: [
+      { key: "DISCORD_BOT_TOKEN",  label: "Bot Token",              secret: true,  hint: "discord.com/developers → Bot" },
+      { key: "DISCORD_OWNER_ID",   label: "Ton User ID",            secret: false, hint: "Profil → Copier l'identifiant" },
+      { key: "DISCORD_ENABLED",    label: "Activer le bot",         secret: false, type: "toggle" },
+    ]},
+    "WhatsApp":           { kind: "stub", note: "Bientôt disponible via Twilio ou WhatsApp Business API (WABA)." },
+  };
+
+  /* ─── Skills reclassifiés en routines ─── */
+  const SKILL_AS_ROUTINE = new Set(["mode-streameur"]);
+
+  /* ─── Registre de config statique ─── */
+  const CONFIGS = {
+    "fusion360": {
+      fullDesc: "Contrôle Autodesk Fusion 360 via MCP HTTP — scripts Python API, lecture et modification de designs 3D, undo/redo, export et lancement d'actions Fusion directement depuis Jarvis.",
+      fields: [
+        { key: "FUSION360_CLIENT_ID",     label: "Client ID",      hint: "Depuis app.autodesk.com", secret: false },
+        { key: "FUSION360_CLIENT_SECRET", label: "Client Secret",  hint: "", secret: true },
+        { key: "FUSION360_MCP_URL",       label: "MCP Server URL", hint: "http://localhost:8765", secret: false },
+      ],
+    },
+    "bambulab-printer": {
+      fullDesc: "Contrôle l'imprimante 3D BambuLab — slice STL, lancement et suivi d'impression via MQTT et API Cloud BambuLab. Compatible X1C, P1S, A1.",
+      fields: [
+        { key: "BAMBULAB_API_KEY", label: "Clé API Bambulab",     hint: "makerworld.bambulab.com", secret: true },
+        { key: "BAMBULAB_SERIAL",  label: "Numéro de série",      hint: "XXXXXXXXXX", secret: false },
+        { key: "BAMBULAB_IP",      label: "IP locale imprimante", hint: "192.168.1.x", secret: false },
+      ],
+    },
+    "mode-streameur": {
+      isRoutine: true,
+      fullDesc: "Lance l'environnement stream complet — OBS Studio, scènes préconfigurées, overlay Twitch. Jarvis orchestre le démarrage, gère les transitions et t'alerte si une app ne répond pas.",
+      appChecks: ["OBS Studio", "Twitch"],
+      fields: [
+        { key: "TWITCH_CLIENT_ID",     label: "Twitch Client ID",       hint: "dev.twitch.tv", secret: false },
+        { key: "TWITCH_CLIENT_SECRET", label: "Twitch Client Secret",   hint: "", secret: true },
+        { key: "OBS_WS_HOST",          label: "OBS WebSocket host",     hint: "localhost:4455", secret: false },
+        { key: "OBS_WS_PASSWORD",      label: "OBS WebSocket password", hint: "", secret: true },
+      ],
+    },
+  };
+
+  /* ─────────────────────────────────────────
+     DETAIL PANEL
+  ───────────────────────────────────────── */
+  let _panelKeyListener = null;
+
+  function initPanel() {
+    if (document.getElementById("detail-panel")) return;
+    const overlay = el("div", { id: "detail-overlay" });
+    overlay.addEventListener("click", closePanel);
+    document.body.appendChild(overlay);
+    document.body.appendChild(el("div", { id: "detail-panel" }));
+    _panelKeyListener = e => { if (e.key === "Escape") closePanel(); };
+    document.addEventListener("keydown", _panelKeyListener);
+  }
+
+  function closePanel() {
+    const panel = document.getElementById("detail-panel");
+    const overlay = document.getElementById("detail-overlay");
+    if (panel) panel.classList.remove("open");
+    if (overlay) overlay.classList.remove("open");
+  }
+
+  function openPanel(buildFn, data) {
+    initPanel();
+    const panel = document.getElementById("detail-panel");
+    panel.innerHTML = "";
+    buildFn(panel, data);
+    const overlay = document.getElementById("detail-overlay");
+    requestAnimationFrame(() => {
+      overlay.classList.add("open");
+      panel.classList.add("open");
+    });
+  }
+
+  function makeCloseBtn() {
+    const btn = el("button", { class: "panel-close", text: "✕" });
+    btn.addEventListener("click", closePanel);
+    return btn;
+  }
+
+  function appendConfigSection(panel, displayName, cfg) {
+    if (!cfg.fields || !cfg.fields.length) return;
+    const sec = el("div", { class: "panel-section" });
+    sec.appendChild(el("div", { class: "panel-section-title", text: "Configuration" }));
+    const inputs = [];
+    cfg.fields.forEach(f => {
+      const fw = el("div", { class: "panel-field" });
+      fw.appendChild(el("div", { class: "panel-field-label", text: f.label }));
+      const inp = el("input", { class: "panel-field-input", type: f.secret ? "password" : "text", placeholder: f.hint || "" });
+      J.api.get("/api/settings").then(ss => {
+        const v = (ss.api_keys || {})[f.key] || "";
+        if (v) inp.value = v;
+      }).catch(() => {});
+      fw.appendChild(inp);
+      inputs.push({ key: f.key, inp });
+      sec.appendChild(fw);
+    });
+    const saveBtn = el("button", { class: "panel-save-btn", text: "Sauvegarder" });
+    saveBtn.addEventListener("click", async () => {
+      saveBtn.textContent = "…"; saveBtn.disabled = true;
+      try {
+        for (const { key, inp } of inputs) {
+          if (inp.value) await J.api.post("/api/settings/update", { key, value: inp.value });
+        }
+        J.notify({ kind: "success", text: displayName + " · config sauvegardée" });
+      } catch (e) {
+        J.notify({ kind: "error", text: e.message });
+      }
+      saveBtn.textContent = "Sauvegarder"; saveBtn.disabled = false;
+    });
+    sec.appendChild(saveBtn);
+    panel.appendChild(sec);
+  }
+
+  /* ─── Skill panel ─── */
+  function buildSkillPanel(panel, s) {
+    const cfg = CONFIGS[s.name] || {};
+    const glyph3 = (s.name || "?").slice(0, 3).toUpperCase();
+
+    const hdr = el("div", { class: "panel-header" });
+    const left = el("div", { class: "panel-header-left" });
+    const glyph = el("div", { class: "panel-glyph skill", text: glyph3 });
+    const info = el("div");
+    info.appendChild(el("div", { class: "panel-name", text: s.name }));
+    info.appendChild(el("div", { class: "panel-type-badge", text: "SKILL" }));
+    left.appendChild(glyph); left.appendChild(info);
+    hdr.appendChild(left); hdr.appendChild(makeCloseBtn());
+    panel.appendChild(hdr);
+
+    const body = el("div", { class: "panel-body" });
+    body.appendChild(el("div", { class: "panel-desc", text: cfg.fullDesc || s.description || "—" }));
+
+    const stSec = el("div", { class: "panel-section" });
+    stSec.appendChild(el("div", { class: "panel-section-title", text: "Statut" }));
+    const stRow = el("div", { class: "panel-check-row" });
+    stRow.appendChild(el("span", { class: "panel-check-label", text: "Configuré" }));
+    stRow.appendChild(el("span", {
+      class: "panel-check-status " + (s.configured !== false ? "ok" : "ko"),
+      text: s.configured !== false ? "Actif" : "Non configuré",
+    }));
+    stSec.appendChild(stRow);
+    body.appendChild(stSec);
+
+    appendConfigSection(body, s.name, cfg);
+    panel.appendChild(body);
+  }
+
+  /* ─── Vue panel ─── */
+  function buildViewPanel(panel, v) {
+    const glyphText = (v.label || v.name || "?").slice(0, 3).toUpperCase();
+
+    const hdr = el("div", { class: "panel-header" });
+    const left = el("div", { class: "panel-header-left" });
+    const glyph = el("div", { class: "panel-glyph skill", text: glyphText });
+    const info = el("div");
+    info.appendChild(el("div", { class: "panel-name", text: v.label || v.name }));
+    info.appendChild(el("div", { class: "panel-type-badge", text: "VUE" }));
+    left.appendChild(glyph); left.appendChild(info);
+    hdr.appendChild(left); hdr.appendChild(makeCloseBtn());
+    panel.appendChild(hdr);
+
+    const body = el("div", { class: "panel-body" });
+    if (v.description) body.appendChild(el("div", { class: "panel-desc", text: v.description }));
+
+    // Statut actif
+    const registered = window.top?.Jarvis?.views?.list() || [];
+    const isActive = registered.some(rv => v.name.includes(rv.id));
+    const stSec = el("div", { class: "panel-section" });
+    stSec.appendChild(el("div", { class: "panel-section-title", text: "Statut" }));
+    const stRow = el("div", { class: "panel-check-row" });
+    stRow.appendChild(el("span", { class: "panel-check-label", text: "État" }));
+    stRow.appendChild(el("span", {
+      class: "panel-check-status " + (isActive ? "ok" : "ko"),
+      text: isActive ? "Active" : "Installée (rechargement requis)",
+    }));
+    stSec.appendChild(stRow);
+    if (v.version) {
+      const vRow = el("div", { class: "panel-check-row" });
+      vRow.appendChild(el("span", { class: "panel-check-label", text: "Version" }));
+      vRow.appendChild(el("span", { class: "panel-check-status ok", text: v.version }));
+      stSec.appendChild(vRow);
+    }
+    body.appendChild(stSec);
+
+    // Capacités
+    if (v.capabilities?.length) {
+      const capSec = el("div", { class: "panel-section" });
+      capSec.appendChild(el("div", { class: "panel-section-title", text: "Capacités" }));
+      v.capabilities.forEach(c => {
+        const row = el("div", { class: "panel-check-row" });
+        row.appendChild(el("span", { class: "panel-check-label", text: c }));
+        capSec.appendChild(row);
+      });
+      body.appendChild(capSec);
+    }
+
+    // Désinstaller
+    const actSec = el("div", { class: "panel-section" });
+    const uninstBtn = el("button", {
+      class: "panel-save-btn",
+      text: "Désinstaller",
+      style: { background: "rgba(255,80,80,0.08)", borderColor: "rgba(255,80,80,0.25)", color: "rgba(255,120,120,0.85)" },
+    });
+    uninstBtn.addEventListener("click", async () => {
+      uninstBtn.textContent = "…"; uninstBtn.disabled = true;
+      try {
+        await J.api.delete("/api/skills/uninstall/" + v.name);
+        J.notify({ kind: "success", text: (v.label || v.name) + " désinstallé" });
+        closePanel();
+        renderVues();
+      } catch (err) {
+        J.notify({ kind: "error", text: err.message });
+        uninstBtn.textContent = "Désinstaller"; uninstBtn.disabled = false;
+      }
+    });
+    actSec.appendChild(uninstBtn);
+    body.appendChild(actSec);
+    panel.appendChild(body);
+  }
+
+  /* ─── Routine panel ─── */
+  function buildRoutinePanel(panel, p) {
+    const cfg = CONFIGS[p.name] || {};
+    const glyph3 = (p.name || "?").slice(0, 3).toUpperCase();
+
+    const hdr = el("div", { class: "panel-header" });
+    const left = el("div", { class: "panel-header-left" });
+    const glyph = el("div", { class: "panel-glyph routine", text: glyph3 });
+    const info = el("div");
+    info.appendChild(el("div", { class: "panel-name", text: p.label || p.name }));
+    info.appendChild(el("div", { class: "panel-type-badge routine", text: "ROUTINE" }));
+    left.appendChild(glyph); left.appendChild(info);
+    hdr.appendChild(left); hdr.appendChild(makeCloseBtn());
+    panel.appendChild(hdr);
+
+    const body = el("div", { class: "panel-body" });
+    body.appendChild(el("div", { class: "panel-desc", text: cfg.fullDesc || p.description || "—" }));
+
+    if (cfg.appChecks && cfg.appChecks.length) {
+      const chkSec = el("div", { class: "panel-section" });
+      chkSec.appendChild(el("div", { class: "panel-section-title", text: "Applications requises" }));
+      cfg.appChecks.forEach(appName => {
+        const row = el("div", { class: "panel-check-row" });
+        row.appendChild(el("span", { class: "panel-check-label", text: appName }));
+        row.appendChild(el("span", { class: "panel-check-status ko", text: "Non vérifié" }));
+        chkSec.appendChild(row);
+      });
+      body.appendChild(chkSec);
+    }
+
+    if (p.platforms && p.platforms.length) {
+      const platSec = el("div", { class: "panel-section" });
+      platSec.appendChild(el("div", { class: "panel-section-title", text: "Plateformes" }));
+      const platRow = el("div", { style: { display: "flex", gap: "6px", flexWrap: "wrap" } });
+      p.platforms.forEach(pl => platRow.appendChild(el("span", { class: "preset-platform", text: pl })));
+      platSec.appendChild(platRow);
+      body.appendChild(platSec);
+    }
+
+    const runSec = el("div", { class: "panel-section" });
+    runSec.appendChild(el("div", { class: "panel-section-title", text: "Lancer" }));
+    const runBtn = el("button", { class: "panel-run-btn", text: "▶ Lancer la routine" });
+    runBtn.addEventListener("click", async () => {
+      runBtn.textContent = "…"; runBtn.disabled = true;
+      try {
+        await J.api.post("/api/presets/" + p.name + "/execute");
+        J.notify({ kind: "success", text: (p.label || p.name) + " lancée" });
+      } catch (e) {
+        J.notify({ kind: "error", text: e.message });
+      }
+      runBtn.textContent = "▶ Lancer la routine"; runBtn.disabled = false;
+    });
+    runSec.appendChild(runBtn);
+    body.appendChild(runSec);
+
+    appendConfigSection(body, p.label || p.name, cfg);
+    panel.appendChild(body);
+  }
+
+  /* ─── Ambiance panel ─── */
+  function buildAmbiancePanel(panel, a) {
+    const hdr = el("div", { class: "panel-header" });
+    const left = el("div", { class: "panel-header-left" });
+    const glyph = el("div", { class: "panel-glyph ambiance", text: (a.name || "").slice(0, 3).toUpperCase() });
+    const info = el("div");
+    info.appendChild(el("div", { class: "panel-name", text: a.name }));
+    info.appendChild(el("div", { class: "panel-type-badge ambiance", text: "AMBIANCE" }));
+    left.appendChild(glyph); left.appendChild(info);
+    hdr.appendChild(left); hdr.appendChild(makeCloseBtn());
+    panel.appendChild(hdr);
+
+    const body = el("div", { class: "panel-body" });
+    body.appendChild(el("div", { class: "panel-desc", text: a.desc || "—" }));
+
+    const actSec = el("div", { class: "panel-section" });
+    actSec.appendChild(el("div", { class: "panel-section-title", text: "Activer" }));
+    const actBtn = el("button", { class: "panel-run-btn", text: "Activer cette ambiance" });
+    actBtn.addEventListener("click", async () => {
+      actBtn.textContent = "…"; actBtn.disabled = true;
+      try {
+        await J.api.post("/api/ambiances/" + a.id, {});
+        J.notify({ kind: "success", text: a.name + " · activée" });
+      } catch (_) {}
+      actBtn.textContent = "Activer cette ambiance"; actBtn.disabled = false;
+    });
+    actSec.appendChild(actBtn);
+    body.appendChild(actSec);
+    panel.appendChild(body);
+  }
+
+  /* ─────────────────────────────────────────
+     PAGE HELPERS
+  ───────────────────────────────────────── */
+  function pageWrapper(pageId, title, meta, body) {
+    const idx = PAGES.findIndex(p => p.id === pageId);
+    const num = String(idx + 1).padStart(2, "0");
+    const wrap = el("div", { class: "page room-in" });
+
+    const head = el("div", { class: "page-head" });
+    const left = el("div");
+    const eyebrow = el("div", { class: "page-eyebrow" });
+    eyebrow.appendChild(el("span", { class: "num", text: num }));
+    eyebrow.appendChild(el("span", { text: " · " + PAGES[idx].label.toUpperCase() }));
+    left.appendChild(eyebrow);
+    left.appendChild(el("h1", { text: title }));
+    head.appendChild(left);
+    if (meta) { const m = el("div", { class: "page-head-meta" }); m.innerHTML = meta; head.appendChild(m); }
+    wrap.appendChild(head);
+
+    const pb = el("div", { class: "page-body" });
+    pb.appendChild(body);
+    wrap.appendChild(pb);
+    return wrap;
+  }
+
+  function escapeHtml(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+
+  function openCorrectionModal(fact, onDone) {
+    /* Modal minimal — overlay + carte. Pas de dépendance externe. */
+    const ov = el("div");
+    ov.style.cssText = "position:fixed;inset:0;background:rgba(0,0,0,.7);display:flex;align-items:center;justify-content:center;z-index:9999;";
+    const card = el("div");
+    card.style.cssText = "background:#0a0a0a;border:1px solid #2a2a2a;border-radius:10px;padding:24px;max-width:540px;width:92%;box-shadow:0 20px 60px rgba(0,0,0,.6);";
+    card.innerHTML = '<div style="font-family:Space Grotesk,Geist,sans-serif;font-size:18px;margin-bottom:6px;color:#d4af6a;">Corriger un fact</div>'
+      + '<div style="font-size:12px;color:#888;margin-bottom:18px;">Trace un event <code>human_correction</code> en audit immuable (§6.7).</div>'
+      + '<div style="font-size:13px;margin-bottom:14px;padding:10px;background:rgba(255,255,255,.04);border-radius:6px;">'
+      + '<span style="color:#aaa">' + escapeHtml(fact.subject) + ' · </span>'
+      + '<span style="color:#d4af6a">' + escapeHtml(fact.predicate) + '</span> · '
+      + '<span>' + escapeHtml(fact.object) + '</span></div>';
+
+    const labelObj = el("label", { text: "Nouvel objet (vide = inchangé)" });
+    labelObj.style.cssText = "display:block;font-size:11px;color:#888;margin-bottom:4px;text-transform:uppercase;letter-spacing:.08em;";
+    card.appendChild(labelObj);
+    const inObj = el("input"); inObj.type = "text"; inObj.placeholder = fact.object;
+    inObj.style.cssText = "width:100%;padding:8px 10px;background:#1a1a1a;border:1px solid #333;border-radius:5px;color:#eee;margin-bottom:14px;font-size:13px;font-family:Geist,sans-serif;";
+    card.appendChild(inObj);
+
+    const labelSt = el("label", { text: "Nouveau statut" });
+    labelSt.style.cssText = "display:block;font-size:11px;color:#888;margin-bottom:4px;text-transform:uppercase;letter-spacing:.08em;";
+    card.appendChild(labelSt);
+    const inSt = el("select");
+    ["", "active", "superseded", "archived", "needs_review"].forEach(v => {
+      const o = el("option"); o.value = v; o.textContent = v || "(inchangé)"; inSt.appendChild(o);
+    });
+    inSt.style.cssText = "width:100%;padding:8px 10px;background:#1a1a1a;border:1px solid #333;border-radius:5px;color:#eee;margin-bottom:14px;font-size:13px;";
+    card.appendChild(inSt);
+
+    const labelTxt = el("label", { text: "Motif" });
+    labelTxt.style.cssText = "display:block;font-size:11px;color:#888;margin-bottom:4px;text-transform:uppercase;letter-spacing:.08em;";
+    card.appendChild(labelTxt);
+    const inTxt = el("textarea"); inTxt.rows = 2; inTxt.placeholder = "Pourquoi cette correction…";
+    inTxt.style.cssText = "width:100%;padding:8px 10px;background:#1a1a1a;border:1px solid #333;border-radius:5px;color:#eee;margin-bottom:18px;font-size:13px;font-family:Geist,sans-serif;resize:vertical;";
+    card.appendChild(inTxt);
+
+    const row = el("div"); row.style.cssText = "display:flex;justify-content:flex-end;gap:8px;";
+    const cancel = el("button", { class: "m-btn", text: "Annuler" });
+    cancel.addEventListener("click", () => ov.remove());
+    const save = el("button", { class: "m-btn m-btn--save", text: "Appliquer" });
+    save.addEventListener("click", async () => {
+      save.disabled = true; save.textContent = "…";
+      try {
+        const body = { target_fact_id: fact.id, correction_text: inTxt.value || "" };
+        if (inObj.value.trim()) body.new_object = inObj.value.trim();
+        if (inSt.value) body.new_status = inSt.value;
+        await J.api.post("/api/memory/correct", body);
+        J.notify({ kind: "success", text: "Correction appliquée — event tracé en audit" });
+        ov.remove();
+        if (onDone) onDone();
+      } catch (e) {
+        J.notify({ kind: "error", text: e.message });
+        save.disabled = false; save.textContent = "Appliquer";
+      }
+    });
+    row.appendChild(cancel); row.appendChild(save);
+    card.appendChild(row);
+
+    ov.appendChild(card);
+    ov.addEventListener("click", (ev) => { if (ev.target === ov) ov.remove(); });
+    document.body.appendChild(ov);
+    inObj.focus();
+  }
+
+  function ghostSec(title, sub, right, content) {
+    const sec = el("div", { class: "ghost-sec" });
+    const hd = el("div", { class: "ghost-sec-hd" });
+    const l = el("div");
+    l.appendChild(el("div", { class: "ghost-sec-title", text: title }));
+    if (sub) l.appendChild(el("div", { class: "ghost-sec-sub", text: sub }));
+    hd.appendChild(l);
+    if (right) hd.appendChild(el("div", { class: "ghost-sec-r", text: right }));
+    sec.appendChild(hd);
+    sec.appendChild(content);
+    return sec;
+  }
+
+  /* ─────────────────────────────────────────
+     01 Intégrations
+  ───────────────────────────────────────── */
+  async function renderIntegrations() {
+    let connectors = [];
+    try { connectors = await J.api.get("/api/settings/connectors"); } catch (_) {}
+
+    const list = el("div", { class: "cn-list" });
+
+    // Sépare les connecteurs "services" des connecteurs "messagerie"
+    const services  = connectors.filter(c => c.group !== "messaging");
+    const messaging = connectors.filter(c => c.group === "messaging");
+
+    function renderConnectorRow(c) {
+      const cfg = CONNECTOR_CONFIG[c.name] || { kind: "key", keys: [] };
+      const status = c.status || "off";
+
+      const row = el("div", { class: "cn-row" });
+      row.appendChild(el("div", { class: "cn-dot " + (status === "soon" ? "off" : status) }));
+
+      const info = el("div", { class: "cn-info" });
+      info.appendChild(el("div", { class: "cn-name", text: c.name }));
+      info.appendChild(el("div", { class: "cn-sub", text: c.sub || "" }));
+      row.appendChild(info);
+
+      const right = el("div", { class: "cn-right" });
+      if (status === "on") {
+        right.appendChild(el("span", { class: "cn-badge on", text: "Connecté" }));
+      } else if (status === "expired") {
+        right.appendChild(el("span", { class: "cn-badge expired", text: "Expiré" }));
+        const btn = el("button", { class: "cn-btn", text: "Reconnecter" });
+        btn.addEventListener("click", () => triggerConnect(c, cfg, expand));
+        right.appendChild(btn);
+      } else if (status === "soon") {
+        right.appendChild(el("span", { class: "cn-badge", text: "Bientôt" }));
+      } else {
+        const btn = el("button", { class: "cn-btn", text: "Configurer →" });
+        btn.addEventListener("click", () => triggerConnect(c, cfg, expand));
+        right.appendChild(btn);
+      }
+      row.appendChild(right);
+      list.appendChild(row);
+
+      const expand = el("div", { class: "cn-expand" });
+      list.appendChild(expand);
+    }
+
+    services.forEach(renderConnectorRow);
+
+    if (messaging.length) {
+      const sep = el("div", { class: "cn-section-sep", text: "Messagerie" });
+      list.appendChild(sep);
+      messaging.forEach(renderConnectorRow);
+    }
+
+    const activeCount = connectors.filter(c => c.status === "on").length;
+    const wrap = el("div");
+    wrap.appendChild(ghostSec(
+      "Intégrations",
+      activeCount + " actives · " + connectors.length + " total",
+      null, list
+    ));
+
+    const page = pageWrapper("integrations", "Tes connecteurs", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  function triggerConnect(c, cfg, expandEl) {
+    if (cfg.kind === "oauth") {
+      window.location.href = cfg.url;
+      return;
+    }
+    if (cfg.kind === "stub") {
+      if (expandEl.classList.contains("open")) {
+        expandEl.classList.remove("open");
+        expandEl.innerHTML = "";
+        return;
+      }
+      expandEl.innerHTML = "";
+      expandEl.appendChild(el("div", { class: "cn-stub-note", text: cfg.note || "Bientôt disponible." }));
+      expandEl.classList.add("open");
+      return;
+    }
+    if (cfg.kind === "key" || cfg.kind === "messaging" || cfg.kind === "oauth_key") {
+      // Toggle expand with input fields
+      if (expandEl.classList.contains("open")) {
+        expandEl.classList.remove("open");
+        expandEl.innerHTML = "";
+        return;
+      }
+      expandEl.innerHTML = "";
+      const inputs = [];
+      J.api.get("/api/settings").then(ss => {
+        (cfg.keys || []).forEach(f => {
+          const fw = el("div", { class: "cn-field" });
+          const labelEl = el("label", { class: "cn-field-label", text: f.label });
+          fw.appendChild(labelEl);
+          if (f.hint) {
+            fw.appendChild(el("div", { class: "cn-field-hint", text: f.hint }));
+          }
+
+          if (f.type === "toggle") {
+            // Valeur courante depuis .env via env-status
+            const tog = el("div", { class: "cn-toggle" });
+            J.api.get("/api/settings/env-status?keys=" + f.key).then(st => {
+              if (st[f.key]) tog.classList.add("on");
+            }).catch(() => {});
+            tog.addEventListener("click", () => tog.classList.toggle("on"));
+            fw.appendChild(tog);
+            inputs.push({ key: f.key, tog, isToggle: true });
+          } else {
+            const inp = el("input", {
+              class: "cn-field-input",
+              type: f.secret ? "password" : "text",
+              placeholder: f.secret ? "••••••••••" : "",
+            });
+            const v = (ss.api_keys || {})[f.key] || "";
+            if (v) inp.value = v;
+            fw.appendChild(inp);
+            inputs.push({ key: f.key, inp });
+          }
+          expandEl.appendChild(fw);
+        });
+      }).catch(() => {});
+
+      const saveBtn = el("button", { class: "cn-save-btn", text: "Sauvegarder" });
+      saveBtn.addEventListener("click", async () => {
+        saveBtn.textContent = "…"; saveBtn.disabled = true;
+        try {
+          for (const item of inputs) {
+            if (item.isToggle) {
+              await J.api.post("/api/settings/update", { key: item.key, value: item.tog.classList.contains("on") ? "true" : "false" });
+            } else if (item.inp.value) {
+              await J.api.post("/api/settings/update", { key: item.key, value: item.inp.value });
+            }
+          }
+          J.notify({ kind: "success", text: c.name + " · configuré" });
+          if (cfg.kind !== "oauth_key") {
+            expandEl.classList.remove("open");
+            expandEl.innerHTML = "";
+            renderIntegrations();
+          }
+        } catch (e) {
+          J.notify({ kind: "error", text: e.message });
+          saveBtn.textContent = "Sauvegarder"; saveBtn.disabled = false;
+        }
+      });
+      expandEl.appendChild(saveBtn);
+
+      // Connecteurs hybrides : on saisit/sauvegarde les credentials de l'app
+      // (App ID + Secret), puis on lance le flux OAuth pour lier son compte.
+      if (cfg.kind === "oauth_key") {
+        expandEl.appendChild(el("div", {
+          class: "cn-field-hint",
+          text: "Sauvegarde tes identifiants d'app, puis connecte ton compte.",
+          style: { marginTop: "10px" },
+        }));
+        const connectBtn = el("button", { class: "cn-save-btn", text: "Connecter mon compte →" });
+        connectBtn.addEventListener("click", () => { window.location.href = cfg.url; });
+        expandEl.appendChild(connectBtn);
+      }
+      expandEl.classList.add("open");
+    }
+  }
+
+  /* ─────────────────────────────────────────
+     02 Skills
+  ───────────────────────────────────────── */
+  async function renderSkills() {
+    let skills = [];
+    try {
+      const r = await J.api.get("/api/skills/installed");
+      skills = r.skills || [];
+    } catch (_) {
+      try {
+        const tools = await J.api.get("/api/tools");
+        skills = tools.map(t => ({ name: t.name, description: t.description, configured: true }));
+      } catch (_) {}
+    }
+
+    skills = skills.filter(s => !SKILL_AS_ROUTINE.has(s.name));
+
+    const grid = el("div", { class: "skills-grid" });
+    skills.forEach(s => {
+      const card = el("div", { class: "skill-card" });
+      card.appendChild(el("div", { class: "skill-glyph", text: (s.name || "?").slice(0, 3).toUpperCase() }));
+      card.appendChild(el("div", { class: "skill-name", text: s.name || s.label || "—" }));
+      const desc = (s.description || "").slice(0, 100);
+      if (desc) card.appendChild(el("div", { class: "skill-desc", text: desc }));
+      card.addEventListener("click", () => openPanel(buildSkillPanel, s));
+      grid.appendChild(card);
+    });
+
+    const wrap = el("div");
+    wrap.appendChild(ghostSec("Skills installés", skills.length + " outils actifs", null, grid));
+    const page = pageWrapper("skills", "Tes outils & skills", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     03 Routines
+  ───────────────────────────────────────── */
+  async function renderRoutines() {
+    let presets = [];
+    let extraRoutines = [];
+    try {
+      const r = await J.api.get("/api/presets");
+      presets = r.presets || [];
+    } catch (_) {}
+
+    try {
+      const r = await J.api.get("/api/skills/installed");
+      (r.skills || [])
+        .filter(s => SKILL_AS_ROUTINE.has(s.name) && !presets.some(p => p.name === s.name))
+        .forEach(s => extraRoutines.push({
+          name: s.name,
+          label: s.label || s.name,
+          description: s.description,
+          platforms: [],
+        }));
+    } catch (_) {}
+
+    const allRoutines = [...presets, ...extraRoutines];
+
+    const grid = el("div", { class: "routine-grid" });
+    if (!allRoutines.length) {
+      grid.appendChild(el("div", { class: "j-empty", text: "Aucune routine installée" }));
+    } else {
+      allRoutines.forEach(p => {
+        const card = el("div", { class: "routine-card" });
+        card.appendChild(el("div", { class: "routine-glyph", text: (p.name || "?").slice(0, 3).toUpperCase() }));
+        card.appendChild(el("div", { class: "routine-name", text: p.label || p.name }));
+        const desc = (p.description || "").slice(0, 100);
+        if (desc) card.appendChild(el("div", { class: "routine-desc", text: desc }));
+        if (p.platforms && p.platforms.length) {
+          const platRow = el("div", { class: "routine-platforms" });
+          p.platforms.forEach(pl => platRow.appendChild(el("span", { class: "preset-platform", text: pl })));
+          card.appendChild(platRow);
+        }
+        card.addEventListener("click", () => openPanel(buildRoutinePanel, p));
+        grid.appendChild(card);
+      });
+    }
+
+    const wrap = el("div");
+    wrap.appendChild(ghostSec("Routines", allRoutines.length + " automatisations", null, grid));
+    const page = pageWrapper("routines", "Tes automatisations", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     04 Ambiances
+  ───────────────────────────────────────── */
+  async function renderVues() {
+    let installedViews = [];
+    try {
+      const r = await J.api.get("/api/skills/installed");
+      installedViews = (r.skills || []).filter(s =>
+        (s.tags || []).includes("view") || s.type === "view"
+      );
+    } catch (_) {}
+
+    const registered = window.top?.Jarvis?.views?.list() || [];
+
+    const grid = el("div", { class: "skills-grid" });
+    installedViews.forEach(v => {
+      const card = el("div", { class: "skill-card" });
+      const glyphText = (v.label || v.name || "?").slice(0, 3).toUpperCase();
+      card.appendChild(el("div", { class: "skill-glyph", text: glyphText }));
+      card.appendChild(el("div", { class: "skill-name", text: v.label || v.name }));
+      if (v.description) card.appendChild(el("div", { class: "skill-desc", text: v.description }));
+      const isActive = registered.some(rv => v.name.includes(rv.id));
+      card.appendChild(el("div", {
+        class: "skill-installed-badge",
+        text: isActive ? "● Active" : "Installée",
+      }));
+      card.addEventListener("click", () => openPanel(buildViewPanel, v));
+      grid.appendChild(card);
+    });
+
+    if (!installedViews.length) {
+      const empty = el("div", { class: "empty-hint", text: "Aucune vue installée — rendez-vous dans le Store." });
+      grid.appendChild(empty);
+    }
+
+    const wrap = el("div");
+    wrap.appendChild(ghostSec("Vues installées", installedViews.length + " vue" + (installedViews.length !== 1 ? "s" : ""), null, grid));
+    const page = pageWrapper("vues", "Vues & affichages", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     05 Store
+  ───────────────────────────────────────── */
+  async function renderStore() {
+    let catalog = [];
+    try {
+      const r = await J.api.get("/api/skills/catalog");
+      catalog = r.skills || [];
+    } catch (_) {}
+
+    const isView    = s => s.type === "view"   || (s.tags || []).includes("view");
+    const isRoutine = s => s.type === "preset" || (s.tags || []).includes("preset");
+
+    const views    = catalog.filter(s => isView(s));
+    const routines = catalog.filter(s => !isView(s) && isRoutine(s));
+    const skills   = catalog.filter(s => !isView(s) && !isRoutine(s));
+
+    function makeStoreCard(s, kind) {
+      const glyphCls = kind === "routine" ? "skill-glyph routine-glyph"
+                     : kind === "view"    ? "skill-glyph view-glyph"
+                     : "skill-glyph";
+      const card = el("div", { class: "skill-card" });
+      card.appendChild(el("div", { class: glyphCls, text: (s.name || "?").slice(0, 3).toUpperCase() }));
+      card.appendChild(el("div", { class: "skill-name", text: s.name }));
+      if (s.description) card.appendChild(el("div", { class: "skill-desc", text: s.description.slice(0, 100) }));
+
+      const footer = el("div", { style: { marginTop: "auto", paddingTop: "4px" } });
+      if (s.installed) {
+        footer.appendChild(el("div", { class: "skill-installed-badge", text: "✓ Installé" }));
+      } else {
+        const installBtn = el("button", { class: "skill-install-btn", text: "Installer" });
+        installBtn.addEventListener("click", async e => {
+          e.stopPropagation();
+          installBtn.textContent = "…"; installBtn.disabled = true;
+          try {
+            await J.api.post("/api/skills/install/" + s.name);
+            J.notify({ kind: "success", text: s.name + " installé" });
+            renderStore();
+          } catch (err) {
+            J.notify({ kind: "error", text: err.message });
+            installBtn.textContent = "Installer"; installBtn.disabled = false;
+          }
+        });
+        footer.appendChild(installBtn);
+      }
+      card.appendChild(footer);
+      return card;
+    }
+
+    const wrap = el("div", { style: { display: "flex", flexDirection: "column", gap: "32px" } });
+
+    if (!catalog.length) {
+      wrap.appendChild(el("div", { class: "j-empty", text: "Catalogue indisponible" }));
+    }
+
+    if (skills.length) {
+      const grid = el("div", { class: "skills-grid" });
+      skills.forEach(s => grid.appendChild(makeStoreCard(s, "skill")));
+      wrap.appendChild(ghostSec("Skills", skills.length + " disponible" + (skills.length !== 1 ? "s" : ""), null, grid));
+    }
+
+    if (routines.length) {
+      const grid = el("div", { class: "skills-grid" });
+      routines.forEach(s => grid.appendChild(makeStoreCard(s, "routine")));
+      wrap.appendChild(ghostSec("Routines", routines.length + " disponible" + (routines.length !== 1 ? "s" : ""), null, grid));
+    }
+
+    if (views.length) {
+      const grid = el("div", { class: "skills-grid" });
+      views.forEach(s => grid.appendChild(makeStoreCard(s, "view")));
+      wrap.appendChild(ghostSec("Vues", views.length + " disponible" + (views.length !== 1 ? "s" : ""), null, grid));
+    }
+
+    const page = pageWrapper("store", "Le store de skills", '<span class="v">' + catalog.length + '</span> disponibles', wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     06 Écosystème
+  ───────────────────────────────────────── */
+  function renderEcosysteme() {
+    const wrap = el("div", { class: "coming-soon-wrap" });
+    wrap.appendChild(el("div", { class: "coming-soon-msg", text: "À venir…" }));
+    const page = pageWrapper("ecosysteme", "L'écosystème Jarvis", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     07 Appareils
+  ───────────────────────────────────────── */
+
+  /* ── Three.js device scenes ──────────────────────────────────────── */
+  /* ─── Macropad 2 touches Le Labo panel ─── */
+  async function buildMacropadPanel(panel) {
+    const hdr  = el("div", { class: "panel-header" });
+    const left = el("div", { class: "panel-header-left" });
+    const glyph = el("div", { class: "panel-glyph skill", text: "MAC" });
+    const info  = el("div");
+    info.appendChild(el("div", { class: "panel-name",       text: "Macropad 2 touches Le Labo" }));
+    info.appendChild(el("div", { class: "panel-type-badge", text: "MACROPAD" }));
+    left.appendChild(glyph); left.appendChild(info);
+    hdr.appendChild(left); hdr.appendChild(makeCloseBtn());
+    panel.appendChild(hdr);
+
+    const body = el("div", { class: "panel-body" });
+    body.appendChild(el("div", { class: "panel-desc",
+      text: "Macropad 2 touches sur puce CH552. Configure les raccourcis, l'éclairage et flash le firmware directement depuis Jarvis." }));
+
+    /* ── Statut USB ── */
+    const stSec = el("div", { class: "panel-section" });
+    stSec.appendChild(el("div", { class: "panel-section-title", text: "Connexion" }));
+    const hidRow  = el("div", { class: "panel-check-row" });
+    const bootRow = el("div", { class: "panel-check-row" });
+    hidRow.appendChild(el("span",  { class: "panel-check-label", text: "Mode HID" }));
+    bootRow.appendChild(el("span", { class: "panel-check-label", text: "Bootloader" }));
+    const hidSt  = el("span", { class: "panel-check-status ko", text: "—" });
+    const bootSt = el("span", { class: "panel-check-status ko", text: "—" });
+    hidRow.appendChild(hidSt); bootRow.appendChild(bootSt);
+    stSec.appendChild(hidRow); stSec.appendChild(bootRow);
+    body.appendChild(stSec);
+
+    J.api.get("/api/macropad/status").then(st => {
+      if (st.hidPresent)         { hidSt.textContent  = "Connecté";  hidSt.className  = "panel-check-status ok"; }
+      else                       { hidSt.textContent  = "Absent";    hidSt.className  = "panel-check-status ko"; }
+      if (st.bootloaderPresent)  { bootSt.textContent = "Prêt";      bootSt.className = "panel-check-status ok"; }
+      else                       { bootSt.textContent = "Absent";    bootSt.className = "panel-check-status ko"; }
+    }).catch(() => { hidSt.textContent = "Erreur"; bootSt.textContent = "Erreur"; });
+
+    /* ── Profil actif + touches ── */
+    const profSec = el("div", { class: "panel-section" });
+    profSec.appendChild(el("div", { class: "panel-section-title", text: "Profil actif" }));
+    const k1Row = el("div", { class: "panel-check-row" });
+    const k2Row = el("div", { class: "panel-check-row" });
+    k1Row.appendChild(el("span", { class: "panel-check-label", text: "Touche K1 (droite)" }));
+    k2Row.appendChild(el("span", { class: "panel-check-label", text: "Touche K2 (gauche)" }));
+    const k1Val = el("span", { class: "panel-check-status", style: "color:var(--fg-2)", text: "—" });
+    const k2Val = el("span", { class: "panel-check-status", style: "color:var(--fg-2)", text: "—" });
+    k1Row.appendChild(k1Val); k2Row.appendChild(k2Val);
+    const profName = el("div", { style: "font-family:var(--mono);font-size:10px;color:var(--fg-3);margin-bottom:10px", text: "Chargement…" });
+    profSec.appendChild(profName);
+    profSec.appendChild(k1Row); profSec.appendChild(k2Row);
+    body.appendChild(profSec);
+
+    J.api.get("/api/macropad/profile").then(({ bundle }) => {
+      if (!bundle) return;
+      const active = (bundle.profiles || []).find(p => p.id === bundle.activeProfileId) || bundle.profiles[0];
+      if (!active) return;
+      profName.textContent = "Profil : " + (active.name || active.id);
+      const keys = active.data && active.data.keys;
+      if (keys) {
+        k1Val.textContent = keys.k1RightP1 ? (keys.k1RightP1.label || keys.k1RightP1.hidCode || "—") : "—";
+        k2Val.textContent = keys.k2LeftP2  ? (keys.k2LeftP2.label  || keys.k2LeftP2.hidCode  || "—") : "—";
+      }
+    }).catch(() => { profName.textContent = "Profil non disponible"; });
+
+    /* ── Actions ── */
+    const actSec = el("div", { class: "panel-section" });
+    actSec.appendChild(el("div", { class: "panel-section-title", text: "Actions" }));
+
+    const compileBtn = el("button", { class: "panel-run-btn", text: "⚙ Compiler le firmware" });
+    compileBtn.style.marginBottom = "8px";
+    compileBtn.addEventListener("click", async () => {
+      compileBtn.textContent = "…"; compileBtn.disabled = true;
+      try {
+        const r = await J.api.post("/api/macropad/compile", { workspace: null });
+        J.notify({ kind: r.ok ? "success" : "error", text: r.ok ? "Compilation réussie" : r.output });
+      } catch (e) { J.notify({ kind: "error", text: e.message }); }
+      compileBtn.textContent = "⚙ Compiler le firmware"; compileBtn.disabled = false;
+    });
+
+    const flashBtn = el("button", { class: "panel-run-btn", text: "⚡ Flasher le firmware" });
+    flashBtn.addEventListener("click", async () => {
+      flashBtn.textContent = "…"; flashBtn.disabled = true;
+      try {
+        const r = await J.api.post("/api/macropad/upload", { workspace: null });
+        J.notify({ kind: r.ok ? "success" : "error", text: r.ok ? "Flash réussi" : r.output });
+      } catch (e) { J.notify({ kind: "error", text: e.message }); }
+      flashBtn.textContent = "⚡ Flasher le firmware"; flashBtn.disabled = false;
+    });
+
+    actSec.appendChild(compileBtn);
+    actSec.appendChild(flashBtn);
+
+    const editorBtn = el("a", { class: "panel-run-btn",
+      text: "✎ Ouvrir l'éditeur complet",
+      href: "/macropad", target: "_blank",
+      style: "display:block;text-align:center;text-decoration:none;margin-top:8px" });
+    actSec.appendChild(editorBtn);
+
+    body.appendChild(actSec);
+    panel.appendChild(body);
+  }
+
+  const _scenes = [];
+
+  function _killScenes() {
+    _scenes.forEach(s => s.dispose());
+    _scenes.length = 0;
+  }
+
+  function buildDevice3D(d) {
+    const type   = d.type || "unknown";
+    const btType = (d.a && d.a[0] === "Type") ? (d.a[1] || "").toLowerCase() : "";
+    const wrap   = el("div", { class: "dv-scene-wrap" });
+    const canvas = document.createElement("canvas");
+    canvas.className = "dv-scene-canvas";
+    wrap.appendChild(canvas);
+    requestAnimationFrame(() => {
+      if (!canvas.isConnected) return;
+      const ctrl = _makeDeviceScene(canvas, type, btType);
+      if (ctrl) _scenes.push(ctrl);
+    });
+    return wrap;
+  }
+
+  function _makeDeviceScene(canvas, type, btType) {
+    const T = window.THREE;
+    if (!T) return null;
+    const W = canvas.offsetWidth  || 280;
+    const H = canvas.offsetHeight || 200;
+
+    const renderer = new T.WebGLRenderer({ canvas, antialias: true, alpha: true });
+    renderer.setSize(W, H, false);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setClearColor(0x000000, 0);
+
+    const scene  = new T.Scene();
+    const camera = new T.PerspectiveCamera(32, W / H, 0.1, 100);
+
+    // Lights
+    scene.add(new T.AmbientLight(0xd0dcff, 0.55));
+    const key = new T.DirectionalLight(0xffffff, 1.1);
+    key.position.set(3, 5, 4);
+    scene.add(key);
+    const fill = new T.DirectionalLight(0x4a9eff, 0.38);
+    fill.position.set(-4, 1, -2);
+    scene.add(fill);
+    const rim = new T.DirectionalLight(0xaaaaff, 0.18);
+    rim.position.set(0, -2, -4);
+    scene.add(rim);
+
+    const group = new T.Group();
+    scene.add(group);
+
+    if (type === "host") {
+      _meshMac(T, group);
+      camera.position.set(0, 1.6, 5.5);
+      camera.lookAt(0, 0.25, 0);
+    } else if (type === "macropad") {
+      _meshMacropad(T, group);
+      camera.position.set(0, 2.8, 3.2);
+      camera.lookAt(0, 0, 0);
+    } else if (btType.includes("headphone") || btType.includes("headset")) {
+      _meshHeadphones(T, group);
+      camera.position.set(0, 0.8, 4.2);
+      camera.lookAt(0, 0.2, 0);
+    } else if (btType.includes("mouse")) {
+      _meshMouse(T, group);
+      camera.position.set(0, 1.8, 4.0);
+      camera.lookAt(0, 0, 0);
+    } else {
+      _meshGeneric(T, group);
+      camera.position.set(0, 1.5, 4.5);
+      camera.lookAt(0, 0.1, 0);
+    }
+
+    let raf, speed = 0.007;
+    canvas.addEventListener("mouseenter", () => { speed = 0; });
+    canvas.addEventListener("mouseleave", () => { speed = 0.007; });
+
+    const tick = () => {
+      raf = requestAnimationFrame(tick);
+      group.rotation.y += speed;
+      renderer.render(scene, camera);
+    };
+    tick();
+
+    return {
+      dispose() {
+        cancelAnimationFrame(raf);
+        group.traverse(o => {
+          if (o.geometry) o.geometry.dispose();
+          if (o.material) {
+            (Array.isArray(o.material) ? o.material : [o.material]).forEach(m => m.dispose());
+          }
+        });
+        renderer.dispose();
+      }
+    };
+  }
+
+  /* ── MacBook Pro ─────────────────────────────── */
+  function _meshMac(T, group) {
+    const alum  = new T.MeshStandardMaterial({ color: 0xb4b4c2, metalness: 0.85, roughness: 0.20 });
+    const dark  = new T.MeshStandardMaterial({ color: 0x060a14,
+      emissive: new T.Color(0x1a3a8a), emissiveIntensity: 0.55, roughness: 0.9 });
+    const bezel = new T.MeshStandardMaterial({ color: 0x080c1a, roughness: 0.8 });
+    const tpad  = new T.MeshStandardMaterial({ color: 0xa8a8b4, metalness: 0.72, roughness: 0.30 });
+
+    // Base (keyboard deck)
+    group.add(new T.Mesh(new T.BoxGeometry(2.2, 0.08, 1.52), alum));
+
+    // Trackpad
+    const tp = new T.Mesh(new T.BoxGeometry(0.58, 0.005, 0.40), tpad);
+    tp.position.set(0, 0.043, 0.34);
+    group.add(tp);
+
+    // Hinge pivot at top-back of base
+    const hinge = new T.Group();
+    hinge.position.set(0, 0.04, -0.76);
+    group.add(hinge);
+
+    const lidH = 1.38;
+
+    // Lid outer frame
+    const lid = new T.Mesh(new T.BoxGeometry(2.2, lidH, 0.06), alum);
+    lid.position.set(0, lidH / 2, 0);
+    hinge.add(lid);
+
+    // Display
+    const disp = new T.Mesh(new T.BoxGeometry(2.04, 1.24, 0.01), dark);
+    disp.position.set(0, lidH / 2 + 0.01, 0.035);
+    hinge.add(disp);
+
+    // Notch
+    const notch = new T.Mesh(new T.BoxGeometry(0.24, 0.05, 0.015), bezel);
+    notch.position.set(0, lidH - 0.04, 0.036);
+    hinge.add(notch);
+
+    // Open ~115° (25° past vertical → rotate hinge backward)
+    hinge.rotation.x = -(25 * Math.PI / 180);
+
+    group.position.y = -0.44;
+  }
+
+  /* ── Macropad ────────────────────────────────── */
+  function _meshMacropad(T, group) {
+    const bodyMat = new T.MeshStandardMaterial({ color: 0x141420, metalness: 0.3, roughness: 0.6 });
+    const frameMat= new T.MeshStandardMaterial({ color: 0x1e1e2e, metalness: 0.2, roughness: 0.5 });
+    const keyMat  = new T.MeshStandardMaterial({ color: 0x22223a, roughness: 0.7 });
+    const litMat  = new T.MeshStandardMaterial({ color: 0x0d2242,
+      emissive: new T.Color(0x4a9eff), emissiveIntensity: 0.85, roughness: 0.6 });
+    const encMat  = new T.MeshStandardMaterial({ color: 0x4a9eff, metalness: 0.4,
+      emissive: new T.Color(0x4a9eff), emissiveIntensity: 0.35 });
+
+    const frame = new T.Mesh(new T.BoxGeometry(1.88, 0.22, 1.38), frameMat);
+    frame.position.y = -0.01;
+    group.add(frame);
+    group.add(new T.Mesh(new T.BoxGeometry(1.82, 0.20, 1.32), bodyMat));
+
+    // 3×4 key grid
+    const cols = 4, rows = 3;
+    const kW = 0.30, kD = 0.25, kH = 0.07;
+    const gapX = 0.08, gapZ = 0.07;
+    const totalW = cols * kW + (cols - 1) * gapX;
+    const totalD = rows * kD + (rows - 1) * gapZ;
+    let idx = 0;
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const key = new T.Mesh(new T.BoxGeometry(kW, kH, kD), idx % 3 === 0 ? litMat : keyMat);
+        key.position.set(
+          -totalW / 2 + c * (kW + gapX) + kW / 2,
+          0.135,
+          -totalD / 2 + r * (kD + gapZ) + kD / 2
+        );
+        group.add(key);
+        idx++;
+      }
+    }
+
+    // Encoder knob
+    const enc = new T.Mesh(new T.CylinderGeometry(0.12, 0.12, 0.1, 20), encMat);
+    enc.position.set(0.68, 0.20, -0.48);
+    group.add(enc);
+
+    group.position.y = -0.12;
+    group.rotation.x = -0.15;
+  }
+
+  /* ── Headphones ──────────────────────────────── */
+  function _meshHeadphones(T, group) {
+    const bandMat = new T.MeshStandardMaterial({ color: 0x282830, metalness: 0.6, roughness: 0.35 });
+    const cupMat  = new T.MeshStandardMaterial({ color: 0x1e1e28, metalness: 0.4, roughness: 0.45 });
+    const padMat  = new T.MeshStandardMaterial({ color: 0x2a2a2a, roughness: 0.85 });
+
+    // Headband (half-torus arc — arche vers le haut)
+    const band = new T.Mesh(new T.TorusGeometry(0.72, 0.062, 10, 40, Math.PI), bandMat);
+    band.position.y = 0;
+    group.add(band);
+
+    [-0.72, 0.72].forEach(x => {
+      // Stem
+      const stem = new T.Mesh(new T.CylinderGeometry(0.038, 0.038, 0.32, 10), bandMat);
+      stem.rotation.z = Math.PI / 2;
+      stem.position.set(x, 0, 0);
+      group.add(stem);
+
+      // Cup shell
+      const cup = new T.Mesh(new T.CylinderGeometry(0.27, 0.24, 0.20, 26), cupMat);
+      cup.rotation.z = Math.PI / 2;
+      cup.position.set(x, 0, 0);
+      group.add(cup);
+
+      // Ear pad
+      const pad = new T.Mesh(new T.CylinderGeometry(0.21, 0.21, 0.04, 26), padMat);
+      pad.rotation.z = Math.PI / 2;
+      pad.position.set(x < 0 ? x - 0.12 : x + 0.12, 0, 0);
+      group.add(pad);
+    });
+
+    group.position.y = -0.38;
+  }
+
+  /* ── Mouse ───────────────────────────────────── */
+  function _meshMouse(T, group) {
+    const bodyMat   = new T.MeshStandardMaterial({ color: 0xbcbcca, metalness: 0.68, roughness: 0.28 });
+    const btnLMat   = new T.MeshStandardMaterial({ color: 0xccccda, metalness: 0.62, roughness: 0.32 });
+    const btnRMat   = new T.MeshStandardMaterial({ color: 0xb8b8c8, metalness: 0.60, roughness: 0.35 });
+    const scrollMat = new T.MeshStandardMaterial({ color: 0x808090, metalness: 0.5, roughness: 0.5 });
+
+    // Body (scaled sphere)
+    const body = new T.Mesh(new T.SphereGeometry(0.52, 28, 18), bodyMat);
+    body.scale.set(0.88, 0.43, 1.18);
+    group.add(body);
+
+    // Left button
+    const lBtn = new T.Mesh(new T.BoxGeometry(0.40, 0.032, 0.52), btnLMat);
+    lBtn.position.set(-0.22, 0.21, -0.18);
+    group.add(lBtn);
+
+    // Right button
+    const rBtn = new T.Mesh(new T.BoxGeometry(0.40, 0.032, 0.52), btnRMat);
+    rBtn.position.set(0.22, 0.21, -0.18);
+    group.add(rBtn);
+
+    // Scroll wheel
+    const scroll = new T.Mesh(new T.CylinderGeometry(0.06, 0.06, 0.24, 14), scrollMat);
+    scroll.rotation.z = Math.PI / 2;
+    scroll.position.set(0, 0.248, -0.15);
+    group.add(scroll);
+
+    group.position.y = -0.08;
+  }
+
+  /* ── Generic BT ──────────────────────────────── */
+  function _meshGeneric(T, group) {
+    const frameMat  = new T.MeshStandardMaterial({ color: 0x1e1e34, metalness: 0.25, roughness: 0.55 });
+    const bodyMat   = new T.MeshStandardMaterial({ color: 0x16162a, metalness: 0.30, roughness: 0.60 });
+    const screenMat = new T.MeshStandardMaterial({ color: 0x060a14,
+      emissive: new T.Color(0x1a3a8a), emissiveIntensity: 0.48, roughness: 0.9 });
+    const dotMat    = new T.MeshStandardMaterial({ color: 0x4a9eff,
+      emissive: new T.Color(0x4a9eff), emissiveIntensity: 1.0 });
+
+    group.add(new T.Mesh(new T.BoxGeometry(1.05, 0.10, 1.60), frameMat));
+    const body = new T.Mesh(new T.BoxGeometry(0.98, 0.09, 1.52), bodyMat);
+    body.position.y = 0.005;
+    group.add(body);
+
+    const screen = new T.Mesh(new T.BoxGeometry(0.82, 0.01, 1.12), screenMat);
+    screen.position.set(0, 0.055, -0.08);
+    group.add(screen);
+
+    const dot = new T.Mesh(new T.CylinderGeometry(0.07, 0.07, 0.012, 16), dotMat);
+    dot.position.set(0, 0.056, 0.58);
+    group.add(dot);
+
+    group.position.y = -0.18;
+    group.rotation.x = -0.14;
+  }
+
+  async function renderAppareils() {
+    let devices = [];
+    try { devices = await J.api.get("/api/settings/devices"); } catch (_) {}
+
+    const grid = el("div", { class: "device-grid-v2" });
+    devices.forEach(d => {
+      const col  = d.col || "muted";
+      const card = el("div", { class: "dv-card-v2" + (col === "muted" ? " dv-card--dim" : " dv-card--glow-" + col) });
+
+      card.appendChild(buildDevice3D(d));
+      if (d.type === "macropad") {
+        card.style.cursor = "pointer";
+        card.addEventListener("click", () => openPanel(buildMacropadPanel));
+      }
+
+      const body = el("div", { class: "dv-body-v2" });
+
+      const nameRow = el("div", { class: "dv-name-row" });
+      nameRow.appendChild(el("div", { class: "dv-name-v2", text: d.name }));
+      nameRow.appendChild(el("div", { class: "dv-badge " + col, text: d.status || "Unknown" }));
+      body.appendChild(nameRow);
+
+      if (d.id) body.appendChild(el("div", { class: "dv-sub-v2", text: d.id }));
+
+      if (d.a || d.b) {
+        const meta = el("div", { class: "dv-meta-v2" });
+        [d.a, d.b].forEach(pair => {
+          if (!pair) return;
+          const item = el("div", { class: "dv-meta-item-v2" });
+          item.appendChild(el("div", { class: "dv-meta-k-v2", text: pair[0] || "" }));
+          item.appendChild(el("div", { class: "dv-meta-v-v2", text: pair[1] || "" }));
+          meta.appendChild(item);
+        });
+        body.appendChild(meta);
+      }
+
+      card.appendChild(body);
+      grid.appendChild(card);
+    });
+
+    const wrap = el("div");
+    wrap.appendChild(ghostSec("Appareils", devices.length + " détectés", null, grid));
+    const page = pageWrapper("appareils", "Tes appareils", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     08 Fils (Sessions)
+  ───────────────────────────────────────── */
+  async function renderFils() {
+    let sessions = [];
+    try { sessions = await J.api.get("/api/sessions"); } catch (_) {}
+
+    const list = el("div");
+    if (!sessions.length) {
+      list.appendChild(el("div", { class: "j-empty", text: "Aucune session récente" }));
+    } else {
+      sessions.slice(0, 20).forEach(s => {
+        const row = el("div", { class: "session-row" });
+        row.appendChild(el("div", { class: "sess-id t-mono", text: (s.id || "").slice(0, 6).toUpperCase() }));
+
+        const preview = el("div");
+        const titleEl = el("div", { class: "sess-preview", text: s.title || s.preview || "—" });
+        preview.appendChild(titleEl);
+        preview.appendChild(el("div", { style: { fontFamily: "var(--mono)", fontSize: "9.5px", color: "var(--fg-3)", marginTop: "3px" },
+          text: (s.message_count || 0) + " messages" }));
+        row.appendChild(preview);
+        row.appendChild(el("div", { class: "sess-date", text: s.date || "" }));
+
+        const viewBtn   = el("button", { class: "m-btn", text: "Voir" });
+        const renameBtn = el("button", { class: "m-btn", text: "Renommer" });
+        const delBtn    = el("button", { class: "m-btn m-btn--danger", text: "✕" });
+        delBtn.title = "Supprimer ce fil";
+        const acts = el("div", { class: "mem-btn-row" });
+        acts.appendChild(viewBtn);
+        acts.appendChild(renameBtn);
+        acts.appendChild(delBtn);
+        row.appendChild(acts);
+        list.appendChild(row);
+
+        /* inline conversation viewer */
+        const viewer   = el("div", { class: "sess-viewer" });
+        const msgList  = el("div", { class: "sess-msg-list" });
+        const closeViewBtn = el("button", { class: "m-btn", text: "Fermer" });
+        viewer.appendChild(msgList);
+        viewer.appendChild(closeViewBtn);
+        list.appendChild(viewer);
+
+        viewBtn.addEventListener("click", async () => {
+          if (viewer.classList.contains("open")) {
+            viewer.classList.remove("open");
+            viewBtn.textContent = "Voir";
+            return;
+          }
+          editor.classList.remove("open");
+          renameBtn.textContent = "Renommer";
+          viewBtn.textContent = "…"; viewBtn.disabled = true;
+          try {
+            const msgs = await J.api.get("/api/sessions/" + encodeURIComponent(s.id) + "/messages?limit=100");
+            msgList.innerHTML = "";
+            if (!msgs.length) {
+              msgList.appendChild(el("div", { class: "sess-msg-empty", text: "Aucun message." }));
+            } else {
+              msgs.forEach(m => {
+                const bubble = el("div", { class: "sess-bubble sess-bubble--" + (m.role === "user" ? "user" : "assistant") });
+                const label  = el("div", { class: "sess-bubble-role", text: m.role === "user" ? "Toi" : "Jarvis" });
+                const body   = el("div", { class: "sess-bubble-body", text: m.content || "" });
+                bubble.appendChild(label);
+                bubble.appendChild(body);
+                msgList.appendChild(bubble);
+              });
+            }
+            viewer.classList.add("open");
+            setTimeout(() => viewer.scrollIntoView({ behavior: "smooth", block: "nearest" }), 50);
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+          }
+          viewBtn.textContent = "Voir"; viewBtn.disabled = false;
+        });
+
+        closeViewBtn.addEventListener("click", () => {
+          viewer.classList.remove("open");
+          viewBtn.textContent = "Voir";
+        });
+
+        /* inline rename editor */
+        const editor  = el("div", { class: "sess-rename-editor" });
+        const inp     = el("input", { class: "sess-rename-input", type: "text" });
+        inp.value       = s.title || s.preview || "";
+        inp.placeholder = "Nouveau titre…";
+        editor.appendChild(inp);
+        const saveBtn  = el("button", { class: "m-btn m-btn--save", text: "Sauvegarder" });
+        const closeBtn = el("button", { class: "m-btn",              text: "Annuler" });
+        const btnRow   = el("div",    { class: "mem-btn-row" });
+        btnRow.appendChild(saveBtn);
+        btnRow.appendChild(closeBtn);
+        editor.appendChild(btnRow);
+        list.appendChild(editor);
+
+        renameBtn.addEventListener("click", () => {
+          const open = editor.classList.contains("open");
+          if (!open) { viewer.classList.remove("open"); viewBtn.textContent = "Voir"; }
+          editor.classList.toggle("open", !open);
+          renameBtn.textContent = open ? "Renommer" : "Annuler";
+          if (!open) { inp.focus(); inp.select(); }
+        });
+
+        closeBtn.addEventListener("click", () => {
+          editor.classList.remove("open");
+          renameBtn.textContent = "Renommer";
+        });
+
+        inp.addEventListener("keydown", e => {
+          if (e.key === "Enter")  saveBtn.click();
+          if (e.key === "Escape") closeBtn.click();
+        });
+
+        saveBtn.addEventListener("click", async () => {
+          const newTitle = inp.value.trim();
+          if (!newTitle) return;
+          const orig = saveBtn.textContent;
+          saveBtn.textContent = "…"; saveBtn.disabled = true;
+          try {
+            await J.api.put("/api/sessions/" + encodeURIComponent(s.id) + "/title", { title: newTitle });
+            titleEl.textContent = newTitle;
+            editor.classList.remove("open");
+            renameBtn.textContent = "Renommer";
+            J.notify({ kind: "success", text: "Fil renommé" });
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+            saveBtn.textContent = "✗ Erreur";
+          }
+          setTimeout(() => { saveBtn.textContent = orig; saveBtn.disabled = false; }, 1800);
+        });
+
+        delBtn.addEventListener("click", async () => {
+          if (!confirm("Supprimer ce fil définitivement ?")) return;
+          delBtn.disabled = true;
+          try {
+            await J.api.delete("/api/sessions/" + encodeURIComponent(s.id));
+            row.remove();
+            editor.remove();
+            J.notify({ kind: "success", text: "Fil supprimé" });
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+            delBtn.disabled = false;
+          }
+        });
+      });
+    }
+
+    const wrap = el("div");
+    wrap.appendChild(ghostSec("Sessions récentes", sessions.length + " fils", null, list));
+    const page = pageWrapper("fils", "Tes conversations", '<span class="v">' + sessions.length + '</span> fils', wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     09 Mémoire
+  ───────────────────────────────────────── */
+  function relTime(iso) {
+    if (!iso) return "—";
+    const d = new Date(iso); const now = new Date();
+    const sec = Math.round((now - d) / 1000);
+    if (sec < 60) return "à l'instant";
+    if (sec < 3600) return Math.round(sec / 60) + " min";
+    if (sec < 86400) return Math.round(sec / 3600) + " h";
+    if (sec < 86400 * 30) return Math.round(sec / 86400) + " j";
+    return d.toLocaleDateString("fr");
+  }
+
+  async function renderMemoire() {
+    let topics = [], index = "", facts = [];
+    try {
+      topics = await J.api.get("/api/memory/topics");
+      const idx = await J.api.get("/api/memory/index");
+      index = idx.content || "";
+    } catch (_) {}
+    try {
+      facts = await J.api.get("/api/memory/facts?status=active&limit=200");
+    } catch (_) {}
+
+    const wrap = el("div", { style: { display: "flex", flexDirection: "column", gap: "40px" } });
+
+    /* ── Facts (Kernel SQL — construit ici, appendé en bas de la page) ── */
+    const factsList = el("div", { style: { display: "flex", flexDirection: "column", gap: "8px" } });
+    if (!facts.length) {
+      factsList.appendChild(el("div", { class: "j-empty", text: "Aucun fact actif dans le Kernel" }));
+    } else {
+      /* Group by category for legibility */
+      const byCat = {};
+      facts.forEach(f => { (byCat[f.category] = byCat[f.category] || []).push(f); });
+      const cats = Object.keys(byCat).sort();
+      cats.forEach(cat => {
+        const catHead = el("div", { class: "mem-cat-head", text: cat + " · " + byCat[cat].length });
+        catHead.style.cssText = "font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#888;margin-top:14px;margin-bottom:4px;";
+        factsList.appendChild(catHead);
+        byCat[cat].forEach(f => {
+          const row = el("div", { class: "fact-row" });
+          row.style.cssText = "display:grid;grid-template-columns:1fr 90px 80px 80px auto;gap:10px;padding:8px 10px;border:1px solid rgba(255,255,255,.06);border-radius:6px;align-items:center;background:rgba(255,255,255,.02);";
+
+          const txt = el("div");
+          txt.innerHTML = '<span style="color:#aaa">' + escapeHtml(f.subject) + ' · </span>'
+            + '<span style="color:#d4af6a">' + escapeHtml(f.predicate) + '</span> · '
+            + '<span>' + escapeHtml(f.object) + '</span>';
+          row.appendChild(txt);
+
+          row.appendChild(el("div", { text: "conf " + (f.confidence * 100).toFixed(0) + "%", style: { fontSize: "11px", color: "#888", textAlign: "right", fontFamily: "Geist Mono, monospace" } }));
+          row.appendChild(el("div", { text: f.decay_policy, style: { fontSize: "11px", color: "#888", textAlign: "center" } }));
+          row.appendChild(el("div", { text: relTime(f.last_seen_at), style: { fontSize: "11px", color: "#888", textAlign: "right" } }));
+
+          const corrBtn = el("button", { class: "m-btn", text: "Corriger" });
+          corrBtn.style.cssText = "padding:4px 10px;font-size:11px;";
+          corrBtn.addEventListener("click", () => openCorrectionModal(f, () => renderMemoire()));
+          row.appendChild(corrBtn);
+
+          factsList.appendChild(row);
+        });
+      });
+    }
+    const factsSection = ghostSec(
+      "Facts (Kernel)",
+      facts.length + " actifs · régénéré à chaque passe deep",
+      null,
+      factsList
+    );
+
+    /* ── Index MEMORY.md (éditable) ── */
+    const indexWrap = el("div", { style: { display: "flex", flexDirection: "column", gap: "10px" } });
+    const indexTa = el("textarea", { class: "mem-textarea" });
+    indexTa.rows = 10;
+    indexTa.value = index;
+    indexWrap.appendChild(indexTa);
+    const indexSave = el("button", { class: "m-btn m-btn--save", text: "Sauvegarder" });
+    indexSave.addEventListener("click", async () => {
+      const orig = indexSave.textContent;
+      indexSave.textContent = "…"; indexSave.disabled = true;
+      try {
+        await J.api.put("/api/memory/index", { content: indexTa.value });
+        J.notify({ kind: "success", text: "MEMORY.md sauvegardé" });
+        indexSave.textContent = "✓ Sauvegardé";
+      } catch (e) {
+        J.notify({ kind: "error", text: e.message });
+        indexSave.textContent = "✗ Erreur";
+      }
+      setTimeout(() => { indexSave.textContent = orig; indexSave.disabled = false; }, 2000);
+    });
+    const idxRow = el("div", { class: "mem-btn-row" });
+    idxRow.appendChild(indexSave);
+    indexWrap.appendChild(idxRow);
+    wrap.appendChild(ghostSec("Index mémoire", "MEMORY.md", null, indexWrap));
+
+    /* ── Topics ── */
+    const list = el("div");
+    if (!topics.length) {
+      list.appendChild(el("div", { class: "j-empty", text: "Aucun topic en mémoire" }));
+    } else {
+      topics.forEach(t => {
+        const row = el("div", { class: "memory-row" });
+        row.appendChild(el("div", { class: "mem-name", text: t.name }));
+        row.appendChild(el("div", { class: "mem-meta", text: Math.round((t.size || 0) / 1024 * 10) / 10 + " ko" }));
+        row.appendChild(el("div", { class: "mem-meta", text: t.mtime ? new Date(t.mtime).toLocaleDateString("fr") : "—" }));
+
+        const editBtn = el("button", { class: "m-btn", text: "Éditer" });
+        const delBtn  = el("button", { class: "m-btn m-btn--danger", text: "✕" });
+        delBtn.title = "Supprimer " + t.name;
+        const acts = el("div", { class: "mem-btn-row" });
+        acts.appendChild(editBtn);
+        acts.appendChild(delBtn);
+        row.appendChild(acts);
+        list.appendChild(row);
+
+        /* inline editor (hidden by default) */
+        const editor = el("div", { class: "mem-topic-editor" });
+        const ta = el("textarea", { class: "mem-textarea" });
+        ta.rows = 14;
+        editor.appendChild(ta);
+        const saveBtn  = el("button", { class: "m-btn m-btn--save",  text: "Sauvegarder" });
+        const closeBtn = el("button", { class: "m-btn",               text: "Fermer" });
+        const btnRow   = el("div",    { class: "mem-btn-row" });
+        btnRow.appendChild(saveBtn);
+        btnRow.appendChild(closeBtn);
+        editor.appendChild(btnRow);
+        list.appendChild(editor);
+
+        editBtn.addEventListener("click", async () => {
+          if (editor.classList.contains("open")) {
+            editor.classList.remove("open");
+            editBtn.textContent = "Éditer";
+            return;
+          }
+          editBtn.textContent = "…"; editBtn.disabled = true;
+          try {
+            const { content } = await J.api.get("/api/memory/topics/" + encodeURIComponent(t.name));
+            ta.value = content;
+            editor.classList.add("open");
+            editBtn.textContent = "Éditer";
+            setTimeout(() => editor.scrollIntoView({ behavior: "smooth", block: "nearest" }), 50);
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+            editBtn.textContent = "Éditer";
+          }
+          editBtn.disabled = false;
+        });
+
+        closeBtn.addEventListener("click", () => {
+          editor.classList.remove("open");
+          editBtn.textContent = "Éditer";
+        });
+
+        saveBtn.addEventListener("click", async () => {
+          const orig = saveBtn.textContent;
+          saveBtn.textContent = "…"; saveBtn.disabled = true;
+          try {
+            await J.api.put("/api/memory/topics/" + encodeURIComponent(t.name), { content: ta.value });
+            J.notify({ kind: "success", text: t.name + " sauvegardé" });
+            saveBtn.textContent = "✓ Sauvegardé";
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+            saveBtn.textContent = "✗ Erreur";
+          }
+          setTimeout(() => { saveBtn.textContent = orig; saveBtn.disabled = false; }, 2000);
+        });
+
+        delBtn.addEventListener("click", async () => {
+          if (!confirm("Supprimer « " + t.name + " » définitivement ?")) return;
+          delBtn.disabled = true;
+          try {
+            await J.api.delete("/api/memory/topics/" + encodeURIComponent(t.name));
+            row.remove();
+            editor.remove();
+            J.notify({ kind: "success", text: t.name + " supprimé" });
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+            delBtn.disabled = false;
+          }
+        });
+      });
+    }
+    wrap.appendChild(ghostSec("Topics", topics.length + " fichiers", null, list));
+
+    /* Facts en bas — la vraie fenêtre Kernel SQL, sous l'Index et les Topics. */
+    wrap.appendChild(factsSection);
+
+    const page = pageWrapper(
+      "memoire",
+      "La mémoire de Jarvis",
+      '<span class="v">' + facts.length + '</span> facts · <span class="v">' + topics.length + '</span> topics',
+      wrap
+    );
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     ROUTER
+  ───────────────────────────────────────── */
+  const RENDERERS = {
+    integrations: renderIntegrations,
+    skills:       renderSkills,
+    routines:     renderRoutines,
+    vues:         renderVues,
+    store:        renderStore,
+    ecosysteme:   renderEcosysteme,
+    appareils:    renderAppareils,
+    fils:         renderFils,
+    memoire:      renderMemoire,
+  };
+
+  function navigate(pageId) {
+    _activePage = pageId;
+    closePanel();
+    _killScenes();
+    const nav = document.getElementById("j-rooms-pages");
+    if (nav) {
+      const btns = Array.from(nav.querySelectorAll("button"));
+      const idx = PAGES.findIndex(p => p.id === pageId);
+      btns.forEach((b, i) => b.dataset.active = i === idx ? "true" : "false");
+    }
+    const fn = RENDERERS[pageId];
+    if (fn) { root.innerHTML = ""; fn(); }
+  }
+
+  /* ─────────────────────────────────────────
+     INIT
+  ───────────────────────────────────────── */
+  J.mountAtmosphere();
+
+  J.mountRooms({
+    mode: "capacites",
+    pages: PAGES,
+    activePage: _activePage,
+    onNav: (id) => navigate(id),
+  });
+
+  J.registerCommands(PAGES.map(p => ({
+    kind: "nav", id: "cap-" + p.id, group: "Atelier",
+    title: p.label, glyph: "→",
+    run: () => navigate(p.id),
+  })));
+
+  renderIntegrations();
+})();

--- a/src/jarvis/interfaces/ui/static/capabilities.js.bak-1782165692
+++ b/src/jarvis/interfaces/ui/static/capabilities.js.bak-1782165692
@@ -1,0 +1,1682 @@
+/* capabilities.js — Atelier (Capacités) v2
+ * 9 sous-pages : Intégrations · Skills · Routines · Vues · Store · Écosystème · Appareils · Fils · Mémoire
+ */
+(function () {
+  "use strict";
+  const J = window.Jarvis, el = J.el;
+
+  const PAGES = [
+    { id: "integrations", label: "Intégrations" },
+    { id: "skills",       label: "Skills" },
+    { id: "routines",     label: "Routines" },
+    { id: "vues",         label: "Vues" },
+    { id: "store",        label: "Store" },
+    { id: "ecosysteme",   label: "Écosystème" },
+    { id: "appareils",    label: "Appareils" },
+    { id: "fils",         label: "Fils" },
+    { id: "memoire",      label: "Mémoire" },
+  ];
+
+  let _activePage = "integrations";
+  const root = document.getElementById("page-root");
+
+  /* ─── Config des connecteurs ─── */
+  const CONNECTOR_CONFIG = {
+    "Gmail":              { kind: "oauth_key", url: "/api/google/auth/gmail", keys: [
+      { key: "GOOGLE_CLIENT_ID",     label: "Client ID",     secret: false, hint: "console.cloud.google.com · OAuth client type « Web » · Redirect URIs : http://127.0.0.1:8000/api/google/callback/gmail + .../calendar" },
+      { key: "GOOGLE_CLIENT_SECRET", label: "Client Secret", secret: true },
+    ]},
+    "Google Calendar":    { kind: "oauth_key", url: "/api/google/auth/calendar", keys: [
+      { key: "GOOGLE_CLIENT_ID",     label: "Client ID",     secret: false, hint: "Mêmes identifiants que Gmail (partagés) · OAuth client type « Web »" },
+      { key: "GOOGLE_CLIENT_SECRET", label: "Client Secret", secret: true },
+    ]},
+    "Spotify":            { kind: "oauth_key", url: "/api/spotify/auth", keys: [
+      { key: "SPOTIFY_CLIENT_ID",     label: "Client ID",     secret: false, hint: "developer.spotify.com/dashboard · Redirect URI : http://127.0.0.1:8000/api/spotify/callback" },
+      { key: "SPOTIFY_CLIENT_SECRET", label: "Client Secret", secret: true },
+    ]},
+    "Deezer":             { kind: "oauth_key", url: "/api/deezer/auth", keys: [
+      { key: "DEEZER_APP_ID",     label: "App ID",     secret: false, hint: "developers.deezer.com/myapps · Redirect URL : http://127.0.0.1:8000/api/deezer/callback" },
+      { key: "DEEZER_APP_SECRET", label: "Secret Key", secret: true },
+    ]},
+    "Notion":             { kind: "key",   keys: [{ key: "NOTION_TOKEN",         label: "Token d'intégration", secret: true }] },
+    "Anthropic (Claude)": { kind: "key",   keys: [{ key: "ANTHROPIC_API_KEY",    label: "Clé API Anthropic",   secret: true }] },
+    "ElevenLabs":         { kind: "key",   keys: [{ key: "ELEVENLABS_API_KEY",   label: "Clé API ElevenLabs",  secret: true }] },
+    "OpenAI":             { kind: "key",   keys: [{ key: "OPENAI_API_KEY",       label: "Clé API OpenAI",      secret: true }] },
+    "Google (API Key)":   { kind: "key",   keys: [{ key: "GOOGLE_API_KEY",       label: "Clé API Google",      secret: true }] },
+    "LiveKit":            { kind: "key",   keys: [
+      { key: "LIVEKIT_URL",        label: "URL",        secret: false },
+      { key: "LIVEKIT_API_KEY",    label: "API Key",    secret: true },
+      { key: "LIVEKIT_API_SECRET", label: "API Secret", secret: true },
+    ]},
+    "Deepgram":           { kind: "key",   keys: [{ key: "DEEPGRAM_API_KEY",     label: "Clé API Deepgram",    secret: true }] },
+    "Mistral":            { kind: "key",   keys: [{ key: "MISTRAL_API_KEY",      label: "Clé API Mistral",     secret: true }] },
+    // ── Messagerie ───────────────────────────────────────────────────────────
+    "Telegram":           { kind: "messaging", keys: [
+      { key: "TELEGRAM_BOT_TOKEN", label: "Bot Token",              secret: true,  hint: "@BotFather → /newbot" },
+      { key: "TELEGRAM_OWNER_ID",  label: "Ton User ID",            secret: false, hint: "@userinfobot → envoie un message" },
+      { key: "TELEGRAM_ENABLED",   label: "Activer le bot",         secret: false, type: "toggle" },
+    ]},
+    "Discord":            { kind: "messaging", keys: [
+      { key: "DISCORD_BOT_TOKEN",  label: "Bot Token",              secret: true,  hint: "discord.com/developers → Bot" },
+      { key: "DISCORD_OWNER_ID",   label: "Ton User ID",            secret: false, hint: "Profil → Copier l'identifiant" },
+      { key: "DISCORD_ENABLED",    label: "Activer le bot",         secret: false, type: "toggle" },
+    ]},
+    "WhatsApp":           { kind: "stub", note: "Bientôt disponible via Twilio ou WhatsApp Business API (WABA)." },
+  };
+
+  /* ─── Skills reclassifiés en routines ─── */
+  const SKILL_AS_ROUTINE = new Set(["mode-streameur"]);
+
+  /* ─── Registre de config statique ─── */
+  const CONFIGS = {
+    "fusion360": {
+      fullDesc: "Contrôle Autodesk Fusion 360 via MCP HTTP — scripts Python API, lecture et modification de designs 3D, undo/redo, export et lancement d'actions Fusion directement depuis Jarvis.",
+      fields: [
+        { key: "FUSION360_CLIENT_ID",     label: "Client ID",      hint: "Depuis app.autodesk.com", secret: false },
+        { key: "FUSION360_CLIENT_SECRET", label: "Client Secret",  hint: "", secret: true },
+        { key: "FUSION360_MCP_URL",       label: "MCP Server URL", hint: "http://localhost:8765", secret: false },
+      ],
+    },
+    "bambulab-printer": {
+      fullDesc: "Contrôle l'imprimante 3D BambuLab — slice STL, lancement et suivi d'impression via MQTT et API Cloud BambuLab. Compatible X1C, P1S, A1.",
+      fields: [
+        { key: "BAMBULAB_API_KEY", label: "Clé API Bambulab",     hint: "makerworld.bambulab.com", secret: true },
+        { key: "BAMBULAB_SERIAL",  label: "Numéro de série",      hint: "XXXXXXXXXX", secret: false },
+        { key: "BAMBULAB_IP",      label: "IP locale imprimante", hint: "192.168.1.x", secret: false },
+      ],
+    },
+    "mode-streameur": {
+      isRoutine: true,
+      fullDesc: "Lance l'environnement stream complet — OBS Studio, scènes préconfigurées, overlay Twitch. Jarvis orchestre le démarrage, gère les transitions et t'alerte si une app ne répond pas.",
+      appChecks: ["OBS Studio", "Twitch"],
+      fields: [
+        { key: "TWITCH_CLIENT_ID",     label: "Twitch Client ID",       hint: "dev.twitch.tv", secret: false },
+        { key: "TWITCH_CLIENT_SECRET", label: "Twitch Client Secret",   hint: "", secret: true },
+        { key: "OBS_WS_HOST",          label: "OBS WebSocket host",     hint: "localhost:4455", secret: false },
+        { key: "OBS_WS_PASSWORD",      label: "OBS WebSocket password", hint: "", secret: true },
+      ],
+    },
+  };
+
+  /* ─────────────────────────────────────────
+     DETAIL PANEL
+  ───────────────────────────────────────── */
+  let _panelKeyListener = null;
+
+  function initPanel() {
+    if (document.getElementById("detail-panel")) return;
+    const overlay = el("div", { id: "detail-overlay" });
+    overlay.addEventListener("click", closePanel);
+    document.body.appendChild(overlay);
+    document.body.appendChild(el("div", { id: "detail-panel" }));
+    _panelKeyListener = e => { if (e.key === "Escape") closePanel(); };
+    document.addEventListener("keydown", _panelKeyListener);
+  }
+
+  function closePanel() {
+    const panel = document.getElementById("detail-panel");
+    const overlay = document.getElementById("detail-overlay");
+    if (panel) panel.classList.remove("open");
+    if (overlay) overlay.classList.remove("open");
+  }
+
+  function openPanel(buildFn, data) {
+    initPanel();
+    const panel = document.getElementById("detail-panel");
+    panel.innerHTML = "";
+    buildFn(panel, data);
+    const overlay = document.getElementById("detail-overlay");
+    requestAnimationFrame(() => {
+      overlay.classList.add("open");
+      panel.classList.add("open");
+    });
+  }
+
+  function makeCloseBtn() {
+    const btn = el("button", { class: "panel-close", text: "✕" });
+    btn.addEventListener("click", closePanel);
+    return btn;
+  }
+
+  function appendConfigSection(panel, displayName, cfg) {
+    if (!cfg.fields || !cfg.fields.length) return;
+    const sec = el("div", { class: "panel-section" });
+    sec.appendChild(el("div", { class: "panel-section-title", text: "Configuration" }));
+    const inputs = [];
+    cfg.fields.forEach(f => {
+      const fw = el("div", { class: "panel-field" });
+      fw.appendChild(el("div", { class: "panel-field-label", text: f.label }));
+      const inp = el("input", { class: "panel-field-input", type: f.secret ? "password" : "text", placeholder: f.hint || "" });
+      J.api.get("/api/settings").then(ss => {
+        const v = (ss.api_keys || {})[f.key] || "";
+        if (v) inp.value = v;
+      }).catch(() => {});
+      fw.appendChild(inp);
+      inputs.push({ key: f.key, inp });
+      sec.appendChild(fw);
+    });
+    const saveBtn = el("button", { class: "panel-save-btn", text: "Sauvegarder" });
+    saveBtn.addEventListener("click", async () => {
+      saveBtn.textContent = "…"; saveBtn.disabled = true;
+      try {
+        for (const { key, inp } of inputs) {
+          if (inp.value) await J.api.post("/api/settings/update", { key, value: inp.value });
+        }
+        J.notify({ kind: "success", text: displayName + " · config sauvegardée" });
+      } catch (e) {
+        J.notify({ kind: "error", text: e.message });
+      }
+      saveBtn.textContent = "Sauvegarder"; saveBtn.disabled = false;
+    });
+    sec.appendChild(saveBtn);
+    panel.appendChild(sec);
+  }
+
+  /* ─── Skill panel ─── */
+  function buildSkillPanel(panel, s) {
+    const cfg = CONFIGS[s.name] || {};
+    const glyph3 = (s.name || "?").slice(0, 3).toUpperCase();
+
+    const hdr = el("div", { class: "panel-header" });
+    const left = el("div", { class: "panel-header-left" });
+    const glyph = el("div", { class: "panel-glyph skill", text: glyph3 });
+    const info = el("div");
+    info.appendChild(el("div", { class: "panel-name", text: s.name }));
+    info.appendChild(el("div", { class: "panel-type-badge", text: "SKILL" }));
+    left.appendChild(glyph); left.appendChild(info);
+    hdr.appendChild(left); hdr.appendChild(makeCloseBtn());
+    panel.appendChild(hdr);
+
+    const body = el("div", { class: "panel-body" });
+    body.appendChild(el("div", { class: "panel-desc", text: cfg.fullDesc || s.description || "—" }));
+
+    const stSec = el("div", { class: "panel-section" });
+    stSec.appendChild(el("div", { class: "panel-section-title", text: "Statut" }));
+    const stRow = el("div", { class: "panel-check-row" });
+    stRow.appendChild(el("span", { class: "panel-check-label", text: "Configuré" }));
+    stRow.appendChild(el("span", {
+      class: "panel-check-status " + (s.configured !== false ? "ok" : "ko"),
+      text: s.configured !== false ? "Actif" : "Non configuré",
+    }));
+    stSec.appendChild(stRow);
+    body.appendChild(stSec);
+
+    appendConfigSection(body, s.name, cfg);
+    panel.appendChild(body);
+  }
+
+  /* ─── Vue panel ─── */
+  function buildViewPanel(panel, v) {
+    const glyphText = (v.label || v.name || "?").slice(0, 3).toUpperCase();
+
+    const hdr = el("div", { class: "panel-header" });
+    const left = el("div", { class: "panel-header-left" });
+    const glyph = el("div", { class: "panel-glyph skill", text: glyphText });
+    const info = el("div");
+    info.appendChild(el("div", { class: "panel-name", text: v.label || v.name }));
+    info.appendChild(el("div", { class: "panel-type-badge", text: "VUE" }));
+    left.appendChild(glyph); left.appendChild(info);
+    hdr.appendChild(left); hdr.appendChild(makeCloseBtn());
+    panel.appendChild(hdr);
+
+    const body = el("div", { class: "panel-body" });
+    if (v.description) body.appendChild(el("div", { class: "panel-desc", text: v.description }));
+
+    // Statut actif
+    const registered = window.top?.Jarvis?.views?.list() || [];
+    const isActive = registered.some(rv => v.name.includes(rv.id));
+    const stSec = el("div", { class: "panel-section" });
+    stSec.appendChild(el("div", { class: "panel-section-title", text: "Statut" }));
+    const stRow = el("div", { class: "panel-check-row" });
+    stRow.appendChild(el("span", { class: "panel-check-label", text: "État" }));
+    stRow.appendChild(el("span", {
+      class: "panel-check-status " + (isActive ? "ok" : "ko"),
+      text: isActive ? "Active" : "Installée (rechargement requis)",
+    }));
+    stSec.appendChild(stRow);
+    if (v.version) {
+      const vRow = el("div", { class: "panel-check-row" });
+      vRow.appendChild(el("span", { class: "panel-check-label", text: "Version" }));
+      vRow.appendChild(el("span", { class: "panel-check-status ok", text: v.version }));
+      stSec.appendChild(vRow);
+    }
+    body.appendChild(stSec);
+
+    // Capacités
+    if (v.capabilities?.length) {
+      const capSec = el("div", { class: "panel-section" });
+      capSec.appendChild(el("div", { class: "panel-section-title", text: "Capacités" }));
+      v.capabilities.forEach(c => {
+        const row = el("div", { class: "panel-check-row" });
+        row.appendChild(el("span", { class: "panel-check-label", text: c }));
+        capSec.appendChild(row);
+      });
+      body.appendChild(capSec);
+    }
+
+    // Désinstaller
+    const actSec = el("div", { class: "panel-section" });
+    const uninstBtn = el("button", {
+      class: "panel-save-btn",
+      text: "Désinstaller",
+      style: { background: "rgba(255,80,80,0.08)", borderColor: "rgba(255,80,80,0.25)", color: "rgba(255,120,120,0.85)" },
+    });
+    uninstBtn.addEventListener("click", async () => {
+      uninstBtn.textContent = "…"; uninstBtn.disabled = true;
+      try {
+        await J.api.delete("/api/skills/uninstall/" + v.name);
+        J.notify({ kind: "success", text: (v.label || v.name) + " désinstallé" });
+        closePanel();
+        renderVues();
+      } catch (err) {
+        J.notify({ kind: "error", text: err.message });
+        uninstBtn.textContent = "Désinstaller"; uninstBtn.disabled = false;
+      }
+    });
+    actSec.appendChild(uninstBtn);
+    body.appendChild(actSec);
+    panel.appendChild(body);
+  }
+
+  /* ─── Routine panel ─── */
+  function buildRoutinePanel(panel, p) {
+    const cfg = CONFIGS[p.name] || {};
+    const glyph3 = (p.name || "?").slice(0, 3).toUpperCase();
+
+    const hdr = el("div", { class: "panel-header" });
+    const left = el("div", { class: "panel-header-left" });
+    const glyph = el("div", { class: "panel-glyph routine", text: glyph3 });
+    const info = el("div");
+    info.appendChild(el("div", { class: "panel-name", text: p.label || p.name }));
+    info.appendChild(el("div", { class: "panel-type-badge routine", text: "ROUTINE" }));
+    left.appendChild(glyph); left.appendChild(info);
+    hdr.appendChild(left); hdr.appendChild(makeCloseBtn());
+    panel.appendChild(hdr);
+
+    const body = el("div", { class: "panel-body" });
+    body.appendChild(el("div", { class: "panel-desc", text: cfg.fullDesc || p.description || "—" }));
+
+    if (cfg.appChecks && cfg.appChecks.length) {
+      const chkSec = el("div", { class: "panel-section" });
+      chkSec.appendChild(el("div", { class: "panel-section-title", text: "Applications requises" }));
+      cfg.appChecks.forEach(appName => {
+        const row = el("div", { class: "panel-check-row" });
+        row.appendChild(el("span", { class: "panel-check-label", text: appName }));
+        row.appendChild(el("span", { class: "panel-check-status ko", text: "Non vérifié" }));
+        chkSec.appendChild(row);
+      });
+      body.appendChild(chkSec);
+    }
+
+    if (p.platforms && p.platforms.length) {
+      const platSec = el("div", { class: "panel-section" });
+      platSec.appendChild(el("div", { class: "panel-section-title", text: "Plateformes" }));
+      const platRow = el("div", { style: { display: "flex", gap: "6px", flexWrap: "wrap" } });
+      p.platforms.forEach(pl => platRow.appendChild(el("span", { class: "preset-platform", text: pl })));
+      platSec.appendChild(platRow);
+      body.appendChild(platSec);
+    }
+
+    const runSec = el("div", { class: "panel-section" });
+    runSec.appendChild(el("div", { class: "panel-section-title", text: "Lancer" }));
+    const runBtn = el("button", { class: "panel-run-btn", text: "▶ Lancer la routine" });
+    runBtn.addEventListener("click", async () => {
+      runBtn.textContent = "…"; runBtn.disabled = true;
+      try {
+        await J.api.post("/api/presets/" + p.name + "/execute");
+        J.notify({ kind: "success", text: (p.label || p.name) + " lancée" });
+      } catch (e) {
+        J.notify({ kind: "error", text: e.message });
+      }
+      runBtn.textContent = "▶ Lancer la routine"; runBtn.disabled = false;
+    });
+    runSec.appendChild(runBtn);
+    body.appendChild(runSec);
+
+    appendConfigSection(body, p.label || p.name, cfg);
+    panel.appendChild(body);
+  }
+
+  /* ─── Ambiance panel ─── */
+  function buildAmbiancePanel(panel, a) {
+    const hdr = el("div", { class: "panel-header" });
+    const left = el("div", { class: "panel-header-left" });
+    const glyph = el("div", { class: "panel-glyph ambiance", text: (a.name || "").slice(0, 3).toUpperCase() });
+    const info = el("div");
+    info.appendChild(el("div", { class: "panel-name", text: a.name }));
+    info.appendChild(el("div", { class: "panel-type-badge ambiance", text: "AMBIANCE" }));
+    left.appendChild(glyph); left.appendChild(info);
+    hdr.appendChild(left); hdr.appendChild(makeCloseBtn());
+    panel.appendChild(hdr);
+
+    const body = el("div", { class: "panel-body" });
+    body.appendChild(el("div", { class: "panel-desc", text: a.desc || "—" }));
+
+    const actSec = el("div", { class: "panel-section" });
+    actSec.appendChild(el("div", { class: "panel-section-title", text: "Activer" }));
+    const actBtn = el("button", { class: "panel-run-btn", text: "Activer cette ambiance" });
+    actBtn.addEventListener("click", async () => {
+      actBtn.textContent = "…"; actBtn.disabled = true;
+      try {
+        await J.api.post("/api/ambiances/" + a.id, {});
+        J.notify({ kind: "success", text: a.name + " · activée" });
+      } catch (_) {}
+      actBtn.textContent = "Activer cette ambiance"; actBtn.disabled = false;
+    });
+    actSec.appendChild(actBtn);
+    body.appendChild(actSec);
+    panel.appendChild(body);
+  }
+
+  /* ─────────────────────────────────────────
+     PAGE HELPERS
+  ───────────────────────────────────────── */
+  function pageWrapper(pageId, title, meta, body) {
+    const idx = PAGES.findIndex(p => p.id === pageId);
+    const num = String(idx + 1).padStart(2, "0");
+    const wrap = el("div", { class: "page room-in" });
+
+    const head = el("div", { class: "page-head" });
+    const left = el("div");
+    const eyebrow = el("div", { class: "page-eyebrow" });
+    eyebrow.appendChild(el("span", { class: "num", text: num }));
+    eyebrow.appendChild(el("span", { text: " · " + PAGES[idx].label.toUpperCase() }));
+    left.appendChild(eyebrow);
+    left.appendChild(el("h1", { text: title }));
+    head.appendChild(left);
+    if (meta) { const m = el("div", { class: "page-head-meta" }); m.innerHTML = meta; head.appendChild(m); }
+    wrap.appendChild(head);
+
+    const pb = el("div", { class: "page-body" });
+    pb.appendChild(body);
+    wrap.appendChild(pb);
+    return wrap;
+  }
+
+  function escapeHtml(s) {
+    return String(s == null ? "" : s)
+      .replace(/&/g, "&amp;").replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+  }
+
+  function openCorrectionModal(fact, onDone) {
+    /* Modal minimal — overlay + carte. Pas de dépendance externe. */
+    const ov = el("div");
+    ov.style.cssText = "position:fixed;inset:0;background:rgba(0,0,0,.7);display:flex;align-items:center;justify-content:center;z-index:9999;";
+    const card = el("div");
+    card.style.cssText = "background:#0a0a0a;border:1px solid #2a2a2a;border-radius:10px;padding:24px;max-width:540px;width:92%;box-shadow:0 20px 60px rgba(0,0,0,.6);";
+    card.innerHTML = '<div style="font-family:Space Grotesk,Geist,sans-serif;font-size:18px;margin-bottom:6px;color:#d4af6a;">Corriger un fact</div>'
+      + '<div style="font-size:12px;color:#888;margin-bottom:18px;">Trace un event <code>human_correction</code> en audit immuable (§6.7).</div>'
+      + '<div style="font-size:13px;margin-bottom:14px;padding:10px;background:rgba(255,255,255,.04);border-radius:6px;">'
+      + '<span style="color:#aaa">' + escapeHtml(fact.subject) + ' · </span>'
+      + '<span style="color:#d4af6a">' + escapeHtml(fact.predicate) + '</span> · '
+      + '<span>' + escapeHtml(fact.object) + '</span></div>';
+
+    const labelObj = el("label", { text: "Nouvel objet (vide = inchangé)" });
+    labelObj.style.cssText = "display:block;font-size:11px;color:#888;margin-bottom:4px;text-transform:uppercase;letter-spacing:.08em;";
+    card.appendChild(labelObj);
+    const inObj = el("input"); inObj.type = "text"; inObj.placeholder = fact.object;
+    inObj.style.cssText = "width:100%;padding:8px 10px;background:#1a1a1a;border:1px solid #333;border-radius:5px;color:#eee;margin-bottom:14px;font-size:13px;font-family:Geist,sans-serif;";
+    card.appendChild(inObj);
+
+    const labelSt = el("label", { text: "Nouveau statut" });
+    labelSt.style.cssText = "display:block;font-size:11px;color:#888;margin-bottom:4px;text-transform:uppercase;letter-spacing:.08em;";
+    card.appendChild(labelSt);
+    const inSt = el("select");
+    ["", "active", "superseded", "archived", "needs_review"].forEach(v => {
+      const o = el("option"); o.value = v; o.textContent = v || "(inchangé)"; inSt.appendChild(o);
+    });
+    inSt.style.cssText = "width:100%;padding:8px 10px;background:#1a1a1a;border:1px solid #333;border-radius:5px;color:#eee;margin-bottom:14px;font-size:13px;";
+    card.appendChild(inSt);
+
+    const labelTxt = el("label", { text: "Motif" });
+    labelTxt.style.cssText = "display:block;font-size:11px;color:#888;margin-bottom:4px;text-transform:uppercase;letter-spacing:.08em;";
+    card.appendChild(labelTxt);
+    const inTxt = el("textarea"); inTxt.rows = 2; inTxt.placeholder = "Pourquoi cette correction…";
+    inTxt.style.cssText = "width:100%;padding:8px 10px;background:#1a1a1a;border:1px solid #333;border-radius:5px;color:#eee;margin-bottom:18px;font-size:13px;font-family:Geist,sans-serif;resize:vertical;";
+    card.appendChild(inTxt);
+
+    const row = el("div"); row.style.cssText = "display:flex;justify-content:flex-end;gap:8px;";
+    const cancel = el("button", { class: "m-btn", text: "Annuler" });
+    cancel.addEventListener("click", () => ov.remove());
+    const save = el("button", { class: "m-btn m-btn--save", text: "Appliquer" });
+    save.addEventListener("click", async () => {
+      save.disabled = true; save.textContent = "…";
+      try {
+        const body = { target_fact_id: fact.id, correction_text: inTxt.value || "" };
+        if (inObj.value.trim()) body.new_object = inObj.value.trim();
+        if (inSt.value) body.new_status = inSt.value;
+        await J.api.post("/api/memory/correct", body);
+        J.notify({ kind: "success", text: "Correction appliquée — event tracé en audit" });
+        ov.remove();
+        if (onDone) onDone();
+      } catch (e) {
+        J.notify({ kind: "error", text: e.message });
+        save.disabled = false; save.textContent = "Appliquer";
+      }
+    });
+    row.appendChild(cancel); row.appendChild(save);
+    card.appendChild(row);
+
+    ov.appendChild(card);
+    ov.addEventListener("click", (ev) => { if (ev.target === ov) ov.remove(); });
+    document.body.appendChild(ov);
+    inObj.focus();
+  }
+
+  function ghostSec(title, sub, right, content) {
+    const sec = el("div", { class: "ghost-sec" });
+    const hd = el("div", { class: "ghost-sec-hd" });
+    const l = el("div");
+    l.appendChild(el("div", { class: "ghost-sec-title", text: title }));
+    if (sub) l.appendChild(el("div", { class: "ghost-sec-sub", text: sub }));
+    hd.appendChild(l);
+    if (right) hd.appendChild(el("div", { class: "ghost-sec-r", text: right }));
+    sec.appendChild(hd);
+    sec.appendChild(content);
+    return sec;
+  }
+
+  /* ─────────────────────────────────────────
+     01 Intégrations
+  ───────────────────────────────────────── */
+  async function renderIntegrations() {
+    let connectors = [];
+    try { connectors = await J.api.get("/api/settings/connectors"); } catch (_) {}
+
+    const list = el("div", { class: "cn-list" });
+
+    // Sépare les connecteurs "services" des connecteurs "messagerie"
+    const services  = connectors.filter(c => c.group !== "messaging");
+    const messaging = connectors.filter(c => c.group === "messaging");
+
+    function renderConnectorRow(c) {
+      const cfg = CONNECTOR_CONFIG[c.name] || { kind: "key", keys: [] };
+      const status = c.status || "off";
+
+      const row = el("div", { class: "cn-row" });
+      row.appendChild(el("div", { class: "cn-dot " + (status === "soon" ? "off" : status) }));
+
+      const info = el("div", { class: "cn-info" });
+      info.appendChild(el("div", { class: "cn-name", text: c.name }));
+      info.appendChild(el("div", { class: "cn-sub", text: c.sub || "" }));
+      row.appendChild(info);
+
+      const right = el("div", { class: "cn-right" });
+      if (status === "on") {
+        right.appendChild(el("span", { class: "cn-badge on", text: "Connecté" }));
+      } else if (status === "expired") {
+        right.appendChild(el("span", { class: "cn-badge expired", text: "Expiré" }));
+        const btn = el("button", { class: "cn-btn", text: "Reconnecter" });
+        btn.addEventListener("click", () => triggerConnect(c, cfg, expand));
+        right.appendChild(btn);
+      } else if (status === "soon") {
+        right.appendChild(el("span", { class: "cn-badge", text: "Bientôt" }));
+      } else {
+        const btn = el("button", { class: "cn-btn", text: "Configurer →" });
+        btn.addEventListener("click", () => triggerConnect(c, cfg, expand));
+        right.appendChild(btn);
+      }
+      row.appendChild(right);
+      list.appendChild(row);
+
+      const expand = el("div", { class: "cn-expand" });
+      list.appendChild(expand);
+    }
+
+    services.forEach(renderConnectorRow);
+
+    if (messaging.length) {
+      const sep = el("div", { class: "cn-section-sep", text: "Messagerie" });
+      list.appendChild(sep);
+      messaging.forEach(renderConnectorRow);
+    }
+
+    const activeCount = connectors.filter(c => c.status === "on").length;
+    const wrap = el("div");
+    wrap.appendChild(ghostSec(
+      "Intégrations",
+      activeCount + " actives · " + connectors.length + " total",
+      null, list
+    ));
+
+    const page = pageWrapper("integrations", "Tes connecteurs", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  function triggerConnect(c, cfg, expandEl) {
+    if (cfg.kind === "oauth") {
+      window.location.href = cfg.url;
+      return;
+    }
+    if (cfg.kind === "stub") {
+      if (expandEl.classList.contains("open")) {
+        expandEl.classList.remove("open");
+        expandEl.innerHTML = "";
+        return;
+      }
+      expandEl.innerHTML = "";
+      expandEl.appendChild(el("div", { class: "cn-stub-note", text: cfg.note || "Bientôt disponible." }));
+      expandEl.classList.add("open");
+      return;
+    }
+    if (cfg.kind === "key" || cfg.kind === "messaging" || cfg.kind === "oauth_key") {
+      // Toggle expand with input fields
+      if (expandEl.classList.contains("open")) {
+        expandEl.classList.remove("open");
+        expandEl.innerHTML = "";
+        return;
+      }
+      expandEl.innerHTML = "";
+      const inputs = [];
+      J.api.get("/api/settings").then(ss => {
+        (cfg.keys || []).forEach(f => {
+          const fw = el("div", { class: "cn-field" });
+          const labelEl = el("label", { class: "cn-field-label", text: f.label });
+          fw.appendChild(labelEl);
+          if (f.hint) {
+            fw.appendChild(el("div", { class: "cn-field-hint", text: f.hint }));
+          }
+
+          if (f.type === "toggle") {
+            // Valeur courante depuis .env via env-status
+            const tog = el("div", { class: "cn-toggle" });
+            J.api.get("/api/settings/env-status?keys=" + f.key).then(st => {
+              if (st[f.key]) tog.classList.add("on");
+            }).catch(() => {});
+            tog.addEventListener("click", () => tog.classList.toggle("on"));
+            fw.appendChild(tog);
+            inputs.push({ key: f.key, tog, isToggle: true });
+          } else {
+            const inp = el("input", {
+              class: "cn-field-input",
+              type: f.secret ? "password" : "text",
+              placeholder: f.secret ? "••••••••••" : "",
+            });
+            const v = (ss.api_keys || {})[f.key] || "";
+            if (v) inp.value = v;
+            fw.appendChild(inp);
+            inputs.push({ key: f.key, inp });
+          }
+          expandEl.appendChild(fw);
+        });
+      }).catch(() => {});
+
+      const saveBtn = el("button", { class: "cn-save-btn", text: "Sauvegarder" });
+      saveBtn.addEventListener("click", async () => {
+        saveBtn.textContent = "…"; saveBtn.disabled = true;
+        try {
+          for (const item of inputs) {
+            if (item.isToggle) {
+              await J.api.post("/api/settings/update", { key: item.key, value: item.tog.classList.contains("on") ? "true" : "false" });
+            } else if (item.inp.value) {
+              await J.api.post("/api/settings/update", { key: item.key, value: item.inp.value });
+            }
+          }
+          J.notify({ kind: "success", text: c.name + " · configuré" });
+          if (cfg.kind !== "oauth_key") {
+            expandEl.classList.remove("open");
+            expandEl.innerHTML = "";
+            renderIntegrations();
+          }
+        } catch (e) {
+          J.notify({ kind: "error", text: e.message });
+          saveBtn.textContent = "Sauvegarder"; saveBtn.disabled = false;
+        }
+      });
+      expandEl.appendChild(saveBtn);
+
+      // Connecteurs hybrides : on saisit/sauvegarde les credentials de l'app
+      // (App ID + Secret), puis on lance le flux OAuth pour lier son compte.
+      if (cfg.kind === "oauth_key") {
+        expandEl.appendChild(el("div", {
+          class: "cn-field-hint",
+          text: "Sauvegarde tes identifiants d'app, puis connecte ton compte.",
+          style: { marginTop: "10px" },
+        }));
+        const connectBtn = el("button", { class: "cn-save-btn", text: "Connecter mon compte →" });
+        connectBtn.addEventListener("click", () => { fetch(cfg.url, { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} }).then(r => { if (r.redirected) window.location.href = r.url; else return r.json(); }).then(d => { if (d && d.auth_url) window.location.href = d.auth_url; }); });
+        expandEl.appendChild(connectBtn);
+      }
+      expandEl.classList.add("open");
+    }
+  }
+
+  /* ─────────────────────────────────────────
+     02 Skills
+  ───────────────────────────────────────── */
+  async function renderSkills() {
+    let skills = [];
+    try {
+      const r = await J.api.get("/api/skills/installed");
+      skills = r.skills || [];
+    } catch (_) {
+      try {
+        const tools = await J.api.get("/api/tools");
+        skills = tools.map(t => ({ name: t.name, description: t.description, configured: true }));
+      } catch (_) {}
+    }
+
+    skills = skills.filter(s => !SKILL_AS_ROUTINE.has(s.name));
+
+    const grid = el("div", { class: "skills-grid" });
+    skills.forEach(s => {
+      const card = el("div", { class: "skill-card" });
+      card.appendChild(el("div", { class: "skill-glyph", text: (s.name || "?").slice(0, 3).toUpperCase() }));
+      card.appendChild(el("div", { class: "skill-name", text: s.name || s.label || "—" }));
+      const desc = (s.description || "").slice(0, 100);
+      if (desc) card.appendChild(el("div", { class: "skill-desc", text: desc }));
+      card.addEventListener("click", () => openPanel(buildSkillPanel, s));
+      grid.appendChild(card);
+    });
+
+    const wrap = el("div");
+    wrap.appendChild(ghostSec("Skills installés", skills.length + " outils actifs", null, grid));
+    const page = pageWrapper("skills", "Tes outils & skills", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     03 Routines
+  ───────────────────────────────────────── */
+  async function renderRoutines() {
+    let presets = [];
+    let extraRoutines = [];
+    try {
+      const r = await J.api.get("/api/presets");
+      presets = r.presets || [];
+    } catch (_) {}
+
+    try {
+      const r = await J.api.get("/api/skills/installed");
+      (r.skills || [])
+        .filter(s => SKILL_AS_ROUTINE.has(s.name) && !presets.some(p => p.name === s.name))
+        .forEach(s => extraRoutines.push({
+          name: s.name,
+          label: s.label || s.name,
+          description: s.description,
+          platforms: [],
+        }));
+    } catch (_) {}
+
+    const allRoutines = [...presets, ...extraRoutines];
+
+    const grid = el("div", { class: "routine-grid" });
+    if (!allRoutines.length) {
+      grid.appendChild(el("div", { class: "j-empty", text: "Aucune routine installée" }));
+    } else {
+      allRoutines.forEach(p => {
+        const card = el("div", { class: "routine-card" });
+        card.appendChild(el("div", { class: "routine-glyph", text: (p.name || "?").slice(0, 3).toUpperCase() }));
+        card.appendChild(el("div", { class: "routine-name", text: p.label || p.name }));
+        const desc = (p.description || "").slice(0, 100);
+        if (desc) card.appendChild(el("div", { class: "routine-desc", text: desc }));
+        if (p.platforms && p.platforms.length) {
+          const platRow = el("div", { class: "routine-platforms" });
+          p.platforms.forEach(pl => platRow.appendChild(el("span", { class: "preset-platform", text: pl })));
+          card.appendChild(platRow);
+        }
+        card.addEventListener("click", () => openPanel(buildRoutinePanel, p));
+        grid.appendChild(card);
+      });
+    }
+
+    const wrap = el("div");
+    wrap.appendChild(ghostSec("Routines", allRoutines.length + " automatisations", null, grid));
+    const page = pageWrapper("routines", "Tes automatisations", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     04 Ambiances
+  ───────────────────────────────────────── */
+  async function renderVues() {
+    let installedViews = [];
+    try {
+      const r = await J.api.get("/api/skills/installed");
+      installedViews = (r.skills || []).filter(s =>
+        (s.tags || []).includes("view") || s.type === "view"
+      );
+    } catch (_) {}
+
+    const registered = window.top?.Jarvis?.views?.list() || [];
+
+    const grid = el("div", { class: "skills-grid" });
+    installedViews.forEach(v => {
+      const card = el("div", { class: "skill-card" });
+      const glyphText = (v.label || v.name || "?").slice(0, 3).toUpperCase();
+      card.appendChild(el("div", { class: "skill-glyph", text: glyphText }));
+      card.appendChild(el("div", { class: "skill-name", text: v.label || v.name }));
+      if (v.description) card.appendChild(el("div", { class: "skill-desc", text: v.description }));
+      const isActive = registered.some(rv => v.name.includes(rv.id));
+      card.appendChild(el("div", {
+        class: "skill-installed-badge",
+        text: isActive ? "● Active" : "Installée",
+      }));
+      card.addEventListener("click", () => openPanel(buildViewPanel, v));
+      grid.appendChild(card);
+    });
+
+    if (!installedViews.length) {
+      const empty = el("div", { class: "empty-hint", text: "Aucune vue installée — rendez-vous dans le Store." });
+      grid.appendChild(empty);
+    }
+
+    const wrap = el("div");
+    wrap.appendChild(ghostSec("Vues installées", installedViews.length + " vue" + (installedViews.length !== 1 ? "s" : ""), null, grid));
+    const page = pageWrapper("vues", "Vues & affichages", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     05 Store
+  ───────────────────────────────────────── */
+  async function renderStore() {
+    let catalog = [];
+    try {
+      const r = await J.api.get("/api/skills/catalog");
+      catalog = r.skills || [];
+    } catch (_) {}
+
+    const isView    = s => s.type === "view"   || (s.tags || []).includes("view");
+    const isRoutine = s => s.type === "preset" || (s.tags || []).includes("preset");
+
+    const views    = catalog.filter(s => isView(s));
+    const routines = catalog.filter(s => !isView(s) && isRoutine(s));
+    const skills   = catalog.filter(s => !isView(s) && !isRoutine(s));
+
+    function makeStoreCard(s, kind) {
+      const glyphCls = kind === "routine" ? "skill-glyph routine-glyph"
+                     : kind === "view"    ? "skill-glyph view-glyph"
+                     : "skill-glyph";
+      const card = el("div", { class: "skill-card" });
+      card.appendChild(el("div", { class: glyphCls, text: (s.name || "?").slice(0, 3).toUpperCase() }));
+      card.appendChild(el("div", { class: "skill-name", text: s.name }));
+      if (s.description) card.appendChild(el("div", { class: "skill-desc", text: s.description.slice(0, 100) }));
+
+      const footer = el("div", { style: { marginTop: "auto", paddingTop: "4px" } });
+      if (s.installed) {
+        footer.appendChild(el("div", { class: "skill-installed-badge", text: "✓ Installé" }));
+      } else {
+        const installBtn = el("button", { class: "skill-install-btn", text: "Installer" });
+        installBtn.addEventListener("click", async e => {
+          e.stopPropagation();
+          installBtn.textContent = "…"; installBtn.disabled = true;
+          try {
+            await J.api.post("/api/skills/install/" + s.name);
+            J.notify({ kind: "success", text: s.name + " installé" });
+            renderStore();
+          } catch (err) {
+            J.notify({ kind: "error", text: err.message });
+            installBtn.textContent = "Installer"; installBtn.disabled = false;
+          }
+        });
+        footer.appendChild(installBtn);
+      }
+      card.appendChild(footer);
+      return card;
+    }
+
+    const wrap = el("div", { style: { display: "flex", flexDirection: "column", gap: "32px" } });
+
+    if (!catalog.length) {
+      wrap.appendChild(el("div", { class: "j-empty", text: "Catalogue indisponible" }));
+    }
+
+    if (skills.length) {
+      const grid = el("div", { class: "skills-grid" });
+      skills.forEach(s => grid.appendChild(makeStoreCard(s, "skill")));
+      wrap.appendChild(ghostSec("Skills", skills.length + " disponible" + (skills.length !== 1 ? "s" : ""), null, grid));
+    }
+
+    if (routines.length) {
+      const grid = el("div", { class: "skills-grid" });
+      routines.forEach(s => grid.appendChild(makeStoreCard(s, "routine")));
+      wrap.appendChild(ghostSec("Routines", routines.length + " disponible" + (routines.length !== 1 ? "s" : ""), null, grid));
+    }
+
+    if (views.length) {
+      const grid = el("div", { class: "skills-grid" });
+      views.forEach(s => grid.appendChild(makeStoreCard(s, "view")));
+      wrap.appendChild(ghostSec("Vues", views.length + " disponible" + (views.length !== 1 ? "s" : ""), null, grid));
+    }
+
+    const page = pageWrapper("store", "Le store de skills", '<span class="v">' + catalog.length + '</span> disponibles', wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     06 Écosystème
+  ───────────────────────────────────────── */
+  function renderEcosysteme() {
+    const wrap = el("div", { class: "coming-soon-wrap" });
+    wrap.appendChild(el("div", { class: "coming-soon-msg", text: "À venir…" }));
+    const page = pageWrapper("ecosysteme", "L'écosystème Jarvis", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     07 Appareils
+  ───────────────────────────────────────── */
+
+  /* ── Three.js device scenes ──────────────────────────────────────── */
+  /* ─── Macropad 2 touches Le Labo panel ─── */
+  async function buildMacropadPanel(panel) {
+    const hdr  = el("div", { class: "panel-header" });
+    const left = el("div", { class: "panel-header-left" });
+    const glyph = el("div", { class: "panel-glyph skill", text: "MAC" });
+    const info  = el("div");
+    info.appendChild(el("div", { class: "panel-name",       text: "Macropad 2 touches Le Labo" }));
+    info.appendChild(el("div", { class: "panel-type-badge", text: "MACROPAD" }));
+    left.appendChild(glyph); left.appendChild(info);
+    hdr.appendChild(left); hdr.appendChild(makeCloseBtn());
+    panel.appendChild(hdr);
+
+    const body = el("div", { class: "panel-body" });
+    body.appendChild(el("div", { class: "panel-desc",
+      text: "Macropad 2 touches sur puce CH552. Configure les raccourcis, l'éclairage et flash le firmware directement depuis Jarvis." }));
+
+    /* ── Statut USB ── */
+    const stSec = el("div", { class: "panel-section" });
+    stSec.appendChild(el("div", { class: "panel-section-title", text: "Connexion" }));
+    const hidRow  = el("div", { class: "panel-check-row" });
+    const bootRow = el("div", { class: "panel-check-row" });
+    hidRow.appendChild(el("span",  { class: "panel-check-label", text: "Mode HID" }));
+    bootRow.appendChild(el("span", { class: "panel-check-label", text: "Bootloader" }));
+    const hidSt  = el("span", { class: "panel-check-status ko", text: "—" });
+    const bootSt = el("span", { class: "panel-check-status ko", text: "—" });
+    hidRow.appendChild(hidSt); bootRow.appendChild(bootSt);
+    stSec.appendChild(hidRow); stSec.appendChild(bootRow);
+    body.appendChild(stSec);
+
+    J.api.get("/api/macropad/status").then(st => {
+      if (st.hidPresent)         { hidSt.textContent  = "Connecté";  hidSt.className  = "panel-check-status ok"; }
+      else                       { hidSt.textContent  = "Absent";    hidSt.className  = "panel-check-status ko"; }
+      if (st.bootloaderPresent)  { bootSt.textContent = "Prêt";      bootSt.className = "panel-check-status ok"; }
+      else                       { bootSt.textContent = "Absent";    bootSt.className = "panel-check-status ko"; }
+    }).catch(() => { hidSt.textContent = "Erreur"; bootSt.textContent = "Erreur"; });
+
+    /* ── Profil actif + touches ── */
+    const profSec = el("div", { class: "panel-section" });
+    profSec.appendChild(el("div", { class: "panel-section-title", text: "Profil actif" }));
+    const k1Row = el("div", { class: "panel-check-row" });
+    const k2Row = el("div", { class: "panel-check-row" });
+    k1Row.appendChild(el("span", { class: "panel-check-label", text: "Touche K1 (droite)" }));
+    k2Row.appendChild(el("span", { class: "panel-check-label", text: "Touche K2 (gauche)" }));
+    const k1Val = el("span", { class: "panel-check-status", style: "color:var(--fg-2)", text: "—" });
+    const k2Val = el("span", { class: "panel-check-status", style: "color:var(--fg-2)", text: "—" });
+    k1Row.appendChild(k1Val); k2Row.appendChild(k2Val);
+    const profName = el("div", { style: "font-family:var(--mono);font-size:10px;color:var(--fg-3);margin-bottom:10px", text: "Chargement…" });
+    profSec.appendChild(profName);
+    profSec.appendChild(k1Row); profSec.appendChild(k2Row);
+    body.appendChild(profSec);
+
+    J.api.get("/api/macropad/profile").then(({ bundle }) => {
+      if (!bundle) return;
+      const active = (bundle.profiles || []).find(p => p.id === bundle.activeProfileId) || bundle.profiles[0];
+      if (!active) return;
+      profName.textContent = "Profil : " + (active.name || active.id);
+      const keys = active.data && active.data.keys;
+      if (keys) {
+        k1Val.textContent = keys.k1RightP1 ? (keys.k1RightP1.label || keys.k1RightP1.hidCode || "—") : "—";
+        k2Val.textContent = keys.k2LeftP2  ? (keys.k2LeftP2.label  || keys.k2LeftP2.hidCode  || "—") : "—";
+      }
+    }).catch(() => { profName.textContent = "Profil non disponible"; });
+
+    /* ── Actions ── */
+    const actSec = el("div", { class: "panel-section" });
+    actSec.appendChild(el("div", { class: "panel-section-title", text: "Actions" }));
+
+    const compileBtn = el("button", { class: "panel-run-btn", text: "⚙ Compiler le firmware" });
+    compileBtn.style.marginBottom = "8px";
+    compileBtn.addEventListener("click", async () => {
+      compileBtn.textContent = "…"; compileBtn.disabled = true;
+      try {
+        const r = await J.api.post("/api/macropad/compile", { workspace: null });
+        J.notify({ kind: r.ok ? "success" : "error", text: r.ok ? "Compilation réussie" : r.output });
+      } catch (e) { J.notify({ kind: "error", text: e.message }); }
+      compileBtn.textContent = "⚙ Compiler le firmware"; compileBtn.disabled = false;
+    });
+
+    const flashBtn = el("button", { class: "panel-run-btn", text: "⚡ Flasher le firmware" });
+    flashBtn.addEventListener("click", async () => {
+      flashBtn.textContent = "…"; flashBtn.disabled = true;
+      try {
+        const r = await J.api.post("/api/macropad/upload", { workspace: null });
+        J.notify({ kind: r.ok ? "success" : "error", text: r.ok ? "Flash réussi" : r.output });
+      } catch (e) { J.notify({ kind: "error", text: e.message }); }
+      flashBtn.textContent = "⚡ Flasher le firmware"; flashBtn.disabled = false;
+    });
+
+    actSec.appendChild(compileBtn);
+    actSec.appendChild(flashBtn);
+
+    const editorBtn = el("a", { class: "panel-run-btn",
+      text: "✎ Ouvrir l'éditeur complet",
+      href: "/macropad", target: "_blank",
+      style: "display:block;text-align:center;text-decoration:none;margin-top:8px" });
+    actSec.appendChild(editorBtn);
+
+    body.appendChild(actSec);
+    panel.appendChild(body);
+  }
+
+  const _scenes = [];
+
+  function _killScenes() {
+    _scenes.forEach(s => s.dispose());
+    _scenes.length = 0;
+  }
+
+  function buildDevice3D(d) {
+    const type   = d.type || "unknown";
+    const btType = (d.a && d.a[0] === "Type") ? (d.a[1] || "").toLowerCase() : "";
+    const wrap   = el("div", { class: "dv-scene-wrap" });
+    const canvas = document.createElement("canvas");
+    canvas.className = "dv-scene-canvas";
+    wrap.appendChild(canvas);
+    requestAnimationFrame(() => {
+      if (!canvas.isConnected) return;
+      const ctrl = _makeDeviceScene(canvas, type, btType);
+      if (ctrl) _scenes.push(ctrl);
+    });
+    return wrap;
+  }
+
+  function _makeDeviceScene(canvas, type, btType) {
+    const T = window.THREE;
+    if (!T) return null;
+    const W = canvas.offsetWidth  || 280;
+    const H = canvas.offsetHeight || 200;
+
+    const renderer = new T.WebGLRenderer({ canvas, antialias: true, alpha: true });
+    renderer.setSize(W, H, false);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setClearColor(0x000000, 0);
+
+    const scene  = new T.Scene();
+    const camera = new T.PerspectiveCamera(32, W / H, 0.1, 100);
+
+    // Lights
+    scene.add(new T.AmbientLight(0xd0dcff, 0.55));
+    const key = new T.DirectionalLight(0xffffff, 1.1);
+    key.position.set(3, 5, 4);
+    scene.add(key);
+    const fill = new T.DirectionalLight(0x4a9eff, 0.38);
+    fill.position.set(-4, 1, -2);
+    scene.add(fill);
+    const rim = new T.DirectionalLight(0xaaaaff, 0.18);
+    rim.position.set(0, -2, -4);
+    scene.add(rim);
+
+    const group = new T.Group();
+    scene.add(group);
+
+    if (type === "host") {
+      _meshMac(T, group);
+      camera.position.set(0, 1.6, 5.5);
+      camera.lookAt(0, 0.25, 0);
+    } else if (type === "macropad") {
+      _meshMacropad(T, group);
+      camera.position.set(0, 2.8, 3.2);
+      camera.lookAt(0, 0, 0);
+    } else if (btType.includes("headphone") || btType.includes("headset")) {
+      _meshHeadphones(T, group);
+      camera.position.set(0, 0.8, 4.2);
+      camera.lookAt(0, 0.2, 0);
+    } else if (btType.includes("mouse")) {
+      _meshMouse(T, group);
+      camera.position.set(0, 1.8, 4.0);
+      camera.lookAt(0, 0, 0);
+    } else {
+      _meshGeneric(T, group);
+      camera.position.set(0, 1.5, 4.5);
+      camera.lookAt(0, 0.1, 0);
+    }
+
+    let raf, speed = 0.007;
+    canvas.addEventListener("mouseenter", () => { speed = 0; });
+    canvas.addEventListener("mouseleave", () => { speed = 0.007; });
+
+    const tick = () => {
+      raf = requestAnimationFrame(tick);
+      group.rotation.y += speed;
+      renderer.render(scene, camera);
+    };
+    tick();
+
+    return {
+      dispose() {
+        cancelAnimationFrame(raf);
+        group.traverse(o => {
+          if (o.geometry) o.geometry.dispose();
+          if (o.material) {
+            (Array.isArray(o.material) ? o.material : [o.material]).forEach(m => m.dispose());
+          }
+        });
+        renderer.dispose();
+      }
+    };
+  }
+
+  /* ── MacBook Pro ─────────────────────────────── */
+  function _meshMac(T, group) {
+    const alum  = new T.MeshStandardMaterial({ color: 0xb4b4c2, metalness: 0.85, roughness: 0.20 });
+    const dark  = new T.MeshStandardMaterial({ color: 0x060a14,
+      emissive: new T.Color(0x1a3a8a), emissiveIntensity: 0.55, roughness: 0.9 });
+    const bezel = new T.MeshStandardMaterial({ color: 0x080c1a, roughness: 0.8 });
+    const tpad  = new T.MeshStandardMaterial({ color: 0xa8a8b4, metalness: 0.72, roughness: 0.30 });
+
+    // Base (keyboard deck)
+    group.add(new T.Mesh(new T.BoxGeometry(2.2, 0.08, 1.52), alum));
+
+    // Trackpad
+    const tp = new T.Mesh(new T.BoxGeometry(0.58, 0.005, 0.40), tpad);
+    tp.position.set(0, 0.043, 0.34);
+    group.add(tp);
+
+    // Hinge pivot at top-back of base
+    const hinge = new T.Group();
+    hinge.position.set(0, 0.04, -0.76);
+    group.add(hinge);
+
+    const lidH = 1.38;
+
+    // Lid outer frame
+    const lid = new T.Mesh(new T.BoxGeometry(2.2, lidH, 0.06), alum);
+    lid.position.set(0, lidH / 2, 0);
+    hinge.add(lid);
+
+    // Display
+    const disp = new T.Mesh(new T.BoxGeometry(2.04, 1.24, 0.01), dark);
+    disp.position.set(0, lidH / 2 + 0.01, 0.035);
+    hinge.add(disp);
+
+    // Notch
+    const notch = new T.Mesh(new T.BoxGeometry(0.24, 0.05, 0.015), bezel);
+    notch.position.set(0, lidH - 0.04, 0.036);
+    hinge.add(notch);
+
+    // Open ~115° (25° past vertical → rotate hinge backward)
+    hinge.rotation.x = -(25 * Math.PI / 180);
+
+    group.position.y = -0.44;
+  }
+
+  /* ── Macropad ────────────────────────────────── */
+  function _meshMacropad(T, group) {
+    const bodyMat = new T.MeshStandardMaterial({ color: 0x141420, metalness: 0.3, roughness: 0.6 });
+    const frameMat= new T.MeshStandardMaterial({ color: 0x1e1e2e, metalness: 0.2, roughness: 0.5 });
+    const keyMat  = new T.MeshStandardMaterial({ color: 0x22223a, roughness: 0.7 });
+    const litMat  = new T.MeshStandardMaterial({ color: 0x0d2242,
+      emissive: new T.Color(0x4a9eff), emissiveIntensity: 0.85, roughness: 0.6 });
+    const encMat  = new T.MeshStandardMaterial({ color: 0x4a9eff, metalness: 0.4,
+      emissive: new T.Color(0x4a9eff), emissiveIntensity: 0.35 });
+
+    const frame = new T.Mesh(new T.BoxGeometry(1.88, 0.22, 1.38), frameMat);
+    frame.position.y = -0.01;
+    group.add(frame);
+    group.add(new T.Mesh(new T.BoxGeometry(1.82, 0.20, 1.32), bodyMat));
+
+    // 3×4 key grid
+    const cols = 4, rows = 3;
+    const kW = 0.30, kD = 0.25, kH = 0.07;
+    const gapX = 0.08, gapZ = 0.07;
+    const totalW = cols * kW + (cols - 1) * gapX;
+    const totalD = rows * kD + (rows - 1) * gapZ;
+    let idx = 0;
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const key = new T.Mesh(new T.BoxGeometry(kW, kH, kD), idx % 3 === 0 ? litMat : keyMat);
+        key.position.set(
+          -totalW / 2 + c * (kW + gapX) + kW / 2,
+          0.135,
+          -totalD / 2 + r * (kD + gapZ) + kD / 2
+        );
+        group.add(key);
+        idx++;
+      }
+    }
+
+    // Encoder knob
+    const enc = new T.Mesh(new T.CylinderGeometry(0.12, 0.12, 0.1, 20), encMat);
+    enc.position.set(0.68, 0.20, -0.48);
+    group.add(enc);
+
+    group.position.y = -0.12;
+    group.rotation.x = -0.15;
+  }
+
+  /* ── Headphones ──────────────────────────────── */
+  function _meshHeadphones(T, group) {
+    const bandMat = new T.MeshStandardMaterial({ color: 0x282830, metalness: 0.6, roughness: 0.35 });
+    const cupMat  = new T.MeshStandardMaterial({ color: 0x1e1e28, metalness: 0.4, roughness: 0.45 });
+    const padMat  = new T.MeshStandardMaterial({ color: 0x2a2a2a, roughness: 0.85 });
+
+    // Headband (half-torus arc — arche vers le haut)
+    const band = new T.Mesh(new T.TorusGeometry(0.72, 0.062, 10, 40, Math.PI), bandMat);
+    band.position.y = 0;
+    group.add(band);
+
+    [-0.72, 0.72].forEach(x => {
+      // Stem
+      const stem = new T.Mesh(new T.CylinderGeometry(0.038, 0.038, 0.32, 10), bandMat);
+      stem.rotation.z = Math.PI / 2;
+      stem.position.set(x, 0, 0);
+      group.add(stem);
+
+      // Cup shell
+      const cup = new T.Mesh(new T.CylinderGeometry(0.27, 0.24, 0.20, 26), cupMat);
+      cup.rotation.z = Math.PI / 2;
+      cup.position.set(x, 0, 0);
+      group.add(cup);
+
+      // Ear pad
+      const pad = new T.Mesh(new T.CylinderGeometry(0.21, 0.21, 0.04, 26), padMat);
+      pad.rotation.z = Math.PI / 2;
+      pad.position.set(x < 0 ? x - 0.12 : x + 0.12, 0, 0);
+      group.add(pad);
+    });
+
+    group.position.y = -0.38;
+  }
+
+  /* ── Mouse ───────────────────────────────────── */
+  function _meshMouse(T, group) {
+    const bodyMat   = new T.MeshStandardMaterial({ color: 0xbcbcca, metalness: 0.68, roughness: 0.28 });
+    const btnLMat   = new T.MeshStandardMaterial({ color: 0xccccda, metalness: 0.62, roughness: 0.32 });
+    const btnRMat   = new T.MeshStandardMaterial({ color: 0xb8b8c8, metalness: 0.60, roughness: 0.35 });
+    const scrollMat = new T.MeshStandardMaterial({ color: 0x808090, metalness: 0.5, roughness: 0.5 });
+
+    // Body (scaled sphere)
+    const body = new T.Mesh(new T.SphereGeometry(0.52, 28, 18), bodyMat);
+    body.scale.set(0.88, 0.43, 1.18);
+    group.add(body);
+
+    // Left button
+    const lBtn = new T.Mesh(new T.BoxGeometry(0.40, 0.032, 0.52), btnLMat);
+    lBtn.position.set(-0.22, 0.21, -0.18);
+    group.add(lBtn);
+
+    // Right button
+    const rBtn = new T.Mesh(new T.BoxGeometry(0.40, 0.032, 0.52), btnRMat);
+    rBtn.position.set(0.22, 0.21, -0.18);
+    group.add(rBtn);
+
+    // Scroll wheel
+    const scroll = new T.Mesh(new T.CylinderGeometry(0.06, 0.06, 0.24, 14), scrollMat);
+    scroll.rotation.z = Math.PI / 2;
+    scroll.position.set(0, 0.248, -0.15);
+    group.add(scroll);
+
+    group.position.y = -0.08;
+  }
+
+  /* ── Generic BT ──────────────────────────────── */
+  function _meshGeneric(T, group) {
+    const frameMat  = new T.MeshStandardMaterial({ color: 0x1e1e34, metalness: 0.25, roughness: 0.55 });
+    const bodyMat   = new T.MeshStandardMaterial({ color: 0x16162a, metalness: 0.30, roughness: 0.60 });
+    const screenMat = new T.MeshStandardMaterial({ color: 0x060a14,
+      emissive: new T.Color(0x1a3a8a), emissiveIntensity: 0.48, roughness: 0.9 });
+    const dotMat    = new T.MeshStandardMaterial({ color: 0x4a9eff,
+      emissive: new T.Color(0x4a9eff), emissiveIntensity: 1.0 });
+
+    group.add(new T.Mesh(new T.BoxGeometry(1.05, 0.10, 1.60), frameMat));
+    const body = new T.Mesh(new T.BoxGeometry(0.98, 0.09, 1.52), bodyMat);
+    body.position.y = 0.005;
+    group.add(body);
+
+    const screen = new T.Mesh(new T.BoxGeometry(0.82, 0.01, 1.12), screenMat);
+    screen.position.set(0, 0.055, -0.08);
+    group.add(screen);
+
+    const dot = new T.Mesh(new T.CylinderGeometry(0.07, 0.07, 0.012, 16), dotMat);
+    dot.position.set(0, 0.056, 0.58);
+    group.add(dot);
+
+    group.position.y = -0.18;
+    group.rotation.x = -0.14;
+  }
+
+  async function renderAppareils() {
+    let devices = [];
+    try { devices = await J.api.get("/api/settings/devices"); } catch (_) {}
+
+    const grid = el("div", { class: "device-grid-v2" });
+    devices.forEach(d => {
+      const col  = d.col || "muted";
+      const card = el("div", { class: "dv-card-v2" + (col === "muted" ? " dv-card--dim" : " dv-card--glow-" + col) });
+
+      card.appendChild(buildDevice3D(d));
+      if (d.type === "macropad") {
+        card.style.cursor = "pointer";
+        card.addEventListener("click", () => openPanel(buildMacropadPanel));
+      }
+
+      const body = el("div", { class: "dv-body-v2" });
+
+      const nameRow = el("div", { class: "dv-name-row" });
+      nameRow.appendChild(el("div", { class: "dv-name-v2", text: d.name }));
+      nameRow.appendChild(el("div", { class: "dv-badge " + col, text: d.status || "Unknown" }));
+      body.appendChild(nameRow);
+
+      if (d.id) body.appendChild(el("div", { class: "dv-sub-v2", text: d.id }));
+
+      if (d.a || d.b) {
+        const meta = el("div", { class: "dv-meta-v2" });
+        [d.a, d.b].forEach(pair => {
+          if (!pair) return;
+          const item = el("div", { class: "dv-meta-item-v2" });
+          item.appendChild(el("div", { class: "dv-meta-k-v2", text: pair[0] || "" }));
+          item.appendChild(el("div", { class: "dv-meta-v-v2", text: pair[1] || "" }));
+          meta.appendChild(item);
+        });
+        body.appendChild(meta);
+      }
+
+      card.appendChild(body);
+      grid.appendChild(card);
+    });
+
+    const wrap = el("div");
+    wrap.appendChild(ghostSec("Appareils", devices.length + " détectés", null, grid));
+    const page = pageWrapper("appareils", "Tes appareils", null, wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     08 Fils (Sessions)
+  ───────────────────────────────────────── */
+  async function renderFils() {
+    let sessions = [];
+    try { sessions = await J.api.get("/api/sessions"); } catch (_) {}
+
+    const list = el("div");
+    if (!sessions.length) {
+      list.appendChild(el("div", { class: "j-empty", text: "Aucune session récente" }));
+    } else {
+      sessions.slice(0, 20).forEach(s => {
+        const row = el("div", { class: "session-row" });
+        row.appendChild(el("div", { class: "sess-id t-mono", text: (s.id || "").slice(0, 6).toUpperCase() }));
+
+        const preview = el("div");
+        const titleEl = el("div", { class: "sess-preview", text: s.title || s.preview || "—" });
+        preview.appendChild(titleEl);
+        preview.appendChild(el("div", { style: { fontFamily: "var(--mono)", fontSize: "9.5px", color: "var(--fg-3)", marginTop: "3px" },
+          text: (s.message_count || 0) + " messages" }));
+        row.appendChild(preview);
+        row.appendChild(el("div", { class: "sess-date", text: s.date || "" }));
+
+        const viewBtn   = el("button", { class: "m-btn", text: "Voir" });
+        const renameBtn = el("button", { class: "m-btn", text: "Renommer" });
+        const delBtn    = el("button", { class: "m-btn m-btn--danger", text: "✕" });
+        delBtn.title = "Supprimer ce fil";
+        const acts = el("div", { class: "mem-btn-row" });
+        acts.appendChild(viewBtn);
+        acts.appendChild(renameBtn);
+        acts.appendChild(delBtn);
+        row.appendChild(acts);
+        list.appendChild(row);
+
+        /* inline conversation viewer */
+        const viewer   = el("div", { class: "sess-viewer" });
+        const msgList  = el("div", { class: "sess-msg-list" });
+        const closeViewBtn = el("button", { class: "m-btn", text: "Fermer" });
+        viewer.appendChild(msgList);
+        viewer.appendChild(closeViewBtn);
+        list.appendChild(viewer);
+
+        viewBtn.addEventListener("click", async () => {
+          if (viewer.classList.contains("open")) {
+            viewer.classList.remove("open");
+            viewBtn.textContent = "Voir";
+            return;
+          }
+          editor.classList.remove("open");
+          renameBtn.textContent = "Renommer";
+          viewBtn.textContent = "…"; viewBtn.disabled = true;
+          try {
+            const msgs = await J.api.get("/api/sessions/" + encodeURIComponent(s.id) + "/messages?limit=100");
+            msgList.innerHTML = "";
+            if (!msgs.length) {
+              msgList.appendChild(el("div", { class: "sess-msg-empty", text: "Aucun message." }));
+            } else {
+              msgs.forEach(m => {
+                const bubble = el("div", { class: "sess-bubble sess-bubble--" + (m.role === "user" ? "user" : "assistant") });
+                const label  = el("div", { class: "sess-bubble-role", text: m.role === "user" ? "Toi" : "Jarvis" });
+                const body   = el("div", { class: "sess-bubble-body", text: m.content || "" });
+                bubble.appendChild(label);
+                bubble.appendChild(body);
+                msgList.appendChild(bubble);
+              });
+            }
+            viewer.classList.add("open");
+            setTimeout(() => viewer.scrollIntoView({ behavior: "smooth", block: "nearest" }), 50);
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+          }
+          viewBtn.textContent = "Voir"; viewBtn.disabled = false;
+        });
+
+        closeViewBtn.addEventListener("click", () => {
+          viewer.classList.remove("open");
+          viewBtn.textContent = "Voir";
+        });
+
+        /* inline rename editor */
+        const editor  = el("div", { class: "sess-rename-editor" });
+        const inp     = el("input", { class: "sess-rename-input", type: "text" });
+        inp.value       = s.title || s.preview || "";
+        inp.placeholder = "Nouveau titre…";
+        editor.appendChild(inp);
+        const saveBtn  = el("button", { class: "m-btn m-btn--save", text: "Sauvegarder" });
+        const closeBtn = el("button", { class: "m-btn",              text: "Annuler" });
+        const btnRow   = el("div",    { class: "mem-btn-row" });
+        btnRow.appendChild(saveBtn);
+        btnRow.appendChild(closeBtn);
+        editor.appendChild(btnRow);
+        list.appendChild(editor);
+
+        renameBtn.addEventListener("click", () => {
+          const open = editor.classList.contains("open");
+          if (!open) { viewer.classList.remove("open"); viewBtn.textContent = "Voir"; }
+          editor.classList.toggle("open", !open);
+          renameBtn.textContent = open ? "Renommer" : "Annuler";
+          if (!open) { inp.focus(); inp.select(); }
+        });
+
+        closeBtn.addEventListener("click", () => {
+          editor.classList.remove("open");
+          renameBtn.textContent = "Renommer";
+        });
+
+        inp.addEventListener("keydown", e => {
+          if (e.key === "Enter")  saveBtn.click();
+          if (e.key === "Escape") closeBtn.click();
+        });
+
+        saveBtn.addEventListener("click", async () => {
+          const newTitle = inp.value.trim();
+          if (!newTitle) return;
+          const orig = saveBtn.textContent;
+          saveBtn.textContent = "…"; saveBtn.disabled = true;
+          try {
+            await J.api.put("/api/sessions/" + encodeURIComponent(s.id) + "/title", { title: newTitle });
+            titleEl.textContent = newTitle;
+            editor.classList.remove("open");
+            renameBtn.textContent = "Renommer";
+            J.notify({ kind: "success", text: "Fil renommé" });
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+            saveBtn.textContent = "✗ Erreur";
+          }
+          setTimeout(() => { saveBtn.textContent = orig; saveBtn.disabled = false; }, 1800);
+        });
+
+        delBtn.addEventListener("click", async () => {
+          if (!confirm("Supprimer ce fil définitivement ?")) return;
+          delBtn.disabled = true;
+          try {
+            await J.api.delete("/api/sessions/" + encodeURIComponent(s.id));
+            row.remove();
+            editor.remove();
+            J.notify({ kind: "success", text: "Fil supprimé" });
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+            delBtn.disabled = false;
+          }
+        });
+      });
+    }
+
+    const wrap = el("div");
+    wrap.appendChild(ghostSec("Sessions récentes", sessions.length + " fils", null, list));
+    const page = pageWrapper("fils", "Tes conversations", '<span class="v">' + sessions.length + '</span> fils', wrap);
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     09 Mémoire
+  ───────────────────────────────────────── */
+  function relTime(iso) {
+    if (!iso) return "—";
+    const d = new Date(iso); const now = new Date();
+    const sec = Math.round((now - d) / 1000);
+    if (sec < 60) return "à l'instant";
+    if (sec < 3600) return Math.round(sec / 60) + " min";
+    if (sec < 86400) return Math.round(sec / 3600) + " h";
+    if (sec < 86400 * 30) return Math.round(sec / 86400) + " j";
+    return d.toLocaleDateString("fr");
+  }
+
+  async function renderMemoire() {
+    let topics = [], index = "", facts = [];
+    try {
+      topics = await J.api.get("/api/memory/topics");
+      const idx = await J.api.get("/api/memory/index");
+      index = idx.content || "";
+    } catch (_) {}
+    try {
+      facts = await J.api.get("/api/memory/facts?status=active&limit=200");
+    } catch (_) {}
+
+    const wrap = el("div", { style: { display: "flex", flexDirection: "column", gap: "40px" } });
+
+    /* ── Facts (Kernel SQL — construit ici, appendé en bas de la page) ── */
+    const factsList = el("div", { style: { display: "flex", flexDirection: "column", gap: "8px" } });
+    if (!facts.length) {
+      factsList.appendChild(el("div", { class: "j-empty", text: "Aucun fact actif dans le Kernel" }));
+    } else {
+      /* Group by category for legibility */
+      const byCat = {};
+      facts.forEach(f => { (byCat[f.category] = byCat[f.category] || []).push(f); });
+      const cats = Object.keys(byCat).sort();
+      cats.forEach(cat => {
+        const catHead = el("div", { class: "mem-cat-head", text: cat + " · " + byCat[cat].length });
+        catHead.style.cssText = "font-size:11px;letter-spacing:.08em;text-transform:uppercase;color:#888;margin-top:14px;margin-bottom:4px;";
+        factsList.appendChild(catHead);
+        byCat[cat].forEach(f => {
+          const row = el("div", { class: "fact-row" });
+          row.style.cssText = "display:grid;grid-template-columns:1fr 90px 80px 80px auto;gap:10px;padding:8px 10px;border:1px solid rgba(255,255,255,.06);border-radius:6px;align-items:center;background:rgba(255,255,255,.02);";
+
+          const txt = el("div");
+          txt.innerHTML = '<span style="color:#aaa">' + escapeHtml(f.subject) + ' · </span>'
+            + '<span style="color:#d4af6a">' + escapeHtml(f.predicate) + '</span> · '
+            + '<span>' + escapeHtml(f.object) + '</span>';
+          row.appendChild(txt);
+
+          row.appendChild(el("div", { text: "conf " + (f.confidence * 100).toFixed(0) + "%", style: { fontSize: "11px", color: "#888", textAlign: "right", fontFamily: "Geist Mono, monospace" } }));
+          row.appendChild(el("div", { text: f.decay_policy, style: { fontSize: "11px", color: "#888", textAlign: "center" } }));
+          row.appendChild(el("div", { text: relTime(f.last_seen_at), style: { fontSize: "11px", color: "#888", textAlign: "right" } }));
+
+          const corrBtn = el("button", { class: "m-btn", text: "Corriger" });
+          corrBtn.style.cssText = "padding:4px 10px;font-size:11px;";
+          corrBtn.addEventListener("click", () => openCorrectionModal(f, () => renderMemoire()));
+          row.appendChild(corrBtn);
+
+          factsList.appendChild(row);
+        });
+      });
+    }
+    const factsSection = ghostSec(
+      "Facts (Kernel)",
+      facts.length + " actifs · régénéré à chaque passe deep",
+      null,
+      factsList
+    );
+
+    /* ── Index MEMORY.md (éditable) ── */
+    const indexWrap = el("div", { style: { display: "flex", flexDirection: "column", gap: "10px" } });
+    const indexTa = el("textarea", { class: "mem-textarea" });
+    indexTa.rows = 10;
+    indexTa.value = index;
+    indexWrap.appendChild(indexTa);
+    const indexSave = el("button", { class: "m-btn m-btn--save", text: "Sauvegarder" });
+    indexSave.addEventListener("click", async () => {
+      const orig = indexSave.textContent;
+      indexSave.textContent = "…"; indexSave.disabled = true;
+      try {
+        await J.api.put("/api/memory/index", { content: indexTa.value });
+        J.notify({ kind: "success", text: "MEMORY.md sauvegardé" });
+        indexSave.textContent = "✓ Sauvegardé";
+      } catch (e) {
+        J.notify({ kind: "error", text: e.message });
+        indexSave.textContent = "✗ Erreur";
+      }
+      setTimeout(() => { indexSave.textContent = orig; indexSave.disabled = false; }, 2000);
+    });
+    const idxRow = el("div", { class: "mem-btn-row" });
+    idxRow.appendChild(indexSave);
+    indexWrap.appendChild(idxRow);
+    wrap.appendChild(ghostSec("Index mémoire", "MEMORY.md", null, indexWrap));
+
+    /* ── Topics ── */
+    const list = el("div");
+    if (!topics.length) {
+      list.appendChild(el("div", { class: "j-empty", text: "Aucun topic en mémoire" }));
+    } else {
+      topics.forEach(t => {
+        const row = el("div", { class: "memory-row" });
+        row.appendChild(el("div", { class: "mem-name", text: t.name }));
+        row.appendChild(el("div", { class: "mem-meta", text: Math.round((t.size || 0) / 1024 * 10) / 10 + " ko" }));
+        row.appendChild(el("div", { class: "mem-meta", text: t.mtime ? new Date(t.mtime).toLocaleDateString("fr") : "—" }));
+
+        const editBtn = el("button", { class: "m-btn", text: "Éditer" });
+        const delBtn  = el("button", { class: "m-btn m-btn--danger", text: "✕" });
+        delBtn.title = "Supprimer " + t.name;
+        const acts = el("div", { class: "mem-btn-row" });
+        acts.appendChild(editBtn);
+        acts.appendChild(delBtn);
+        row.appendChild(acts);
+        list.appendChild(row);
+
+        /* inline editor (hidden by default) */
+        const editor = el("div", { class: "mem-topic-editor" });
+        const ta = el("textarea", { class: "mem-textarea" });
+        ta.rows = 14;
+        editor.appendChild(ta);
+        const saveBtn  = el("button", { class: "m-btn m-btn--save",  text: "Sauvegarder" });
+        const closeBtn = el("button", { class: "m-btn",               text: "Fermer" });
+        const btnRow   = el("div",    { class: "mem-btn-row" });
+        btnRow.appendChild(saveBtn);
+        btnRow.appendChild(closeBtn);
+        editor.appendChild(btnRow);
+        list.appendChild(editor);
+
+        editBtn.addEventListener("click", async () => {
+          if (editor.classList.contains("open")) {
+            editor.classList.remove("open");
+            editBtn.textContent = "Éditer";
+            return;
+          }
+          editBtn.textContent = "…"; editBtn.disabled = true;
+          try {
+            const { content } = await J.api.get("/api/memory/topics/" + encodeURIComponent(t.name));
+            ta.value = content;
+            editor.classList.add("open");
+            editBtn.textContent = "Éditer";
+            setTimeout(() => editor.scrollIntoView({ behavior: "smooth", block: "nearest" }), 50);
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+            editBtn.textContent = "Éditer";
+          }
+          editBtn.disabled = false;
+        });
+
+        closeBtn.addEventListener("click", () => {
+          editor.classList.remove("open");
+          editBtn.textContent = "Éditer";
+        });
+
+        saveBtn.addEventListener("click", async () => {
+          const orig = saveBtn.textContent;
+          saveBtn.textContent = "…"; saveBtn.disabled = true;
+          try {
+            await J.api.put("/api/memory/topics/" + encodeURIComponent(t.name), { content: ta.value });
+            J.notify({ kind: "success", text: t.name + " sauvegardé" });
+            saveBtn.textContent = "✓ Sauvegardé";
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+            saveBtn.textContent = "✗ Erreur";
+          }
+          setTimeout(() => { saveBtn.textContent = orig; saveBtn.disabled = false; }, 2000);
+        });
+
+        delBtn.addEventListener("click", async () => {
+          if (!confirm("Supprimer « " + t.name + " » définitivement ?")) return;
+          delBtn.disabled = true;
+          try {
+            await J.api.delete("/api/memory/topics/" + encodeURIComponent(t.name));
+            row.remove();
+            editor.remove();
+            J.notify({ kind: "success", text: t.name + " supprimé" });
+          } catch (e) {
+            J.notify({ kind: "error", text: e.message });
+            delBtn.disabled = false;
+          }
+        });
+      });
+    }
+    wrap.appendChild(ghostSec("Topics", topics.length + " fichiers", null, list));
+
+    /* Facts en bas — la vraie fenêtre Kernel SQL, sous l'Index et les Topics. */
+    wrap.appendChild(factsSection);
+
+    const page = pageWrapper(
+      "memoire",
+      "La mémoire de Jarvis",
+      '<span class="v">' + facts.length + '</span> facts · <span class="v">' + topics.length + '</span> topics',
+      wrap
+    );
+    root.innerHTML = ""; root.appendChild(page);
+  }
+
+  /* ─────────────────────────────────────────
+     ROUTER
+  ───────────────────────────────────────── */
+  const RENDERERS = {
+    integrations: renderIntegrations,
+    skills:       renderSkills,
+    routines:     renderRoutines,
+    vues:         renderVues,
+    store:        renderStore,
+    ecosysteme:   renderEcosysteme,
+    appareils:    renderAppareils,
+    fils:         renderFils,
+    memoire:      renderMemoire,
+  };
+
+  function navigate(pageId) {
+    _activePage = pageId;
+    closePanel();
+    _killScenes();
+    const nav = document.getElementById("j-rooms-pages");
+    if (nav) {
+      const btns = Array.from(nav.querySelectorAll("button"));
+      const idx = PAGES.findIndex(p => p.id === pageId);
+      btns.forEach((b, i) => b.dataset.active = i === idx ? "true" : "false");
+    }
+    const fn = RENDERERS[pageId];
+    if (fn) { root.innerHTML = ""; fn(); }
+  }
+
+  /* ─────────────────────────────────────────
+     INIT
+  ───────────────────────────────────────── */
+  J.mountAtmosphere();
+
+  J.mountRooms({
+    mode: "capacites",
+    pages: PAGES,
+    activePage: _activePage,
+    onNav: (id) => navigate(id),
+  });
+
+  J.registerCommands(PAGES.map(p => ({
+    kind: "nav", id: "cap-" + p.id, group: "Atelier",
+    title: p.label, glyph: "→",
+    run: () => navigate(p.id),
+  })));
+
+  renderIntegrations();
+})();

--- a/src/jarvis/interfaces/ui/static/command.html
+++ b/src/jarvis/interfaces/ui/static/command.html
@@ -1168,5 +1168,16 @@ connectWS();
 })();
 </script>
 
+<style>
+.jmc-home-btn-standalone{position:fixed;bottom:24px;left:24px;z-index:9000;
+background:rgba(15,20,31,0.9);border:0.5px solid rgba(220,232,255,0.10);
+border-radius:8px;color:rgba(220,232,255,0.5);width:36px;height:36px;
+display:flex;align-items:center;justify-content:center;
+text-decoration:none;opacity:.55;transition:opacity .15s,border-color .15s,color .15s;}
+.jmc-home-btn-standalone:hover{opacity:1;border-color:#4A9EFF;color:#4A9EFF;}
+</style>
+<a href="/" class="jmc-home-btn-standalone" title="Retour Home">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12L12 3l9 9"/><path d="M9 21V12h6v9"/></svg>
+</a>
 </body>
 </html>

--- a/src/jarvis/interfaces/ui/static/command.html.bak-1782249020
+++ b/src/jarvis/interfaces/ui/static/command.html.bak-1782249020
@@ -1,0 +1,1172 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Command Center — JARVIS</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=DM+Sans:wght@400;500&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:          #06080D;
+      --blue:        #2D7DD2;
+      --blue-bright: #4A9EFF;
+      --gold:        #B8963E;
+      --text:        #DCE8FF;
+      --dim:         rgba(200, 218, 255, 0.55);
+      --text-dim:    rgba(74, 158, 255, 0.38);
+      --green:       #36D399;
+      --red:         #FF4444;
+      --orange:      #FFB547;
+      --purple:      #9B59B6;
+      --border:      rgba(74, 158, 255, 0.08);
+      --sep:         rgba(74, 158, 255, 0.05);
+    }
+
+    html, body { width: 100%; height: 100%; background: var(--bg); color: var(--text); font-family: 'DM Sans', sans-serif; font-size: 13px; overflow: hidden; }
+
+    /* film grain */
+    body::before {
+      content: ''; position: fixed; inset: 0; z-index: 0; pointer-events: none; opacity: 0.022;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+      background-size: 160px;
+    }
+
+    /* ══ SHELL ═══════════════════════════════════════════════════ */
+    #app { position: relative; z-index: 1; height: 100vh; display: flex; flex-direction: column; }
+
+    /* ══ TOPBAR ══════════════════════════════════════════════════ */
+    #topbar {
+      height: 48px; flex-shrink: 0;
+      display: flex; align-items: center; gap: 12px;
+      padding: 0 20px;
+      border-bottom: 1px solid var(--border);
+      background: rgba(6,8,13,0.95);
+      backdrop-filter: blur(14px);
+    }
+
+    .back-btn {
+      display: flex; align-items: center; gap: 5px;
+      padding: 4px 10px; border: 1px solid var(--border); border-radius: 5px;
+      background: transparent; cursor: pointer; color: var(--text-dim);
+      font: 500 10px/1 'DM Mono', monospace; letter-spacing: 0.08em;
+      transition: color 150ms, border-color 150ms;
+    }
+    .back-btn:hover { color: var(--text); border-color: rgba(74,158,255,0.22); }
+
+    .topbar-title {
+      font: 700 13px/1 'Space Grotesk', sans-serif;
+      letter-spacing: 0.22em; text-transform: uppercase;
+      color: rgba(200,218,255,0.65);
+    }
+
+    .topbar-spacer { flex: 1; }
+
+    #last-analyzed {
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--text-dim); letter-spacing: 0.05em;
+    }
+
+    .analyze-btn {
+      display: flex; align-items: center; gap: 5px;
+      padding: 5px 12px; border: 1px solid var(--border); border-radius: 5px;
+      background: transparent; cursor: pointer; color: var(--text-dim);
+      font: 500 10px/1 'DM Mono', monospace; letter-spacing: 0.08em;
+      transition: color 150ms, border-color 150ms;
+    }
+    .analyze-btn:hover { color: var(--text); border-color: rgba(74,158,255,0.25); }
+    .analyze-btn.spinning .ai { animation: spin 0.7s linear infinite; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ══ MAIN ════════════════════════════════════════════════════ */
+    #main-area { flex: 1; min-height: 0; display: flex; }
+
+    /* ══ SIDEBAR ═════════════════════════════════════════════════ */
+    #sidebar {
+      width: 200px; flex-shrink: 0;
+      border-right: 1px solid var(--border);
+      display: flex; flex-direction: column;
+      overflow: hidden;
+    }
+
+    .sb-section { padding: 14px 16px 8px; }
+
+    .sb-label {
+      font: 500 8.5px/1 'DM Mono', monospace; letter-spacing: 0.16em; text-transform: uppercase;
+      color: var(--text-dim); margin-bottom: 10px;
+    }
+
+    .cat-list { display: flex; flex-direction: column; gap: 1px; }
+
+    .cat-item {
+      display: flex; align-items: center; gap: 8px;
+      padding: 6px 8px; border-radius: 4px; cursor: pointer;
+      transition: background 150ms;
+    }
+    .cat-item:hover { background: rgba(74,158,255,0.05); }
+    .cat-item.active { background: rgba(74,158,255,0.08); }
+
+    .cat-active-pip {
+      width: 4px; height: 4px; border-radius: 50%;
+      background: var(--blue-bright); opacity: 0; flex-shrink: 0;
+    }
+    .cat-item.active .cat-active-pip { opacity: 1; }
+
+    .cat-ico { font-size: 11px; width: 16px; text-align: center; flex-shrink: 0; }
+
+    .cat-name {
+      flex: 1; font: 500 10px/1 'DM Mono', monospace; letter-spacing: 0.08em;
+      color: var(--text-dim); transition: color 150ms;
+    }
+    .cat-item:hover .cat-name, .cat-item.active .cat-name { color: var(--text); }
+
+    .cat-count {
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--blue-bright); min-width: 16px; text-align: right;
+    }
+
+    .sb-sep { height: 1px; background: var(--sep); margin: 5px 16px; }
+
+    .sb-bottom {
+      margin-top: auto; border-top: 1px solid var(--sep);
+      padding: 10px 16px 14px;
+    }
+
+    .src-item {
+      display: flex; align-items: center; gap: 7px;
+      padding: 3px 8px;
+      font: 400 9px/1 'DM Mono', monospace; letter-spacing: 0.06em;
+      color: var(--text-dim);
+    }
+    .src-dot { width: 4px; height: 4px; border-radius: 50%; background: var(--green); flex-shrink: 0; }
+    .src-dot.error { background: var(--red); }
+
+    /* ══ INITIATIVE LIST ══════════════════════════════════════════ */
+    #main-list {
+      flex: 1; min-width: 0; overflow-y: auto; overflow-x: hidden;
+      scrollbar-width: thin; scrollbar-color: rgba(74,158,255,0.10) transparent;
+    }
+    #main-list::-webkit-scrollbar { width: 2px; }
+    #main-list::-webkit-scrollbar-thumb { background: rgba(74,158,255,0.14); border-radius: 2px; }
+
+    .group-sep {
+      display: flex; align-items: center; gap: 10px;
+      padding: 12px 20px 6px; flex-shrink: 0;
+    }
+    .group-sep-label {
+      font: 500 8.5px/1 'DM Mono', monospace; letter-spacing: 0.16em; text-transform: uppercase;
+      color: var(--text-dim); white-space: nowrap;
+    }
+    .group-sep-line { flex: 1; height: 1px; background: var(--sep); }
+
+    /* Row */
+    .init-row { border-bottom: 1px solid var(--sep); }
+
+    .init-header {
+      display: flex; align-items: center; gap: 10px;
+      padding: 14px 20px; min-height: 48px; cursor: pointer;
+      transition: background 120ms;
+    }
+    .init-header:hover { background: rgba(74,158,255,0.025); }
+
+    .p-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+    .p-dot.high   { background: var(--red); }
+    .p-dot.medium { background: var(--orange); }
+    .p-dot.low    { background: var(--text-dim); }
+
+    .init-cat {
+      font: 500 9px/1 'DM Mono', monospace; letter-spacing: 0.12em;
+      width: 60px; flex-shrink: 0;
+      color: var(--text-dim);
+    }
+
+    .init-title {
+      flex: 1; min-width: 0;
+      font: 500 12.5px/1.3 'DM Sans', sans-serif; color: var(--text);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+
+    .status-badge {
+      font: 500 8px/1 'DM Mono', monospace; letter-spacing: 0.10em;
+      padding: 2px 6px; border-radius: 3px; flex-shrink: 0;
+    }
+    .status-badge.done     { background: rgba(54,211,153,0.10); color: var(--green); }
+    .status-badge.failed   { background: rgba(255,68,68,0.10); color: var(--red); }
+    .status-badge.dismissed{ background: rgba(74,158,255,0.06); color: var(--text-dim); }
+    .status-badge.in_progress { background: rgba(255,181,71,0.10); color: var(--orange); }
+    .status-badge.awaiting_confirm { background: rgba(155,89,182,0.12); color: var(--purple); }
+
+    .expand-arr {
+      font: 400 14px/1 'DM Mono', monospace; color: var(--text-dim);
+      flex-shrink: 0; transition: transform 200ms, color 150ms;
+    }
+    .init-row.expanded .expand-arr { transform: rotate(90deg); color: var(--blue-bright); }
+
+    /* Dimmed when filter active */
+    .init-row.dimmed .init-title,
+    .init-row.dimmed .init-cat,
+    .init-row.dimmed .p-dot,
+    .init-row.dimmed .p-badge { opacity: 0.22; }
+
+    /* Detail */
+    .init-detail { overflow: hidden; height: 0; opacity: 0; }
+
+    .init-inner { padding: 2px 20px 16px 36px; }
+
+    .d-section { margin-bottom: 12px; }
+    .d-label {
+      font: 500 8px/1 'DM Mono', monospace; letter-spacing: 0.22em; text-transform: uppercase;
+      color: var(--text-dim); margin-bottom: 5px;
+    }
+    .d-body { font: 400 12.5px/1.62 'DM Sans', sans-serif; color: var(--dim); }
+    .d-body.action { color: var(--text); font-weight: 500; }
+
+    /* Draft */
+    .draft-toggle {
+      display: inline-flex; align-items: center; gap: 4px; margin-top: 6px;
+      font: 500 9px/1 'DM Mono', monospace; letter-spacing: 0.08em; color: var(--blue-bright);
+      cursor: pointer; background: none; border: none; padding: 0;
+      transition: opacity 150ms;
+    }
+    .draft-toggle:hover { opacity: 0.7; }
+    .draft-toggle .arr { display: inline-block; transition: transform 150ms; }
+    .draft-toggle.open .arr { transform: rotate(90deg); }
+
+    .draft-block {
+      display: none; margin-top: 8px; padding: 10px 12px;
+      background: rgba(74,158,255,0.04); border: 1px solid rgba(74,158,255,0.10); border-radius: 6px;
+      font: 400 11px/1.65 'DM Mono', monospace; color: rgba(200,218,255,0.68);
+      white-space: pre-wrap; word-break: break-word;
+    }
+    .draft-block.open { display: block; }
+
+    .edit-draft-btn {
+      display: none; margin-top: 5px; align-items: center; gap: 4px;
+      font: 500 9px/1 'DM Mono', monospace; letter-spacing: 0.08em; color: var(--text-dim);
+      cursor: pointer; background: none; border: 1px solid var(--border); border-radius: 4px; padding: 3px 8px;
+      transition: color 150ms, border-color 150ms;
+    }
+    .edit-draft-btn:hover { color: var(--text); border-color: rgba(74,158,255,0.20); }
+
+    .draft-ta {
+      display: none; width: 100%; margin-top: 8px; padding: 10px 12px;
+      background: rgba(74,158,255,0.04); border: 1px solid rgba(74,158,255,0.15); border-radius: 6px;
+      font: 400 11px/1.65 'DM Mono', monospace; color: rgba(200,218,255,0.85);
+      resize: vertical; min-height: 90px; outline: none;
+      transition: border-color 150ms;
+    }
+    .draft-ta.open { display: block; }
+    .draft-ta:focus { border-color: rgba(74,158,255,0.30); }
+
+    /* Rectify */
+    .rectify-zone {
+      display: none; margin-top: 10px; padding: 10px 12px;
+      background: rgba(251,191,36,0.03); border: 1px solid rgba(251,191,36,0.12); border-radius: 6px;
+    }
+    .rectify-zone.open { display: block; }
+
+    .rectify-prompt {
+      font: 500 9px/1 'DM Mono', monospace; letter-spacing: 0.12em; text-transform: uppercase;
+      color: rgba(251,191,36,0.45); margin-bottom: 7px;
+    }
+
+    .rectify-input {
+      width: 100%; padding: 8px 10px;
+      background: rgba(0,0,0,0.28); border: 1px solid rgba(255,255,255,0.08); border-radius: 5px;
+      color: var(--text); font: 400 12px/1.5 'DM Mono', monospace;
+      resize: none; min-height: 56px; outline: none; transition: border-color 150ms;
+    }
+    .rectify-input:focus { border-color: rgba(251,191,36,0.25); }
+
+    .rectify-footer {
+      display: flex; justify-content: flex-end; gap: 6px; margin-top: 7px;
+    }
+
+    /* Result banner */
+    .result-banner {
+      display: none; margin-top: 10px; padding: 8px 12px;
+      border-radius: 6px; font: 400 11px/1.5 'DM Mono', monospace;
+    }
+    .result-banner.show { display: block; }
+    .result-banner.ok  { background: rgba(54,211,153,0.06); border: 1px solid rgba(54,211,153,0.18); color: var(--green); }
+    .result-banner.err { background: rgba(255,68,68,0.06); border: 1px solid rgba(255,68,68,0.18); color: var(--red); }
+    .result-banner.warn{ background: rgba(155,89,182,0.06); border: 1px solid rgba(155,89,182,0.18); color: var(--purple); }
+
+    /* Row action buttons */
+    .row-actions { display: flex; gap: 6px; margin-top: 12px; flex-wrap: wrap; }
+
+    .rbtn {
+      padding: 6px 12px; border: 1px solid var(--border); border-radius: 5px;
+      background: transparent; cursor: pointer;
+      font: 500 9.5px/1 'DM Mono', monospace; letter-spacing: 0.06em;
+      transition: color 150ms, border-color 150ms, background 150ms;
+    }
+    .rbtn:disabled { opacity: 0.4; cursor: default; pointer-events: none; }
+    .rbtn-sm { padding: 4px 9px; font-size: 9px; }
+
+    .rbtn-ignore  { color: rgba(255,68,68,0.5); }
+    .rbtn-ignore:hover { color: var(--red); border-color: rgba(255,68,68,0.30); background: rgba(255,68,68,0.04); }
+
+    .rbtn-rectify { color: rgba(251,191,36,0.5); }
+    .rbtn-rectify:hover, .rbtn-rectify.active { color: #FBBF24; border-color: rgba(251,191,36,0.28); background: rgba(251,191,36,0.04); }
+
+    .rbtn-validate { color: rgba(54,211,153,0.6); }
+    .rbtn-validate:hover { color: var(--green); border-color: rgba(54,211,153,0.32); background: rgba(54,211,153,0.04); }
+
+    .rbtn-run { color: rgba(74,158,255,0.7); }
+    .rbtn-run:hover { color: var(--blue-bright); border-color: rgba(74,158,255,0.35); background: rgba(74,158,255,0.05); }
+
+    .rbtn-confirm { color: rgba(155,89,182,0.7); }
+    .rbtn-confirm:hover { color: var(--purple); border-color: rgba(155,89,182,0.35); background: rgba(155,89,182,0.05); }
+
+    .rbtn-cancel { color: var(--text-dim); }
+    .rbtn-cancel:hover { color: var(--text); border-color: rgba(74,158,255,0.20); }
+
+    /* Spinner */
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .spinner {
+      display: inline-block; width: 10px; height: 10px;
+      border: 1.5px solid rgba(54,211,153,0.22); border-top-color: var(--green);
+      border-radius: 50%; animation: spin 0.6s linear infinite;
+      vertical-align: middle;
+    }
+
+    /* Empty */
+    #empty-state {
+      display: none; flex-direction: column; align-items: center; justify-content: center;
+      gap: 10px; padding: 80px 20px;
+      font: 400 11px/1 'DM Mono', monospace; letter-spacing: 0.12em; text-transform: uppercase;
+      color: var(--text-dim);
+    }
+    #empty-state.show { display: flex; }
+    #empty-state .e-ico { font-size: 22px; opacity: 0.25; margin-bottom: 4px; }
+
+    /* ══ HISTORY SECTION ═════════════════════════════════════════ */
+    #history-section { padding: 0 0 20px; }
+
+    .history-row {
+      display: flex; align-items: center; gap: 10px;
+      padding: 8px 20px; border-bottom: 1px solid var(--sep);
+      opacity: 0.55;
+    }
+    .history-row:hover { opacity: 0.78; }
+
+    .h-title {
+      flex: 1; min-width: 0;
+      font: 400 12px/1 'DM Sans', sans-serif; color: var(--dim);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .h-cat {
+      font: 500 8px/1 'DM Mono', monospace; letter-spacing: 0.10em;
+      color: var(--text-dim); width: 56px; flex-shrink: 0;
+    }
+    .h-date {
+      font: 400 9px/1 'DM Mono', monospace;
+      color: var(--text-dim); flex-shrink: 0;
+    }
+
+    /* ══ FOOTER ══════════════════════════════════════════════════ */
+    #footer {
+      height: 44px; flex-shrink: 0;
+      border-top: 1px solid var(--border);
+      display: flex; align-items: center; padding: 0 20px; gap: 14px;
+      background: rgba(6,8,13,0.94);
+    }
+
+    .footer-section { display: flex; align-items: center; gap: 7px; }
+    .footer-lbl {
+      font: 500 8px/1 'DM Mono', monospace; letter-spacing: 0.14em; text-transform: uppercase;
+      color: var(--text-dim); white-space: nowrap;
+    }
+    #footer-agenda {
+      font: 400 10px/1 'DM Mono', monospace; color: rgba(200,218,255,0.38);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 320px;
+    }
+
+    .footer-stats {
+      margin-left: auto; display: flex; align-items: center; gap: 12px; flex-shrink: 0;
+      font: 400 10px/1 'DM Mono', monospace; color: rgba(200,218,255,0.30);
+    }
+    .f-stat { white-space: nowrap; }
+
+    /* ══ OVERLAY ══════════════════════════════════════════════════ */
+    #transition-overlay {
+      position: fixed; inset: 0; z-index: 9999;
+      pointer-events: none; opacity: 1; background: #000;
+    }
+  </style>
+</head>
+<body>
+
+<div id="transition-overlay"></div>
+
+<div id="app">
+
+  <!-- ── TOPBAR ──────────────────────────────────────────────── -->
+  <div id="topbar">
+    <button class="back-btn" onclick="transitionTo('/')">
+      <svg width="8" height="8" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><path d="M8 2L4 6l4 4"/></svg>
+      retour
+    </button>
+    <div class="topbar-title">Command Center</div>
+    <div class="topbar-spacer"></div>
+    <span id="last-analyzed"></span>
+    <button class="analyze-btn" id="analyze-btn" onclick="runNow()">
+      <svg class="ai" width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6">
+        <path d="M14 8A6 6 0 1 1 8 2"/><path d="M12 2l2 2-2 2" stroke-linecap="round"/>
+      </svg>
+      analyser
+    </button>
+  </div>
+
+  <!-- ── MAIN ───────────────────────────────────────────────── -->
+  <div id="main-area">
+
+    <!-- SIDEBAR -->
+    <div id="sidebar">
+      <div class="sb-section">
+        <div class="sb-label">Catégories</div>
+        <div class="cat-list">
+          <div class="cat-item active" data-cat="all" onclick="setFilter('all')">
+            <div class="cat-active-pip"></div>
+            <span class="cat-ico">●</span>
+            <span class="cat-name">Tous</span>
+            <span class="cat-count" id="cnt-all">—</span>
+          </div>
+          <div class="sb-sep" style="margin:4px 0"></div>
+          <div class="cat-item" data-cat="email" onclick="setFilter('email')">
+            <div class="cat-active-pip"></div>
+            <span class="cat-ico">📧</span>
+            <span class="cat-name">Emails</span>
+            <span class="cat-count" id="cnt-email">—</span>
+          </div>
+          <div class="cat-item" data-cat="agenda" onclick="setFilter('agenda')">
+            <div class="cat-active-pip"></div>
+            <span class="cat-ico">📅</span>
+            <span class="cat-name">Agenda</span>
+            <span class="cat-count" id="cnt-agenda">—</span>
+          </div>
+          <div class="cat-item" data-cat="taches" onclick="setFilter('taches')">
+            <div class="cat-active-pip"></div>
+            <span class="cat-ico">✓</span>
+            <span class="cat-name">Tâches</span>
+            <span class="cat-count" id="cnt-taches">—</span>
+          </div>
+          <div class="cat-item" data-cat="missions" onclick="setFilter('missions')">
+            <div class="cat-active-pip"></div>
+            <span class="cat-ico">⚙</span>
+            <span class="cat-name">Missions</span>
+            <span class="cat-count" id="cnt-missions">—</span>
+          </div>
+          <div class="cat-item" data-cat="insights" onclick="setFilter('insights')">
+            <div class="cat-active-pip"></div>
+            <span class="cat-ico">💡</span>
+            <span class="cat-name">Insights</span>
+            <span class="cat-count" id="cnt-insights">—</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="sb-bottom">
+        <div class="sb-label" style="margin-bottom:8px">Sources</div>
+        <div class="src-item"><div class="src-dot" id="src-gmail"></div>Gmail</div>
+        <div class="src-item"><div class="src-dot" id="src-calendar"></div>Calendar</div>
+        <div class="src-item"><div class="src-dot" id="src-notion"></div>Notion</div>
+        <div class="src-item"><div class="src-dot" id="src-jarvis"></div>Jarvis</div>
+      </div>
+    </div>
+
+    <!-- LIST -->
+    <div id="main-list">
+      <div id="empty-state">
+        <div class="e-ico">✓</div>
+        <div>Aucune initiative en attente</div>
+      </div>
+      <div id="history-section"></div>
+    </div>
+
+  </div>
+
+  <!-- ── FOOTER ──────────────────────────────────────────────── -->
+  <div id="footer">
+    <div class="footer-section">
+      <span class="footer-lbl">Agenda 48h</span>
+      <span id="footer-agenda">—</span>
+    </div>
+    <div class="footer-stats">
+      <span class="f-stat" id="fstat-emails">📧 —</span>
+      <span class="f-stat" id="fstat-tasks">✓ —</span>
+      <span class="f-stat" id="fstat-missions">⚙ —</span>
+    </div>
+  </div>
+
+</div><!-- #app -->
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js"></script>
+
+<script>
+// ── Config ────────────────────────────────────────────────────
+
+const TYPE_CAT = {
+  draft_response: 'email',
+  reminder:       'agenda',
+  suggestion:     'taches',
+  alert:          'insights',
+  auto_task:      'missions',
+  info:           'insights',
+};
+
+const TYPE_LABEL = {
+  draft_response: 'EMAIL',
+  reminder:       'AGENDA',
+  suggestion:     'TÂCHES',
+  alert:          'ALERTE',
+  auto_task:      'MISSION',
+  info:           'INFO',
+};
+
+// Libellé du bouton d'action principal par type
+const TYPE_RUN_LABEL = {
+  draft_response: '✉ Préparer brouillon',
+  auto_task:      '⚙ Lancer la mission',
+  reminder:       '✓ Marquer traité',
+  suggestion:     '✓ Marquer traité',
+  alert:          '✓ Traité',
+  info:           '✓ Traité',
+};
+
+const PRIORITY_ORDER = { high: 0, medium: 1, low: 2 };
+
+const GROUP_LABELS = {
+  high:   'Haute priorité',
+  medium: 'Moyenne priorité',
+  low:    'Informations',
+};
+
+const HISTORY_STATUS_DONE = new Set(['done', 'approved', 'rejected', 'dismissed', 'failed']);
+
+// ── State ─────────────────────────────────────────────────────
+
+let initiatives = [];   // pending uniquement
+let historyItems = [];  // done/dismissed/rejected
+let activeFilter = 'all';
+let expandedId   = null;
+
+// ── Utils ─────────────────────────────────────────────────────
+
+function esc(s) {
+  return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function getCat(init) { return TYPE_CAT[init.type] || 'insights'; }
+
+function fmtDate(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  const now = new Date();
+  const diff = Math.round((now - d) / 60000);
+  if (diff < 60) return `${diff}min`;
+  if (diff < 1440) return `${Math.round(diff/60)}h`;
+  return `${Math.round(diff/1440)}j`;
+}
+
+// ── Render ────────────────────────────────────────────────────
+
+function renderList() {
+  const container = document.getElementById('main-list');
+  const empty     = document.getElementById('empty-state');
+
+  container.querySelectorAll('.init-row, .group-sep').forEach(el => el.remove());
+
+  if (!initiatives.length) { empty.classList.add('show'); updateCounts(); renderHistory(); return; }
+  empty.classList.remove('show');
+
+  const sorted = [...initiatives].sort((a,b) =>
+    (PRIORITY_ORDER[a.priority] ?? 9) - (PRIORITY_ORDER[b.priority] ?? 9)
+  );
+
+  const groups = { high: [], medium: [], low: [] };
+  sorted.forEach(i => {
+    const p = i.priority || 'low';
+    (groups[p] || groups.low).push(i);
+  });
+
+  const filterCat = activeFilter === 'all' ? null : activeFilter;
+  const histEl    = document.getElementById('history-section');
+
+  ['high','medium','low'].forEach(prio => {
+    const grp = groups[prio];
+    if (!grp.length) return;
+
+    const sep = document.createElement('div');
+    sep.className = 'group-sep';
+    sep.innerHTML = `<span class="group-sep-label">${GROUP_LABELS[prio]}</span><div class="group-sep-line"></div>`;
+    container.insertBefore(sep, histEl);
+
+    grp.forEach(init => container.insertBefore(buildRow(init, filterCat), histEl));
+  });
+
+  renderHistory();
+  updateCounts();
+}
+
+function buildRow(init, filterCat) {
+  const cat    = getCat(init);
+  const label  = TYPE_LABEL[init.type] || init.type.toUpperCase();
+  const dimmed = filterCat && cat !== filterCat;
+
+  const row = document.createElement('div');
+  row.className = `init-row${dimmed ? ' dimmed' : ''}`;
+  row.id        = `row-${init.id}`;
+  row.dataset.cat = cat;
+
+  const hasDraft    = Boolean(init.draft_content);
+  const runLabel    = TYPE_RUN_LABEL[init.type] || '▶ Lancer';
+  const isAwaiting  = init.status === 'awaiting_confirm';
+
+  row.innerHTML = `
+    <div class="init-header" onclick="toggleRow('${init.id}')">
+      <div class="p-dot ${init.priority}"></div>
+      <div class="init-cat">${esc(label)}</div>
+      <div class="init-title">${esc(init.title)}</div>
+      ${isAwaiting ? '<span class="status-badge awaiting_confirm">CONFIRM. REQUISE</span>' : ''}
+      <div class="expand-arr">›</div>
+    </div>
+    <div class="init-detail" id="detail-${init.id}">
+      <div class="init-inner">
+
+        ${init.context ? `
+        <div class="d-section">
+          <div class="d-label">Contexte</div>
+          <div class="d-body">${esc(init.context)}</div>
+        </div>` : ''}
+
+        ${init.reasoning ? `
+        <div class="d-section">
+          <div class="d-label">Raisonnement Jarvis</div>
+          <div class="d-body">${esc(init.reasoning)}</div>
+        </div>` : ''}
+
+        <div class="d-section">
+          <div class="d-label">Action proposée</div>
+          <div class="d-body action">${esc(init.action)}</div>
+          ${hasDraft ? `
+            <button class="draft-toggle" id="dtog-${init.id}" onclick="toggleDraft('${init.id}')">
+              <span class="arr">›</span>&nbsp;Voir brouillon
+            </button>
+            <pre class="draft-block" id="dblock-${init.id}">${esc(init.draft_content)}</pre>
+            <button class="edit-draft-btn" id="dedit-${init.id}" onclick="editDraft('${init.id}')">✎ Modifier</button>
+            <textarea class="draft-ta" id="dta-${init.id}">${esc(init.draft_content)}</textarea>
+          ` : ''}
+        </div>
+
+        <div class="result-banner" id="rbanner-${init.id}"></div>
+
+        <div class="rectify-zone" id="rzone-${init.id}">
+          <div class="rectify-prompt">Qu'est-ce qui cloche ?</div>
+          <textarea class="rectify-input" id="rinput-${init.id}" placeholder="Décris ce que tu veux changer…" rows="2"></textarea>
+          <div class="rectify-footer">
+            <button class="rbtn rbtn-sm rbtn-cancel" onclick="closeRectify('${init.id}')">Annuler</button>
+            <button class="rbtn rbtn-sm rbtn-validate" id="rsend-${init.id}" onclick="submitRectify('${init.id}')">Regénérer →</button>
+          </div>
+        </div>
+
+        <div class="row-actions" id="actions-${init.id}">
+          ${_buildActionBtns(init)}
+        </div>
+
+      </div>
+    </div>
+  `;
+
+  return row;
+}
+
+function _buildActionBtns(init) {
+  const id = init.id;
+  const isAwaiting = init.status === 'awaiting_confirm';
+
+  const dismissBtn  = `<button class="rbtn rbtn-ignore"  onclick="doDismiss('${id}')">✗ Ignorer</button>`;
+  const rectifyBtn  = `<button class="rbtn rbtn-rectify" id="rrect-${id}" onclick="toggleRectify('${id}')">⟳ Rectifier</button>`;
+
+  if (isAwaiting) {
+    // Étape 2 : brouillon prêt, attente confirmation envoi
+    return `
+      ${dismissBtn}
+      <button class="rbtn rbtn-confirm" id="rconfirm-${id}" onclick="doConfirm('${id}')">📤 Confirmer l'envoi</button>
+    `;
+  }
+
+  const runLabel = TYPE_RUN_LABEL[init.type] || '▶ Lancer';
+  return `
+    ${dismissBtn}
+    ${['pending', 'draft_response', 'auto_task', 'reminder', 'suggestion', 'alert', 'info'].includes(init.status || 'pending') ? rectifyBtn : ''}
+    <button class="rbtn rbtn-run" id="rrun-${id}" onclick="doRun('${id}')">${runLabel}</button>
+  `;
+}
+
+// ── History ───────────────────────────────────────────────────
+
+function renderHistory() {
+  const section = document.getElementById('history-section');
+  section.innerHTML = '';
+
+  if (!historyItems.length) return;
+
+  const sep = document.createElement('div');
+  sep.className = 'group-sep';
+  sep.innerHTML = `<span class="group-sep-label">Historique récent</span><div class="group-sep-line"></div>`;
+  section.appendChild(sep);
+
+  const filterCat = activeFilter === 'all' ? null : activeFilter;
+  const shown = filterCat
+    ? historyItems.filter(i => getCat(i) === filterCat)
+    : historyItems;
+
+  shown.slice(0, 20).forEach(init => {
+    const row = document.createElement('div');
+    row.className = 'history-row';
+    const label = TYPE_LABEL[init.type] || init.type.toUpperCase();
+    const statusCls = init.status || 'done';
+    row.innerHTML = `
+      <div class="p-dot ${init.priority || 'low'}"></div>
+      <div class="h-cat">${esc(label)}</div>
+      <div class="h-title">${esc(init.title)}</div>
+      <span class="status-badge ${statusCls}">${esc(init.status || 'done').toUpperCase()}</span>
+      <div class="h-date">${fmtDate(init.created_at)}</div>
+    `;
+    section.appendChild(row);
+  });
+}
+
+// ── Filter ────────────────────────────────────────────────────
+
+function setFilter(cat) {
+  activeFilter = (activeFilter === cat) ? 'all' : cat;
+
+  document.querySelectorAll('.cat-item').forEach(el => {
+    el.classList.toggle('active', el.dataset.cat === activeFilter);
+  });
+
+  const filterCat = activeFilter === 'all' ? null : activeFilter;
+  document.querySelectorAll('.init-row').forEach(row => {
+    row.classList.toggle('dimmed', Boolean(filterCat) && row.dataset.cat !== filterCat);
+  });
+
+  renderHistory();
+}
+
+// ── Counts ────────────────────────────────────────────────────
+
+function updateCounts() {
+  const c = { all: 0, email: 0, agenda: 0, taches: 0, missions: 0, insights: 0 };
+  initiatives.forEach(i => { const cat = getCat(i); c.all++; if (c[cat] !== undefined) c[cat]++; });
+
+  Object.entries(c).forEach(([k,v]) => {
+    const el = document.getElementById(`cnt-${k}`);
+    if (el) el.textContent = v || '—';
+  });
+
+  document.getElementById('fstat-emails').textContent   = `📧 ${c.email} email${c.email !== 1 ? 's' : ''}`;
+  document.getElementById('fstat-missions').textContent = `⚙ ${c.missions} mission${c.missions !== 1 ? 's' : ''}`;
+}
+
+// ── Expand / collapse ─────────────────────────────────────────
+
+function toggleRow(id) {
+  const detail = document.getElementById(`detail-${id}`);
+  const row    = document.getElementById(`row-${id}`);
+  if (!detail || !row) return;
+
+  if (expandedId === id) {
+    gsap.to(detail, { duration: 0.18, height: 0, opacity: 0, ease: 'power2.in' });
+    row.classList.remove('expanded');
+    expandedId = null;
+  } else {
+    if (expandedId) {
+      const pd = document.getElementById(`detail-${expandedId}`);
+      const pr = document.getElementById(`row-${expandedId}`);
+      if (pd) gsap.to(pd, { duration: 0.14, height: 0, opacity: 0, ease: 'power2.in' });
+      if (pr) pr.classList.remove('expanded');
+    }
+
+    expandedId = id;
+    row.classList.add('expanded');
+
+    gsap.fromTo(detail,
+      { height: 0, opacity: 0 },
+      { duration: 0.25, height: 'auto', opacity: 1, ease: 'power2.out' }
+    );
+
+    setTimeout(() => row.scrollIntoView({ behavior: 'smooth', block: 'nearest' }), 150);
+  }
+}
+
+function _remeasure(id) {
+  if (expandedId !== id) return;
+  const detail = document.getElementById(`detail-${id}`);
+  if (!detail) return;
+  gsap.killTweensOf(detail, 'height');
+  gsap.to(detail, { duration: 0.12, height: 'auto', ease: 'none' });
+}
+
+// ── Draft ─────────────────────────────────────────────────────
+
+function toggleDraft(id) {
+  const tog   = document.getElementById(`dtog-${id}`);
+  const block = document.getElementById(`dblock-${id}`);
+  const edit  = document.getElementById(`dedit-${id}`);
+  if (!block) return;
+  const open = block.classList.toggle('open');
+  tog?.classList.toggle('open', open);
+  if (edit) edit.style.display = open ? 'inline-flex' : 'none';
+  setTimeout(() => _remeasure(id), 20);
+}
+
+function editDraft(id) {
+  const block = document.getElementById(`dblock-${id}`);
+  const ta    = document.getElementById(`dta-${id}`);
+  if (!block || !ta) return;
+  block.style.display = 'none';
+  ta.classList.add('open');
+  ta.focus();
+  setTimeout(() => _remeasure(id), 20);
+}
+
+// ── Rectify ───────────────────────────────────────────────────
+
+function toggleRectify(id) {
+  const zone = document.getElementById(`rzone-${id}`);
+  const btn  = document.getElementById(`rrect-${id}`);
+  if (!zone) return;
+  const open = zone.classList.toggle('open');
+  btn?.classList.toggle('active', open);
+  if (open) document.getElementById(`rinput-${id}`)?.focus();
+  setTimeout(() => _remeasure(id), 20);
+}
+
+function closeRectify(id) {
+  document.getElementById(`rzone-${id}`)?.classList.remove('open');
+  document.getElementById(`rrect-${id}`)?.classList.remove('active');
+  setTimeout(() => _remeasure(id), 20);
+}
+
+async function submitRectify(id) {
+  const input   = document.getElementById(`rinput-${id}`);
+  const sendBtn = document.getElementById(`rsend-${id}`);
+  const correction = input?.value?.trim();
+  if (!correction) return;
+
+  sendBtn.disabled = true;
+  sendBtn.innerHTML = '<span class="spinner"></span>';
+
+  try {
+    const r = await fetch(`/api/initiatives/${id}/rectify`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ correction }),
+    });
+    if (!r.ok) throw new Error(await r.text());
+    const updated = await r.json();
+
+    const idx = initiatives.findIndex(i => i.id === id);
+    if (idx >= 0) Object.assign(initiatives[idx], updated);
+
+    const row = document.getElementById(`row-${id}`);
+    if (row) {
+      gsap.to(row, {
+        duration: 0.18, opacity: 0, x: 8, ease: 'power2.in',
+        onComplete: () => {
+          expandedId = null;
+          renderList();
+          setTimeout(() => toggleRow(id), 60);
+        }
+      });
+    }
+  } catch {
+    sendBtn.disabled = false;
+    sendBtn.textContent = 'Erreur — réessayer';
+  }
+}
+
+// ── Actions ───────────────────────────────────────────────────
+
+function _removeRow(id, dir) {
+  const row = document.getElementById(`row-${id}`);
+  if (!row) return;
+  if (expandedId === id) expandedId = null;
+
+  gsap.to(row, {
+    duration: 0.2, x: dir === 'left' ? -28 : 28, opacity: 0, ease: 'power2.in',
+    onComplete: () => {
+      row.remove();
+      initiatives = initiatives.filter(i => i.id !== id);
+      updateCounts();
+      if (!initiatives.length) document.getElementById('empty-state').classList.add('show');
+    }
+  });
+}
+
+function _showBanner(id, cls, msg) {
+  const el = document.getElementById(`rbanner-${id}`);
+  if (!el) return;
+  el.className = `result-banner show ${cls}`;
+  el.textContent = msg;
+  setTimeout(() => _remeasure(id), 20);
+}
+
+function doDismiss(id) {
+  fetch(`/api/proactive/initiatives/${id}/dismiss`, { method: 'POST' }).catch(() => {});
+  _removeRow(id, 'left');
+}
+
+// Bouton principal : run step 1
+async function doRun(id) {
+  const btn = document.getElementById(`rrun-${id}`);
+  if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spinner"></span>'; }
+
+  try {
+    const r = await fetch(`/api/proactive/initiatives/${id}/run`, { method: 'POST' });
+    const data = await r.json();
+
+    if (data.status === 'draft_ready') {
+      // Mettre à jour l'initiative locale
+      const idx = initiatives.findIndex(i => i.id === id);
+      if (idx >= 0) {
+        initiatives[idx].status = 'awaiting_confirm';
+        initiatives[idx].draft_content = data.draft;
+      }
+      // Remplacer les boutons
+      const actionsEl = document.getElementById(`actions-${id}`);
+      if (actionsEl) {
+        actionsEl.innerHTML = `
+          <button class="rbtn rbtn-ignore" onclick="doDismiss('${id}')">✗ Ignorer</button>
+          <button class="rbtn rbtn-confirm" id="rconfirm-${id}" onclick="doConfirm('${id}')">📤 Confirmer l'envoi</button>
+        `;
+      }
+      // Afficher le brouillon
+      const dblock = document.getElementById(`dblock-${id}`);
+      if (dblock) { dblock.textContent = data.draft; dblock.classList.add('open'); }
+      const dtog = document.getElementById(`dtog-${id}`);
+      if (dtog) dtog.classList.add('open');
+      const dedit = document.getElementById(`dedit-${id}`);
+      if (dedit) dedit.style.display = 'inline-flex';
+      const dta = document.getElementById(`dta-${id}`);
+      if (dta) dta.value = data.draft;
+      // Badge sur le header
+      const header = document.querySelector(`#row-${id} .init-header`);
+      const existing = header?.querySelector('.status-badge');
+      if (header && !existing) {
+        const badge = document.createElement('span');
+        badge.className = 'status-badge awaiting_confirm';
+        badge.textContent = 'CONFIRM. REQUISE';
+        header.insertBefore(badge, header.querySelector('.expand-arr'));
+      }
+      _showBanner(id, 'warn', 'Brouillon prêt — relisez puis confirmez l\'envoi.');
+      setTimeout(() => _remeasure(id), 40);
+
+    } else if (data.status === 'mission_launched') {
+      _showBanner(id, 'ok', `Mission lancée — projet ${data.project_id || ''} (${data.steps || 0} étapes)`);
+      setTimeout(() => _removeRow(id, 'right'), 2200);
+
+    } else if (data.status === 'handled') {
+      _removeRow(id, 'right');
+
+    } else if (data.status === 'budget_exceeded') {
+      _showBanner(id, 'err', 'Budget insuffisant pour lancer cette mission.');
+      if (btn) { btn.disabled = false; btn.textContent = '⚙ Lancer la mission'; }
+
+    } else if (data.error) {
+      _showBanner(id, 'err', `Erreur : ${data.error}`);
+      if (btn) { btn.disabled = false; btn.textContent = TYPE_RUN_LABEL[initiatives.find(i=>i.id===id)?.type] || '▶ Lancer'; }
+
+    } else {
+      if (btn) { btn.disabled = false; btn.textContent = TYPE_RUN_LABEL[initiatives.find(i=>i.id===id)?.type] || '▶ Lancer'; }
+    }
+  } catch (e) {
+    _showBanner(id, 'err', 'Erreur réseau');
+    if (btn) { btn.disabled = false; btn.textContent = TYPE_RUN_LABEL[initiatives.find(i=>i.id===id)?.type] || '▶ Lancer'; }
+  }
+}
+
+// Bouton confirmation envoi mail (step 2)
+async function doConfirm(id) {
+  const btn = document.getElementById(`rconfirm-${id}`);
+  if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spinner"></span>'; }
+
+  // Récupérer le brouillon potentiellement modifié
+  const ta = document.getElementById(`dta-${id}`);
+  const draft_content = ta?.classList.contains('open') ? ta.value : null;
+
+  try {
+    const r = await fetch(`/api/proactive/initiatives/${id}/confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ draft_content }),
+    });
+    const data = await r.json();
+
+    if (data.status === 'sent') {
+      _showBanner(id, 'ok', `Mail envoyé (id: ${data.message_id || 'ok'})`);
+      setTimeout(() => _removeRow(id, 'right'), 2200);
+    } else if (data.status === 'draft_only') {
+      _showBanner(id, 'warn', `Outil d'envoi indisponible — copiez le brouillon ci-dessus.`);
+      if (btn) { btn.disabled = false; btn.textContent = '📤 Confirmer l\'envoi'; }
+    } else if (data.status === 'blocked') {
+      _showBanner(id, 'err', `Envoi bloqué (approbation désactivée).`);
+      if (btn) { btn.disabled = false; btn.textContent = '📤 Confirmer l\'envoi'; }
+    } else if (data.error) {
+      _showBanner(id, 'err', `Erreur : ${data.error}`);
+      if (btn) { btn.disabled = false; btn.textContent = '📤 Confirmer l\'envoi'; }
+    }
+  } catch {
+    _showBanner(id, 'err', 'Erreur réseau');
+    if (btn) { btn.disabled = false; btn.textContent = '📤 Confirmer l\'envoi'; }
+  }
+}
+
+// Conserver la compat avec l'ancien endpoint approve (non utilisé dans la nouvelle UI)
+function doIgnore(id) { doDismiss(id); }
+
+// ── Run now ───────────────────────────────────────────────────
+
+let _analyzeTimer = null;
+
+async function runNow() {
+  const btn = document.getElementById('analyze-btn');
+  if (btn.disabled) return;
+  btn.classList.add('spinning');
+  btn.disabled = true;
+  document.getElementById('last-analyzed').textContent = 'analyse en cours…';
+
+  try { await fetch('/api/proactive/run', { method: 'POST' }); } catch {}
+
+  _analyzeTimer = setTimeout(() => _analysisDone(), 5 * 60 * 1000);
+}
+
+function _analysisDone() {
+  if (_analyzeTimer) { clearTimeout(_analyzeTimer); _analyzeTimer = null; }
+  const btn = document.getElementById('analyze-btn');
+  btn.classList.remove('spinning');
+  btn.disabled = false;
+  document.getElementById('last-analyzed').textContent = "analysé à l'instant";
+  loadInitiatives();
+}
+
+// ── Timestamp ─────────────────────────────────────────────────
+
+async function fetchStatus() {
+  try {
+    const r = await fetch('/api/proactive/status');
+    const d = await r.json();
+    const el = document.getElementById('last-analyzed');
+    if (d.last_run) {
+      const diff = Math.round((Date.now() - new Date(d.last_run).getTime()) / 60000);
+      el.textContent = diff < 1 ? "analysé à l'instant"
+        : diff < 60 ? `analysé il y a ${diff}min`
+        : `analysé il y a ${Math.round(diff/60)}h`;
+    }
+  } catch {}
+}
+
+// ── Footer ────────────────────────────────────────────────────
+
+async function loadFooter() {
+  try {
+    const r = await fetch('/api/events');
+    const d = await r.json();
+    const evts = d.events || [];
+    document.getElementById('footer-agenda').textContent =
+      evts.length ? evts.slice(0,2).map(e => `${e.time} ${e.name}`).join(' · ') : 'aucun événement';
+  } catch { document.getElementById('footer-agenda').textContent = '—'; }
+
+  try {
+    const r = await fetch('/api/tasks');
+    const d = await r.json();
+    const n = (d.tasks || []).filter(t => !t.done).length;
+    document.getElementById('fstat-tasks').textContent = `✓ ${n} tâche${n !== 1 ? 's' : ''}`;
+  } catch {}
+}
+
+// ── Load ──────────────────────────────────────────────────────
+
+async function loadInitiatives() {
+  try {
+    // Charge tout sur 7 jours pour avoir l'historique
+    const r = await fetch('/api/proactive/initiatives?days=7');
+    const all = await r.json();
+
+    initiatives  = all.filter(i => !HISTORY_STATUS_DONE.has(i.status));
+    historyItems = all.filter(i => HISTORY_STATUS_DONE.has(i.status))
+                      .sort((a,b) => new Date(b.created_at) - new Date(a.created_at));
+    renderList();
+  } catch {
+    document.getElementById('empty-state').classList.add('show');
+  }
+}
+
+// ── WebSocket ─────────────────────────────────────────────────
+
+let _reloadTimer = null;
+function _scheduleReload() {
+  clearTimeout(_reloadTimer);
+  _reloadTimer = setTimeout(loadInitiatives, 300);
+}
+
+function connectWS() {
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  const ws = new WebSocket(`${proto}://${location.host}/ws`);
+  ws.onmessage = e => {
+    try {
+      const msg = JSON.parse(e.data);
+      if (msg.type === 'proactive_update') {
+        _analysisDone();
+      } else if (msg.type === 'initiatives_restored') {
+        // Rechargement groupé après un restart — un seul fetch debounced
+        _scheduleReload();
+      }
+      // initiative_pending individuel : ignoré (le cycle complet envoie proactive_update en fin)
+    } catch {}
+  };
+  ws.onclose = () => setTimeout(connectWS, 3000);
+}
+
+// ── Boot ──────────────────────────────────────────────────────
+
+loadInitiatives();
+fetchStatus();
+loadFooter();
+connectWS();
+</script>
+
+<!-- GSAP page transitions -->
+<script>
+(function () {
+  const ov  = document.getElementById('transition-overlay');
+  const ui  = '#app';
+  const dir = sessionStorage.getItem('tx-dir') || 'forward';
+  const xIn = dir === 'forward' ? 40 : -40;
+  sessionStorage.removeItem('tx-dir');
+
+  window.addEventListener('load', () => {
+    gsap.timeline()
+      .to(ov, { duration: 0.2, opacity: 0, ease: 'power2.out' })
+      .from(ui, { duration: 0.38, x: xIn, opacity: 0, filter: 'blur(6px)', ease: 'power2.out', clearProps: 'all' }, '<0.05');
+  });
+
+  window.transitionTo = function (href, direction) {
+    direction = direction || 'back';
+    sessionStorage.setItem('tx-dir', direction);
+    const xOut = direction === 'forward' ? -40 : 40;
+    gsap.set(ov, { pointerEvents: 'all' });
+    gsap.timeline({ onComplete: () => { window.location.href = href; } })
+      .to(ui,  { duration: 0.28, x: xOut, opacity: 0, filter: 'blur(6px)', ease: 'power2.in' })
+      .to(ov,  { duration: 0.22, opacity: 1, ease: 'power2.in' }, '<');
+  };
+})();
+</script>
+
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/config/sphereStyle.js.bak-1782262661
+++ b/src/jarvis/interfaces/ui/static/config/sphereStyle.js.bak-1782262661
@@ -62,24 +62,13 @@
     // ── Couleur ───────────────────────────────────────────────────────────
     // Signature visuelle mono-couleur. La chauffe pendant CONVERGE/IGNITE
     // est dérivée de cette base et y RETOURNE strictement à l'entrée ONLINE.
-    /* Couleur accent — lit window.JARVIS_ACCENT_COLOR si défini (thème custom) */
-    function _parseAccent(hex) {
-        if (!hex || !/^#[0-9a-fA-F]{6}$/.test(hex)) return null;
-        return {
-            hex:  parseInt(hex.slice(1), 16),
-            str:  hex,
-            rgb:  [parseInt(hex.slice(1,3),16), parseInt(hex.slice(3,5),16), parseInt(hex.slice(5,7),16)],
-            vec3: [parseInt(hex.slice(1,3),16)/255, parseInt(hex.slice(3,5),16)/255, parseInt(hex.slice(5,7),16)/255],
-        };
-    }
-    const _customAccent = _parseAccent(window.JARVIS_ACCENT_COLOR);
     const COLOR = {
-        BASE_HEX:        _customAccent ? _customAccent.hex  : 0x4A9EFF,
-        BASE_HEX_STRING: _customAccent ? _customAccent.str  : '#4A9EFF',
-        BASE_RGB_255:    _customAccent ? _customAccent.rgb  : [74, 158, 255],
-        BASE_VEC3:       _customAccent ? _customAccent.vec3 : [0x4A / 255, 0x9E / 255, 0xFF / 255],
+        BASE_HEX: 0x4A9EFF,
+        BASE_HEX_STRING: '#4A9EFF',
+        BASE_RGB_255: [74, 158, 255],
+        BASE_VEC3: [0x4A / 255, 0x9E / 255, 0xFF / 255], // ≈ [0.2902, 0.6196, 1.0000]
         HEAT_WHITE_VEC3: [1.0, 1.0, 1.0],
-        HEAT_MIX_MAX: 0.70,
+        HEAT_MIX_MAX: 0.70,              // mix(base, white, heat · 0.70) — heat ∈ [0,1]
     };
 
     // ── Animation idle (orb.js, en ONLINE) ────────────────────────────────

--- a/src/jarvis/interfaces/ui/static/dashboard.css
+++ b/src/jarvis/interfaces/ui/static/dashboard.css
@@ -17,11 +17,11 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
   transition: border-color .15s;
 }
 .kpi-card:hover { border-color: var(--line-2); }
-.kpi-lbl { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3); }
-.kpi-val { font-family: var(--serif); font-weight: 300; font-size: 36px; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
-.kpi-unit { font-size: 14px; letter-spacing: 0; opacity: 0.55; margin-left: 3px; }
+.kpi-lbl { font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3); }
+.kpi-val { font-family: var(--serif); font-weight: 300; font-size: 2.25rem; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
+.kpi-unit { font-size: 0.875rem; letter-spacing: 0; opacity: 0.55; margin-left: 3px; }
 .kpi-delta {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.08em;
   display: flex; align-items: center; gap: 6px;
 }
 .kpi-delta.up   { color: var(--green); }
@@ -44,16 +44,16 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
 }
 .mission-row:first-child { border-top: 0.5px solid var(--line-1); }
 .mission-row--clickable { cursor: pointer; }
-.mission-row--clickable:hover { background: rgba(74,158,255,.04); }
+.mission-row--clickable:hover { background: rgba(var(--c-accent), .04); }
 .mission-row--ended { opacity: .55; }
 .mission-row--ended .m-title { text-decoration: line-through; text-decoration-color: var(--fg-4); }
 .mission-row--ended.mission-row--failed { opacity: .7; }
 .mission-row--ended.mission-row--failed .m-title { text-decoration: none; }
-.m-detail-hint { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--fg-4); text-transform: uppercase; transition: color .12s; }
+.m-detail-hint { font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.1em; color: var(--fg-4); text-transform: uppercase; transition: color .12s; }
 .mission-row--clickable:hover .m-detail-hint { color: var(--accent); }
-.m-id { font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; color: var(--fg-3); }
+.m-id { font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.06em; color: var(--fg-3); }
 .m-status {
-  margin-top: 5px; font-family: var(--mono); font-size: 9.5px;
+  margin-top: 5px; font-family: var(--mono); font-size: 0.5938rem;
   letter-spacing: 0.14em; text-transform: uppercase;
 }
 .m-status.run    { color: var(--green); }
@@ -62,29 +62,29 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
 .m-status.done   { color: var(--fg-4); }
 .m-status.failed { color: var(--red); }
 .m-status.killed { color: var(--fg-4); }
-.m-title { color: var(--fg-0); font-size: 13.5px; letter-spacing: -0.005em; line-height: 1.35; }
-.m-sub   { color: var(--fg-2); font-family: var(--mono); font-size: 10.5px; margin-top: 5px; }
+.m-title { color: var(--fg-0); font-size: 0.8438rem; letter-spacing: -0.005em; line-height: 1.35; }
+.m-sub   { color: var(--fg-2); font-family: var(--mono); font-size: 0.6562rem; margin-top: 5px; }
 .m-prog-bar { height: 2px; background: var(--bg-3); border-radius: 2px; overflow: hidden; margin-bottom: 5px; }
 .m-prog-bar > div { height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF); transition: width .4s; }
-.m-prog-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-2); display: flex; justify-content: space-between; }
-.m-eta { font-family: var(--mono); font-size: 11px; color: var(--fg-2); text-align: right; }
+.m-prog-meta { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-2); display: flex; justify-content: space-between; }
+.m-eta { font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-2); text-align: right; }
 .m-actions { display: flex; gap: 6px; justify-content: flex-end; }
 .m-btn {
   appearance: none; background: transparent;
   border: 0.5px solid var(--line-2); border-radius: 6px;
-  color: var(--fg-2); font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 0.5938rem;
   letter-spacing: 0.1em; text-transform: uppercase;
   padding: 5px 9px; cursor: pointer;
   transition: all .15s;
 }
 .m-btn:hover { border-color: var(--accent-line); color: var(--accent); }
-.m-btn.danger:hover { border-color: rgba(229,72,77,.4); color: var(--red); }
+.m-btn.danger:hover { border-color: rgba(var(--c-red), .4); color: var(--red); }
 
 /* ── Shared panel primitives (reused from capabilities pattern) ── */
 .panel-close {
   appearance: none; background: transparent;
   border: 0.5px solid var(--line-2); border-radius: 8px;
-  color: var(--fg-3); font-size: 14px; width: 30px; height: 30px;
+  color: var(--fg-3); font-size: 0.875rem; width: 30px; height: 30px;
   cursor: pointer; display: grid; place-items: center; flex-shrink: 0;
   transition: all .12s;
 }
@@ -92,7 +92,7 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
 .panel-body { padding: 24px 28px; display: flex; flex-direction: column; gap: 28px; flex: 1; overflow-y: auto; }
 .panel-section { display: flex; flex-direction: column; gap: 10px; }
 .panel-section-title {
-  font-family: var(--mono); font-size: 9px; letter-spacing: 0.22em; text-transform: uppercase;
+  font-family: var(--mono); font-size: 0.5625rem; letter-spacing: 0.22em; text-transform: uppercase;
   color: var(--fg-3); padding-bottom: 8px; border-bottom: 0.5px solid var(--line-1);
 }
 
@@ -119,20 +119,20 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
 }
 .mp-header-left { display: flex; align-items: flex-start; gap: 14px; }
 .mp-status-badge {
-  font-family: var(--mono); font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase;
+  font-family: var(--mono); font-size: 0.5625rem; letter-spacing: 0.18em; text-transform: uppercase;
   padding: 4px 8px; border-radius: 6px; flex-shrink: 0; margin-top: 2px;
   background: var(--bg-2); color: var(--fg-2);
 }
-.mp-status-badge.run  { background: rgba(54,211,153,.12); color: var(--green); }
+.mp-status-badge.run  { background: rgba(var(--c-green), .12); color: var(--green); }
 .mp-status-badge.wait { background: rgba(251,189,35,.12); color: var(--amber); }
 .mp-status-badge.queue { background: var(--bg-2); color: var(--fg-3); }
-.mp-title { font-size: 15px; color: var(--fg-0); line-height: 1.4; letter-spacing: -0.01em; }
-.mp-sub   { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 4px; }
+.mp-title { font-size: 0.9375rem; color: var(--fg-0); line-height: 1.4; letter-spacing: -0.01em; }
+.mp-sub   { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); margin-top: 4px; }
 
 .mp-prog-bar { height: 3px; background: var(--bg-3); border-radius: 3px; overflow: hidden; margin-bottom: 6px; }
 .mp-prog-bar > div { height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF); transition: width .4s; }
-.mp-prog-label { font-family: var(--mono); font-size: 10px; color: var(--fg-2); }
-.mp-loading { padding: 12px 0; font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+.mp-prog-label { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-2); }
+.mp-loading { padding: 12px 0; font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-3); }
 .mp-act-row { display: flex; gap: 8px; }
 
 /* Steps */
@@ -142,30 +142,30 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
 }
 .mp-step:last-child { border-bottom: 0; }
 .mp-step-num {
-  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--fg-4);
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.1em; color: var(--fg-4);
   flex-shrink: 0; padding-top: 2px; min-width: 20px;
 }
 .mp-step--done .mp-step-num { color: var(--green); }
 .mp-step--error .mp-step-num { color: var(--red); }
 .mp-step-content { flex: 1; min-width: 0; }
-.mp-step-title { font-size: 12.5px; color: var(--fg-1); line-height: 1.4; }
+.mp-step-title { font-size: 0.7812rem; color: var(--fg-1); line-height: 1.4; }
 .mp-step-status {
-  display: inline-block; font-family: var(--mono); font-size: 8.5px; letter-spacing: 0.15em; text-transform: uppercase;
+  display: inline-block; font-family: var(--mono); font-size: 0.5312rem; letter-spacing: 0.15em; text-transform: uppercase;
   padding: 2px 6px; border-radius: 4px; margin-top: 4px;
   background: var(--bg-2); color: var(--fg-3);
 }
-.mp-step-status--done    { background: rgba(54,211,153,.12); color: var(--green); }
-.mp-step-status--running { background: rgba(74,158,255,.12); color: var(--accent); }
-.mp-step-status--error   { background: rgba(229,72,77,.12); color: var(--red); }
+.mp-step-status--done    { background: rgba(var(--c-green), .12); color: var(--green); }
+.mp-step-status--running { background: rgba(var(--c-accent), .12); color: var(--accent); }
+.mp-step-status--error   { background: rgba(var(--c-red), .12); color: var(--red); }
 .mp-step-status--waiting { background: rgba(251,189,35,.12); color: var(--amber); }
 .mp-step-output {
-  margin-top: 6px; font-family: var(--mono); font-size: 10px; color: var(--fg-2);
+  margin-top: 6px; font-family: var(--mono); font-size: 0.625rem; color: var(--fg-2);
   background: var(--bg-1); border-radius: 6px; padding: 8px 10px;
   line-height: 1.5; white-space: pre-wrap; word-break: break-word;
 }
 .mp-step-error {
-  margin-top: 6px; font-family: var(--mono); font-size: 10px; color: var(--red);
-  background: rgba(229,72,77,.06); border-radius: 6px; padding: 8px 10px;
+  margin-top: 6px; font-family: var(--mono); font-size: 0.625rem; color: var(--red);
+  background: rgba(var(--c-red), .06); border-radius: 6px; padding: 8px 10px;
   white-space: pre-wrap; word-break: break-word;
 }
 
@@ -175,14 +175,14 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
   padding: 8px 0; border-bottom: 0.5px solid var(--line-1);
 }
 .mp-file-row:last-child { border-bottom: 0; }
-.mp-file-icon { font-size: 14px; flex-shrink: 0; }
+.mp-file-icon { font-size: 0.875rem; flex-shrink: 0; }
 .mp-file-name {
   appearance: none; background: transparent; border: none; padding: 0;
-  font-family: var(--mono); font-size: 11px; color: var(--accent);
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--accent);
   cursor: pointer; text-align: left; word-break: break-all;
-  text-decoration: underline; text-underline-offset: 3px; text-decoration-color: rgba(74,158,255,.35);
+  text-decoration: underline; text-underline-offset: 3px; text-decoration-color: rgba(var(--c-accent), .35);
 }
-.mp-file-name:hover { color: var(--fg-0); text-decoration-color: rgba(74,158,255,.8); }
+.mp-file-name:hover { color: var(--fg-0); text-decoration-color: rgba(var(--c-accent), .8); }
 
 /* ── File viewer popup ── */
 #dash-file-popup-overlay {
@@ -210,30 +210,30 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
   padding: 14px 18px; border-bottom: 0.5px solid var(--line-1);
   flex-shrink: 0; gap: 12px;
 }
-.fp-path { font-family: var(--mono); font-size: 11px; color: var(--fg-1); word-break: break-all; }
+.fp-path { font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-1); word-break: break-all; }
 .fp-close {
   appearance: none; background: transparent; border: 0.5px solid var(--line-2);
-  border-radius: 6px; color: var(--fg-2); font-size: 12px; width: 26px; height: 26px;
+  border-radius: 6px; color: var(--fg-2); font-size: 0.75rem; width: 26px; height: 26px;
   cursor: pointer; flex-shrink: 0; display: grid; place-items: center;
   transition: all .12s;
 }
 .fp-close:hover { border-color: var(--line-3); color: var(--fg-0); }
 .fp-body { overflow-y: auto; padding: 24px 24px; flex: 1; }
-.fp-loading { padding: 32px; font-family: var(--mono); font-size: 11px; color: var(--fg-3); text-align: center; }
+.fp-loading { padding: 32px; font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-3); text-align: center; }
 .fp-code {
-  font-family: var(--mono); font-size: 11.5px; line-height: 1.65;
+  font-family: var(--mono); font-size: 0.7188rem; line-height: 1.65;
   color: var(--fg-1); white-space: pre-wrap; word-break: break-word; margin: 0;
 }
-.fp-markdown { color: var(--fg-1); font-size: 13.5px; line-height: 1.7; }
-.fp-markdown h1 { font-size: 22px; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 16px; color: var(--fg-0); }
-.fp-markdown h2 { font-size: 17px; font-weight: 500; letter-spacing: -0.01em; margin: 24px 0 10px; color: var(--fg-0); border-bottom: 0.5px solid var(--line-1); padding-bottom: 6px; }
-.fp-markdown h3 { font-size: 14px; font-weight: 500; margin: 18px 0 8px; color: var(--fg-0); }
+.fp-markdown { color: var(--fg-1); font-size: 0.8438rem; line-height: 1.7; }
+.fp-markdown h1 { font-size: 1.375rem; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 16px; color: var(--fg-0); }
+.fp-markdown h2 { font-size: 1.0625rem; font-weight: 500; letter-spacing: -0.01em; margin: 24px 0 10px; color: var(--fg-0); border-bottom: 0.5px solid var(--line-1); padding-bottom: 6px; }
+.fp-markdown h3 { font-size: 0.875rem; font-weight: 500; margin: 18px 0 8px; color: var(--fg-0); }
 .fp-markdown p  { margin: 0 0 12px; }
 .fp-markdown ul { padding-left: 18px; margin: 0 0 12px; }
 .fp-markdown li { margin-bottom: 4px; }
-.fp-markdown code { font-family: var(--mono); font-size: 11.5px; background: var(--bg-2); padding: 1px 5px; border-radius: 4px; color: var(--accent); }
+.fp-markdown code { font-family: var(--mono); font-size: 0.7188rem; background: var(--bg-2); padding: 1px 5px; border-radius: 4px; color: var(--accent); }
 .fp-markdown pre { background: var(--bg-1); border: 0.5px solid var(--line-1); border-radius: 10px; padding: 14px 16px; overflow-x: auto; margin: 0 0 16px; }
-.fp-markdown pre code { background: transparent; padding: 0; color: var(--fg-1); font-size: 11.5px; }
+.fp-markdown pre code { background: transparent; padding: 0; color: var(--fg-1); font-size: 0.7188rem; }
 .fp-markdown a { color: var(--accent); text-underline-offset: 3px; }
 .fp-markdown strong { color: var(--fg-0); font-weight: 500; }
 
@@ -249,9 +249,9 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
   padding: 20px;
   display: flex; flex-direction: column; gap: 12px;
 }
-.aw-title { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--fg-3); }
-.aw-val   { font-family: var(--serif); font-weight: 300; font-size: 42px; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
-.aw-delta { font-family: var(--mono); font-size: 10px; }
+.aw-title { font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--fg-3); }
+.aw-val   { font-family: var(--serif); font-weight: 300; font-size: 2.625rem; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
+.aw-delta { font-family: var(--mono); font-size: 0.625rem; }
 .aw-delta.up { color: var(--green); }
 .aw-delta.dn { color: var(--red); }
 
@@ -266,12 +266,12 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
   width: 28px; height: 28px; border-radius: 6px;
   background: var(--bg-2); border: 0.5px solid var(--line-2);
   display: grid; place-items: center;
-  font-family: var(--mono); font-size: 11px; color: var(--fg-1);
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-1);
 }
 .src-bar-wrap { position: relative; height: 2px; background: var(--bg-3); border-radius: 2px; }
 .src-bar-fill { position: absolute; inset: 0 auto 0 0; border-radius: 2px; transition: width .4s; }
-.src-num { font-family: var(--mono); font-size: 11px; color: var(--fg-1); white-space: nowrap; }
-.src-delta { font-family: var(--mono); font-size: 10px; white-space: nowrap; }
+.src-num { font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-1); white-space: nowrap; }
+.src-delta { font-family: var(--mono); font-size: 0.625rem; white-space: nowrap; }
 
 /* Top content */
 .top-row {
@@ -280,10 +280,10 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
   border-bottom: 0.5px solid var(--line-1);
 }
 .top-row:last-child { border-bottom: 0; }
-.top-rank { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; color: var(--fg-4); }
-.top-title { font-size: 13px; color: var(--fg-1); line-height: 1.4; }
-.top-views { font-family: var(--mono); font-size: 11px; color: var(--fg-0); white-space: nowrap; }
-.top-chg { font-family: var(--mono); font-size: 10px; white-space: nowrap; }
+.top-rank { font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.12em; color: var(--fg-4); }
+.top-title { font-size: 0.8125rem; color: var(--fg-1); line-height: 1.4; }
+.top-views { font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-0); white-space: nowrap; }
+.top-chg { font-family: var(--mono); font-size: 0.625rem; white-space: nowrap; }
 
 /* ── Tâches (checkboxes) ── */
 .task-row {
@@ -297,10 +297,10 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
   cursor: pointer; transition: border-color .15s, background .15s;
   position: relative;
 }
-.task-check:hover { border-color: rgba(54,211,153,0.45); }
+.task-check:hover { border-color: rgba(var(--c-green), 0.45); }
 .task-row.done .task-check {
-  background: rgba(54,211,153,0.12);
-  border-color: rgba(54,211,153,0.55);
+  background: rgba(var(--c-green), 0.12);
+  border-color: rgba(var(--c-green), 0.55);
 }
 .task-row.done .task-check::after {
   content: "";
@@ -311,13 +311,13 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
   border-bottom: 1.5px solid var(--green);
   transform: rotate(40deg);
 }
-.task-label { font-size: 13px; color: var(--fg-1); line-height: 1.4; }
+.task-label { font-size: 0.8125rem; color: var(--fg-1); line-height: 1.4; }
 .task-row.done .task-label { color: var(--fg-3); text-decoration: line-through; }
-.task-src { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--fg-3); text-transform: uppercase; margin-top: 3px; }
+.task-src { font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.1em; color: var(--fg-3); text-transform: uppercase; margin-top: 3px; }
 .task-del {
   flex-shrink: 0; margin-top: 2px; width: 18px; height: 18px;
   display: grid; place-items: center; border-radius: 4px;
-  font-size: 14px; color: var(--fg-3); cursor: pointer; opacity: 0;
+  font-size: 0.875rem; color: var(--fg-3); cursor: pointer; opacity: 0;
   transition: opacity .15s, color .15s;
 }
 .task-row:hover .task-del { opacity: 1; }
@@ -325,14 +325,14 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
 .task-new-input {
   width: 100%; padding: 8px 12px; margin-bottom: 8px;
   background: var(--bg-2); border: 0.5px solid var(--accent-line);
-  border-radius: 8px; color: var(--fg-1); font-size: 13px; outline: none;
+  border-radius: 8px; color: var(--fg-1); font-size: 0.8125rem; outline: none;
   box-sizing: border-box;
 }
 
 /* Done count chip */
 .done-chip {
   display: inline-flex; align-items: center; gap: 6px;
-  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.1em; text-transform: uppercase;
   color: var(--fg-3); padding: 3px 8px; border: 0.5px solid var(--line-2); border-radius: 999px;
 }
 
@@ -340,13 +340,13 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
 .add-bar {
   display: flex; gap: 10px; align-items: center;
   padding: 10px 14px;
-  background: rgba(220,232,255,0.02);
+  background: rgba(var(--c-fg), 0.02);
   border: 0.5px dashed var(--line-2); border-radius: 10px;
   cursor: pointer; transition: border-color .15s, background .15s;
   margin-top: 8px;
 }
 .add-bar:hover { border-color: var(--accent-line); background: var(--accent-soft); }
-.add-bar span { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); }
+.add-bar span { font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); }
 .add-bar:hover span { color: var(--accent); }
 
 /* ─────────────────────────────────────────────────────────────
@@ -364,12 +364,12 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
   display: inline-block;
   padding: 3px 9px;
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 0.625rem;
   letter-spacing: 0.06em;
   font-weight: 600;
   color: var(--red);
-  background: rgba(229, 72, 77, 0.10);
-  border: 1px solid rgba(229, 72, 77, 0.35);
+  background: rgba(var(--c-red), 0.10);
+  border: 1px solid rgba(var(--c-red), 0.35);
   border-radius: 3px;
   white-space: nowrap;
 }
@@ -382,21 +382,21 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
   display: inline-block;
   padding: 3px 9px;
   font-family: var(--mono);
-  font-size: 10.5px;
+  font-size: 0.6562rem;
   color: var(--fg-2);
-  background: rgba(220, 232, 255, 0.03);
+  background: rgba(var(--c-fg), 0.03);
   border: 1px solid var(--line-2);
   border-radius: 3px;
 }
-.gov-chip.risk-low    { color: var(--green); border-color: rgba(54, 211, 153, 0.30); }
+.gov-chip.risk-low    { color: var(--green); border-color: rgba(var(--c-green), 0.30); }
 .gov-chip.risk-medium { color: var(--amber); border-color: rgba(251, 189, 35, 0.30); }
-.gov-chip.risk-high   { color: var(--red);   border-color: rgba(229, 72, 77, 0.30); }
+.gov-chip.risk-high   { color: var(--red);   border-color: rgba(var(--c-red), 0.30); }
 
-.gov-next { margin-top: 8px; font-size: 12px; color: var(--fg-2); line-height: 1.5; }
+.gov-next { margin-top: 8px; font-size: 0.75rem; color: var(--fg-2); line-height: 1.5; }
 .gov-next-lbl {
   display: inline-block;
   font-family: var(--mono);
-  font-size: 9.5px;
+  font-size: 0.5938rem;
   text-transform: uppercase;
   letter-spacing: 0.10em;
   color: var(--fg-3);
@@ -423,7 +423,7 @@ body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
 ───────────────────────────────────────────────────────────── */
 
 .badge--maintenance {
-  background: rgba(220, 232, 255, 0.05);
+  background: rgba(var(--c-fg), 0.05);
   color: var(--fg-3);
   border: 1px solid var(--line-2);
 }

--- a/src/jarvis/interfaces/ui/static/dashboard.css.bak-1782254922
+++ b/src/jarvis/interfaces/ui/static/dashboard.css.bak-1782254922
@@ -1,0 +1,437 @@
+/* dashboard.css — Workspace (Pilotage) v2 */
+
+/* ── Layout ── */
+body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
+
+/* ── Aperçu — KPI strip ── */
+.kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+.kpi-card {
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-1); border-radius: 14px;
+  padding: 18px 20px 16px;
+  display: flex; flex-direction: column; gap: 8px;
+  transition: border-color .15s;
+}
+.kpi-card:hover { border-color: var(--line-2); }
+.kpi-lbl { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3); }
+.kpi-val { font-family: var(--serif); font-weight: 300; font-size: 36px; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
+.kpi-unit { font-size: 14px; letter-spacing: 0; opacity: 0.55; margin-left: 3px; }
+.kpi-delta {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  display: flex; align-items: center; gap: 6px;
+}
+.kpi-delta.up   { color: var(--green); }
+.kpi-delta.down { color: var(--red); }
+.kpi-spark { margin-top: 4px; }
+
+/* ── Initiatives ── */
+.init-actions {
+  display: flex; gap: 8px;
+}
+
+/* ── Missions ── */
+.mission-row {
+  display: grid;
+  grid-template-columns: 88px 1fr 200px 80px;
+  align-items: center; gap: 18px;
+  padding: 16px 0;
+  border-bottom: 0.5px solid var(--line-1);
+  transition: background .12s;
+}
+.mission-row:first-child { border-top: 0.5px solid var(--line-1); }
+.mission-row--clickable { cursor: pointer; }
+.mission-row--clickable:hover { background: rgba(74,158,255,.04); }
+.mission-row--ended { opacity: .55; }
+.mission-row--ended .m-title { text-decoration: line-through; text-decoration-color: var(--fg-4); }
+.mission-row--ended.mission-row--failed { opacity: .7; }
+.mission-row--ended.mission-row--failed .m-title { text-decoration: none; }
+.m-detail-hint { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--fg-4); text-transform: uppercase; transition: color .12s; }
+.mission-row--clickable:hover .m-detail-hint { color: var(--accent); }
+.m-id { font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; color: var(--fg-3); }
+.m-status {
+  margin-top: 5px; font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.14em; text-transform: uppercase;
+}
+.m-status.run    { color: var(--green); }
+.m-status.wait   { color: var(--amber); }
+.m-status.queue  { color: var(--fg-3); }
+.m-status.done   { color: var(--fg-4); }
+.m-status.failed { color: var(--red); }
+.m-status.killed { color: var(--fg-4); }
+.m-title { color: var(--fg-0); font-size: 13.5px; letter-spacing: -0.005em; line-height: 1.35; }
+.m-sub   { color: var(--fg-2); font-family: var(--mono); font-size: 10.5px; margin-top: 5px; }
+.m-prog-bar { height: 2px; background: var(--bg-3); border-radius: 2px; overflow: hidden; margin-bottom: 5px; }
+.m-prog-bar > div { height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF); transition: width .4s; }
+.m-prog-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-2); display: flex; justify-content: space-between; }
+.m-eta { font-family: var(--mono); font-size: 11px; color: var(--fg-2); text-align: right; }
+.m-actions { display: flex; gap: 6px; justify-content: flex-end; }
+.m-btn {
+  appearance: none; background: transparent;
+  border: 0.5px solid var(--line-2); border-radius: 6px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 5px 9px; cursor: pointer;
+  transition: all .15s;
+}
+.m-btn:hover { border-color: var(--accent-line); color: var(--accent); }
+.m-btn.danger:hover { border-color: rgba(229,72,77,.4); color: var(--red); }
+
+/* ── Shared panel primitives (reused from capabilities pattern) ── */
+.panel-close {
+  appearance: none; background: transparent;
+  border: 0.5px solid var(--line-2); border-radius: 8px;
+  color: var(--fg-3); font-size: 14px; width: 30px; height: 30px;
+  cursor: pointer; display: grid; place-items: center; flex-shrink: 0;
+  transition: all .12s;
+}
+.panel-close:hover { border-color: var(--fg-2); color: var(--fg-1); }
+.panel-body { padding: 24px 28px; display: flex; flex-direction: column; gap: 28px; flex: 1; overflow-y: auto; }
+.panel-section { display: flex; flex-direction: column; gap: 10px; }
+.panel-section-title {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--fg-3); padding-bottom: 8px; border-bottom: 0.5px solid var(--line-1);
+}
+
+/* ── Mission detail panel ── */
+#dash-detail-overlay {
+  display: none; position: fixed; inset: 0; z-index: 1100;
+  background: rgba(0,0,0,.45); backdrop-filter: blur(4px);
+}
+#dash-detail-overlay.open { display: block; }
+#dash-detail-panel {
+  position: fixed; top: 0; right: -1060px; bottom: 0; width: 1040px;
+  z-index: 1101; background: var(--bg-0);
+  border-left: 0.5px solid var(--line-1);
+  display: flex; flex-direction: column;
+  transition: right .25s cubic-bezier(.22,1,.36,1);
+  overflow-y: auto;
+}
+#dash-detail-panel.open { right: 0; }
+
+.mp-header {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  padding: 28px 28px 20px; border-bottom: 0.5px solid var(--line-1);
+  gap: 16px; flex-shrink: 0;
+}
+.mp-header-left { display: flex; align-items: flex-start; gap: 14px; }
+.mp-status-badge {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase;
+  padding: 4px 8px; border-radius: 6px; flex-shrink: 0; margin-top: 2px;
+  background: var(--bg-2); color: var(--fg-2);
+}
+.mp-status-badge.run  { background: rgba(54,211,153,.12); color: var(--green); }
+.mp-status-badge.wait { background: rgba(251,189,35,.12); color: var(--amber); }
+.mp-status-badge.queue { background: var(--bg-2); color: var(--fg-3); }
+.mp-title { font-size: 15px; color: var(--fg-0); line-height: 1.4; letter-spacing: -0.01em; }
+.mp-sub   { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 4px; }
+
+.mp-prog-bar { height: 3px; background: var(--bg-3); border-radius: 3px; overflow: hidden; margin-bottom: 6px; }
+.mp-prog-bar > div { height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF); transition: width .4s; }
+.mp-prog-label { font-family: var(--mono); font-size: 10px; color: var(--fg-2); }
+.mp-loading { padding: 12px 0; font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+.mp-act-row { display: flex; gap: 8px; }
+
+/* Steps */
+.mp-step {
+  display: flex; gap: 14px; align-items: flex-start;
+  padding: 10px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.mp-step:last-child { border-bottom: 0; }
+.mp-step-num {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--fg-4);
+  flex-shrink: 0; padding-top: 2px; min-width: 20px;
+}
+.mp-step--done .mp-step-num { color: var(--green); }
+.mp-step--error .mp-step-num { color: var(--red); }
+.mp-step-content { flex: 1; min-width: 0; }
+.mp-step-title { font-size: 12.5px; color: var(--fg-1); line-height: 1.4; }
+.mp-step-status {
+  display: inline-block; font-family: var(--mono); font-size: 8.5px; letter-spacing: 0.15em; text-transform: uppercase;
+  padding: 2px 6px; border-radius: 4px; margin-top: 4px;
+  background: var(--bg-2); color: var(--fg-3);
+}
+.mp-step-status--done    { background: rgba(54,211,153,.12); color: var(--green); }
+.mp-step-status--running { background: rgba(74,158,255,.12); color: var(--accent); }
+.mp-step-status--error   { background: rgba(229,72,77,.12); color: var(--red); }
+.mp-step-status--waiting { background: rgba(251,189,35,.12); color: var(--amber); }
+.mp-step-output {
+  margin-top: 6px; font-family: var(--mono); font-size: 10px; color: var(--fg-2);
+  background: var(--bg-1); border-radius: 6px; padding: 8px 10px;
+  line-height: 1.5; white-space: pre-wrap; word-break: break-word;
+}
+.mp-step-error {
+  margin-top: 6px; font-family: var(--mono); font-size: 10px; color: var(--red);
+  background: rgba(229,72,77,.06); border-radius: 6px; padding: 8px 10px;
+  white-space: pre-wrap; word-break: break-word;
+}
+
+/* Files */
+.mp-file-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.mp-file-row:last-child { border-bottom: 0; }
+.mp-file-icon { font-size: 14px; flex-shrink: 0; }
+.mp-file-name {
+  appearance: none; background: transparent; border: none; padding: 0;
+  font-family: var(--mono); font-size: 11px; color: var(--accent);
+  cursor: pointer; text-align: left; word-break: break-all;
+  text-decoration: underline; text-underline-offset: 3px; text-decoration-color: rgba(74,158,255,.35);
+}
+.mp-file-name:hover { color: var(--fg-0); text-decoration-color: rgba(74,158,255,.8); }
+
+/* ── File viewer popup ── */
+#dash-file-popup-overlay {
+  display: none; position: fixed; inset: 0; z-index: 1200;
+  background: rgba(0,0,0,.55); backdrop-filter: blur(6px);
+}
+#dash-file-popup-overlay.open { display: block; }
+#dash-file-popup {
+  display: none; position: fixed;
+  top: 50%; left: 50%; z-index: 1201;
+  transform: translate(-50%, -50%) scale(.96);
+  width: min(820px, 94vw); max-height: 80vh;
+  background: var(--bg-0); border: 0.5px solid var(--line-2);
+  border-radius: 16px; overflow: hidden;
+  flex-direction: column;
+  box-shadow: 0 32px 80px rgba(0,0,0,.5);
+  transition: transform .18s cubic-bezier(.22,1,.36,1), opacity .18s;
+  opacity: 0;
+}
+#dash-file-popup.open {
+  display: flex; transform: translate(-50%, -50%) scale(1); opacity: 1;
+}
+.fp-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 18px; border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0; gap: 12px;
+}
+.fp-path { font-family: var(--mono); font-size: 11px; color: var(--fg-1); word-break: break-all; }
+.fp-close {
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-2); font-size: 12px; width: 26px; height: 26px;
+  cursor: pointer; flex-shrink: 0; display: grid; place-items: center;
+  transition: all .12s;
+}
+.fp-close:hover { border-color: var(--line-3); color: var(--fg-0); }
+.fp-body { overflow-y: auto; padding: 24px 24px; flex: 1; }
+.fp-loading { padding: 32px; font-family: var(--mono); font-size: 11px; color: var(--fg-3); text-align: center; }
+.fp-code {
+  font-family: var(--mono); font-size: 11.5px; line-height: 1.65;
+  color: var(--fg-1); white-space: pre-wrap; word-break: break-word; margin: 0;
+}
+.fp-markdown { color: var(--fg-1); font-size: 13.5px; line-height: 1.7; }
+.fp-markdown h1 { font-size: 22px; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 16px; color: var(--fg-0); }
+.fp-markdown h2 { font-size: 17px; font-weight: 500; letter-spacing: -0.01em; margin: 24px 0 10px; color: var(--fg-0); border-bottom: 0.5px solid var(--line-1); padding-bottom: 6px; }
+.fp-markdown h3 { font-size: 14px; font-weight: 500; margin: 18px 0 8px; color: var(--fg-0); }
+.fp-markdown p  { margin: 0 0 12px; }
+.fp-markdown ul { padding-left: 18px; margin: 0 0 12px; }
+.fp-markdown li { margin-bottom: 4px; }
+.fp-markdown code { font-family: var(--mono); font-size: 11.5px; background: var(--bg-2); padding: 1px 5px; border-radius: 4px; color: var(--accent); }
+.fp-markdown pre { background: var(--bg-1); border: 0.5px solid var(--line-1); border-radius: 10px; padding: 14px 16px; overflow-x: auto; margin: 0 0 16px; }
+.fp-markdown pre code { background: transparent; padding: 0; color: var(--fg-1); font-size: 11.5px; }
+.fp-markdown a { color: var(--accent); text-underline-offset: 3px; }
+.fp-markdown strong { color: var(--fg-0); font-weight: 500; }
+
+/* ── Analytics ── */
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+.analytics-widget {
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-1); border-radius: 14px;
+  padding: 20px;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.aw-title { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--fg-3); }
+.aw-val   { font-family: var(--serif); font-weight: 300; font-size: 42px; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
+.aw-delta { font-family: var(--mono); font-size: 10px; }
+.aw-delta.up { color: var(--green); }
+.aw-delta.dn { color: var(--red); }
+
+/* Source bars */
+.src-row {
+  display: grid; grid-template-columns: 28px 1fr auto auto;
+  align-items: center; gap: 12px; padding: 10px 0;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.src-row:last-child { border-bottom: 0; }
+.src-glyph {
+  width: 28px; height: 28px; border-radius: 6px;
+  background: var(--bg-2); border: 0.5px solid var(--line-2);
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-1);
+}
+.src-bar-wrap { position: relative; height: 2px; background: var(--bg-3); border-radius: 2px; }
+.src-bar-fill { position: absolute; inset: 0 auto 0 0; border-radius: 2px; transition: width .4s; }
+.src-num { font-family: var(--mono); font-size: 11px; color: var(--fg-1); white-space: nowrap; }
+.src-delta { font-family: var(--mono); font-size: 10px; white-space: nowrap; }
+
+/* Top content */
+.top-row {
+  display: grid; grid-template-columns: 28px 1fr auto auto;
+  align-items: center; gap: 14px; padding: 12px 0;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.top-row:last-child { border-bottom: 0; }
+.top-rank { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; color: var(--fg-4); }
+.top-title { font-size: 13px; color: var(--fg-1); line-height: 1.4; }
+.top-views { font-family: var(--mono); font-size: 11px; color: var(--fg-0); white-space: nowrap; }
+.top-chg { font-family: var(--mono); font-size: 10px; white-space: nowrap; }
+
+/* ── Tâches (checkboxes) ── */
+.task-row {
+  display: flex; align-items: flex-start; gap: 14px;
+  padding: 11px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.task-row:last-child { border-bottom: 0; }
+.task-check {
+  width: 17px; height: 17px; border-radius: 50%; flex-shrink: 0; margin-top: 1px;
+  border: 1.5px solid rgba(255,255,255,0.12); background: transparent;
+  cursor: pointer; transition: border-color .15s, background .15s;
+  position: relative;
+}
+.task-check:hover { border-color: rgba(54,211,153,0.45); }
+.task-row.done .task-check {
+  background: rgba(54,211,153,0.12);
+  border-color: rgba(54,211,153,0.55);
+}
+.task-row.done .task-check::after {
+  content: "";
+  position: absolute;
+  left: 4px; top: 1.5px;
+  width: 5px; height: 8px;
+  border-right: 1.5px solid var(--green);
+  border-bottom: 1.5px solid var(--green);
+  transform: rotate(40deg);
+}
+.task-label { font-size: 13px; color: var(--fg-1); line-height: 1.4; }
+.task-row.done .task-label { color: var(--fg-3); text-decoration: line-through; }
+.task-src { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--fg-3); text-transform: uppercase; margin-top: 3px; }
+.task-del {
+  flex-shrink: 0; margin-top: 2px; width: 18px; height: 18px;
+  display: grid; place-items: center; border-radius: 4px;
+  font-size: 14px; color: var(--fg-3); cursor: pointer; opacity: 0;
+  transition: opacity .15s, color .15s;
+}
+.task-row:hover .task-del { opacity: 1; }
+.task-del:hover { color: #e05; }
+.task-new-input {
+  width: 100%; padding: 8px 12px; margin-bottom: 8px;
+  background: var(--bg-2); border: 0.5px solid var(--accent-line);
+  border-radius: 8px; color: var(--fg-1); font-size: 13px; outline: none;
+  box-sizing: border-box;
+}
+
+/* Done count chip */
+.done-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--fg-3); padding: 3px 8px; border: 0.5px solid var(--line-2); border-radius: 999px;
+}
+
+/* ── Add-item bar ── */
+.add-bar {
+  display: flex; gap: 10px; align-items: center;
+  padding: 10px 14px;
+  background: rgba(220,232,255,0.02);
+  border: 0.5px dashed var(--line-2); border-radius: 10px;
+  cursor: pointer; transition: border-color .15s, background .15s;
+  margin-top: 8px;
+}
+.add-bar:hover { border-color: var(--accent-line); background: var(--accent-soft); }
+.add-bar span { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); }
+.add-bar:hover span { color: var(--accent); }
+
+/* ─────────────────────────────────────────────────────────────
+   PHASE 6 §10.1 — Badge "NIVEAU 5 — VALIDATION FORCÉE"
+   Affiché sur les initiatives EXTERNAL_ACTION pour matérialiser
+   visuellement que la validation humaine est obligatoire par
+   principe (needs_human_validation), quel que soit le flag
+   requires_validation. Couleur rouge — signal d'alerte.
+───────────────────────────────────────────────────────────── */
+
+.row-stripe-title-row {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.lvl5-badge {
+  display: inline-block;
+  padding: 3px 9px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  color: var(--red);
+  background: rgba(229, 72, 77, 0.10);
+  border: 1px solid rgba(229, 72, 77, 0.35);
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+/* Bloc gouvernance §10.1 dans le panel détail */
+.gov-panel .gov-chips {
+  display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px;
+}
+.gov-chip {
+  display: inline-block;
+  padding: 3px 9px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--fg-2);
+  background: rgba(220, 232, 255, 0.03);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+}
+.gov-chip.risk-low    { color: var(--green); border-color: rgba(54, 211, 153, 0.30); }
+.gov-chip.risk-medium { color: var(--amber); border-color: rgba(251, 189, 35, 0.30); }
+.gov-chip.risk-high   { color: var(--red);   border-color: rgba(229, 72, 77, 0.30); }
+
+.gov-next { margin-top: 8px; font-size: 12px; color: var(--fg-2); line-height: 1.5; }
+.gov-next-lbl {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  color: var(--fg-3);
+  margin-right: 8px;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Inbox unifiée — section "Skills à valider" (Skill Lab PHASE 4)
+   Badge violet pour distinguer visuellement les candidates d'une
+   initiative proactive classique.
+───────────────────────────────────────────────────────────── */
+
+.badge--skills {
+  background: rgba(155, 89, 182, 0.12);
+  color: #c193e2;
+  border: 1px solid rgba(155, 89, 182, 0.32);
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Inbox unifiée — section "Maintenance" (Curator PHASE 6)
+   Badge neutre/gris pour signaler que la maintenance n'est jamais
+   urgente. Titre dégraissé visuellement pour ne pas concurrencer
+   les vraies initiatives proactives.
+───────────────────────────────────────────────────────────── */
+
+.badge--maintenance {
+  background: rgba(220, 232, 255, 0.05);
+  color: var(--fg-3);
+  border: 1px solid var(--line-2);
+}
+
+.skill-row .row-stripe-bar.med,
+.patch-row .row-stripe-bar.low {
+  /* Réutilise les barres latérales existantes — aucune surcharge. */
+}
+.patch-row .row-stripe-title {
+  font-weight: 400; /* moins de poids visuel — la maintenance n'est pas urgente */
+}

--- a/src/jarvis/interfaces/ui/static/dashboard.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/dashboard.css.bak-1782259625
@@ -1,0 +1,437 @@
+/* dashboard.css — Workspace (Pilotage) v2 */
+
+/* ── Layout ── */
+body[data-mode="workspace"] { overflow-y: auto; overflow-x: hidden; }
+
+/* ── Aperçu — KPI strip ── */
+.kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+.kpi-card {
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-1); border-radius: 14px;
+  padding: 18px 20px 16px;
+  display: flex; flex-direction: column; gap: 8px;
+  transition: border-color .15s;
+}
+.kpi-card:hover { border-color: var(--line-2); }
+.kpi-lbl { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-3); }
+.kpi-val { font-family: var(--serif); font-weight: 300; font-size: 36px; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
+.kpi-unit { font-size: 14px; letter-spacing: 0; opacity: 0.55; margin-left: 3px; }
+.kpi-delta {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  display: flex; align-items: center; gap: 6px;
+}
+.kpi-delta.up   { color: var(--green); }
+.kpi-delta.down { color: var(--red); }
+.kpi-spark { margin-top: 4px; }
+
+/* ── Initiatives ── */
+.init-actions {
+  display: flex; gap: 8px;
+}
+
+/* ── Missions ── */
+.mission-row {
+  display: grid;
+  grid-template-columns: 88px 1fr 200px 80px;
+  align-items: center; gap: 18px;
+  padding: 16px 0;
+  border-bottom: 0.5px solid var(--line-1);
+  transition: background .12s;
+}
+.mission-row:first-child { border-top: 0.5px solid var(--line-1); }
+.mission-row--clickable { cursor: pointer; }
+.mission-row--clickable:hover { background: rgba(var(--c-accent), .04); }
+.mission-row--ended { opacity: .55; }
+.mission-row--ended .m-title { text-decoration: line-through; text-decoration-color: var(--fg-4); }
+.mission-row--ended.mission-row--failed { opacity: .7; }
+.mission-row--ended.mission-row--failed .m-title { text-decoration: none; }
+.m-detail-hint { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--fg-4); text-transform: uppercase; transition: color .12s; }
+.mission-row--clickable:hover .m-detail-hint { color: var(--accent); }
+.m-id { font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; color: var(--fg-3); }
+.m-status {
+  margin-top: 5px; font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.14em; text-transform: uppercase;
+}
+.m-status.run    { color: var(--green); }
+.m-status.wait   { color: var(--amber); }
+.m-status.queue  { color: var(--fg-3); }
+.m-status.done   { color: var(--fg-4); }
+.m-status.failed { color: var(--red); }
+.m-status.killed { color: var(--fg-4); }
+.m-title { color: var(--fg-0); font-size: 13.5px; letter-spacing: -0.005em; line-height: 1.35; }
+.m-sub   { color: var(--fg-2); font-family: var(--mono); font-size: 10.5px; margin-top: 5px; }
+.m-prog-bar { height: 2px; background: var(--bg-3); border-radius: 2px; overflow: hidden; margin-bottom: 5px; }
+.m-prog-bar > div { height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF); transition: width .4s; }
+.m-prog-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-2); display: flex; justify-content: space-between; }
+.m-eta { font-family: var(--mono); font-size: 11px; color: var(--fg-2); text-align: right; }
+.m-actions { display: flex; gap: 6px; justify-content: flex-end; }
+.m-btn {
+  appearance: none; background: transparent;
+  border: 0.5px solid var(--line-2); border-radius: 6px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 5px 9px; cursor: pointer;
+  transition: all .15s;
+}
+.m-btn:hover { border-color: var(--accent-line); color: var(--accent); }
+.m-btn.danger:hover { border-color: rgba(var(--c-red), .4); color: var(--red); }
+
+/* ── Shared panel primitives (reused from capabilities pattern) ── */
+.panel-close {
+  appearance: none; background: transparent;
+  border: 0.5px solid var(--line-2); border-radius: 8px;
+  color: var(--fg-3); font-size: 14px; width: 30px; height: 30px;
+  cursor: pointer; display: grid; place-items: center; flex-shrink: 0;
+  transition: all .12s;
+}
+.panel-close:hover { border-color: var(--fg-2); color: var(--fg-1); }
+.panel-body { padding: 24px 28px; display: flex; flex-direction: column; gap: 28px; flex: 1; overflow-y: auto; }
+.panel-section { display: flex; flex-direction: column; gap: 10px; }
+.panel-section-title {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--fg-3); padding-bottom: 8px; border-bottom: 0.5px solid var(--line-1);
+}
+
+/* ── Mission detail panel ── */
+#dash-detail-overlay {
+  display: none; position: fixed; inset: 0; z-index: 1100;
+  background: rgba(0,0,0,.45); backdrop-filter: blur(4px);
+}
+#dash-detail-overlay.open { display: block; }
+#dash-detail-panel {
+  position: fixed; top: 0; right: -1060px; bottom: 0; width: 1040px;
+  z-index: 1101; background: var(--bg-0);
+  border-left: 0.5px solid var(--line-1);
+  display: flex; flex-direction: column;
+  transition: right .25s cubic-bezier(.22,1,.36,1);
+  overflow-y: auto;
+}
+#dash-detail-panel.open { right: 0; }
+
+.mp-header {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  padding: 28px 28px 20px; border-bottom: 0.5px solid var(--line-1);
+  gap: 16px; flex-shrink: 0;
+}
+.mp-header-left { display: flex; align-items: flex-start; gap: 14px; }
+.mp-status-badge {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.18em; text-transform: uppercase;
+  padding: 4px 8px; border-radius: 6px; flex-shrink: 0; margin-top: 2px;
+  background: var(--bg-2); color: var(--fg-2);
+}
+.mp-status-badge.run  { background: rgba(var(--c-green), .12); color: var(--green); }
+.mp-status-badge.wait { background: rgba(251,189,35,.12); color: var(--amber); }
+.mp-status-badge.queue { background: var(--bg-2); color: var(--fg-3); }
+.mp-title { font-size: 15px; color: var(--fg-0); line-height: 1.4; letter-spacing: -0.01em; }
+.mp-sub   { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 4px; }
+
+.mp-prog-bar { height: 3px; background: var(--bg-3); border-radius: 3px; overflow: hidden; margin-bottom: 6px; }
+.mp-prog-bar > div { height: 100%; background: linear-gradient(90deg, var(--accent), #6BB0FF); transition: width .4s; }
+.mp-prog-label { font-family: var(--mono); font-size: 10px; color: var(--fg-2); }
+.mp-loading { padding: 12px 0; font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+.mp-act-row { display: flex; gap: 8px; }
+
+/* Steps */
+.mp-step {
+  display: flex; gap: 14px; align-items: flex-start;
+  padding: 10px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.mp-step:last-child { border-bottom: 0; }
+.mp-step-num {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--fg-4);
+  flex-shrink: 0; padding-top: 2px; min-width: 20px;
+}
+.mp-step--done .mp-step-num { color: var(--green); }
+.mp-step--error .mp-step-num { color: var(--red); }
+.mp-step-content { flex: 1; min-width: 0; }
+.mp-step-title { font-size: 12.5px; color: var(--fg-1); line-height: 1.4; }
+.mp-step-status {
+  display: inline-block; font-family: var(--mono); font-size: 8.5px; letter-spacing: 0.15em; text-transform: uppercase;
+  padding: 2px 6px; border-radius: 4px; margin-top: 4px;
+  background: var(--bg-2); color: var(--fg-3);
+}
+.mp-step-status--done    { background: rgba(var(--c-green), .12); color: var(--green); }
+.mp-step-status--running { background: rgba(var(--c-accent), .12); color: var(--accent); }
+.mp-step-status--error   { background: rgba(var(--c-red), .12); color: var(--red); }
+.mp-step-status--waiting { background: rgba(251,189,35,.12); color: var(--amber); }
+.mp-step-output {
+  margin-top: 6px; font-family: var(--mono); font-size: 10px; color: var(--fg-2);
+  background: var(--bg-1); border-radius: 6px; padding: 8px 10px;
+  line-height: 1.5; white-space: pre-wrap; word-break: break-word;
+}
+.mp-step-error {
+  margin-top: 6px; font-family: var(--mono); font-size: 10px; color: var(--red);
+  background: rgba(var(--c-red), .06); border-radius: 6px; padding: 8px 10px;
+  white-space: pre-wrap; word-break: break-word;
+}
+
+/* Files */
+.mp-file-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.mp-file-row:last-child { border-bottom: 0; }
+.mp-file-icon { font-size: 14px; flex-shrink: 0; }
+.mp-file-name {
+  appearance: none; background: transparent; border: none; padding: 0;
+  font-family: var(--mono); font-size: 11px; color: var(--accent);
+  cursor: pointer; text-align: left; word-break: break-all;
+  text-decoration: underline; text-underline-offset: 3px; text-decoration-color: rgba(var(--c-accent), .35);
+}
+.mp-file-name:hover { color: var(--fg-0); text-decoration-color: rgba(var(--c-accent), .8); }
+
+/* ── File viewer popup ── */
+#dash-file-popup-overlay {
+  display: none; position: fixed; inset: 0; z-index: 1200;
+  background: rgba(0,0,0,.55); backdrop-filter: blur(6px);
+}
+#dash-file-popup-overlay.open { display: block; }
+#dash-file-popup {
+  display: none; position: fixed;
+  top: 50%; left: 50%; z-index: 1201;
+  transform: translate(-50%, -50%) scale(.96);
+  width: min(820px, 94vw); max-height: 80vh;
+  background: var(--bg-0); border: 0.5px solid var(--line-2);
+  border-radius: 16px; overflow: hidden;
+  flex-direction: column;
+  box-shadow: 0 32px 80px rgba(0,0,0,.5);
+  transition: transform .18s cubic-bezier(.22,1,.36,1), opacity .18s;
+  opacity: 0;
+}
+#dash-file-popup.open {
+  display: flex; transform: translate(-50%, -50%) scale(1); opacity: 1;
+}
+.fp-header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 14px 18px; border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0; gap: 12px;
+}
+.fp-path { font-family: var(--mono); font-size: 11px; color: var(--fg-1); word-break: break-all; }
+.fp-close {
+  appearance: none; background: transparent; border: 0.5px solid var(--line-2);
+  border-radius: 6px; color: var(--fg-2); font-size: 12px; width: 26px; height: 26px;
+  cursor: pointer; flex-shrink: 0; display: grid; place-items: center;
+  transition: all .12s;
+}
+.fp-close:hover { border-color: var(--line-3); color: var(--fg-0); }
+.fp-body { overflow-y: auto; padding: 24px 24px; flex: 1; }
+.fp-loading { padding: 32px; font-family: var(--mono); font-size: 11px; color: var(--fg-3); text-align: center; }
+.fp-code {
+  font-family: var(--mono); font-size: 11.5px; line-height: 1.65;
+  color: var(--fg-1); white-space: pre-wrap; word-break: break-word; margin: 0;
+}
+.fp-markdown { color: var(--fg-1); font-size: 13.5px; line-height: 1.7; }
+.fp-markdown h1 { font-size: 22px; font-weight: 600; letter-spacing: -0.02em; margin: 0 0 16px; color: var(--fg-0); }
+.fp-markdown h2 { font-size: 17px; font-weight: 500; letter-spacing: -0.01em; margin: 24px 0 10px; color: var(--fg-0); border-bottom: 0.5px solid var(--line-1); padding-bottom: 6px; }
+.fp-markdown h3 { font-size: 14px; font-weight: 500; margin: 18px 0 8px; color: var(--fg-0); }
+.fp-markdown p  { margin: 0 0 12px; }
+.fp-markdown ul { padding-left: 18px; margin: 0 0 12px; }
+.fp-markdown li { margin-bottom: 4px; }
+.fp-markdown code { font-family: var(--mono); font-size: 11.5px; background: var(--bg-2); padding: 1px 5px; border-radius: 4px; color: var(--accent); }
+.fp-markdown pre { background: var(--bg-1); border: 0.5px solid var(--line-1); border-radius: 10px; padding: 14px 16px; overflow-x: auto; margin: 0 0 16px; }
+.fp-markdown pre code { background: transparent; padding: 0; color: var(--fg-1); font-size: 11.5px; }
+.fp-markdown a { color: var(--accent); text-underline-offset: 3px; }
+.fp-markdown strong { color: var(--fg-0); font-weight: 500; }
+
+/* ── Analytics ── */
+.analytics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+.analytics-widget {
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-1); border-radius: 14px;
+  padding: 20px;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.aw-title { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--fg-3); }
+.aw-val   { font-family: var(--serif); font-weight: 300; font-size: 42px; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
+.aw-delta { font-family: var(--mono); font-size: 10px; }
+.aw-delta.up { color: var(--green); }
+.aw-delta.dn { color: var(--red); }
+
+/* Source bars */
+.src-row {
+  display: grid; grid-template-columns: 28px 1fr auto auto;
+  align-items: center; gap: 12px; padding: 10px 0;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.src-row:last-child { border-bottom: 0; }
+.src-glyph {
+  width: 28px; height: 28px; border-radius: 6px;
+  background: var(--bg-2); border: 0.5px solid var(--line-2);
+  display: grid; place-items: center;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-1);
+}
+.src-bar-wrap { position: relative; height: 2px; background: var(--bg-3); border-radius: 2px; }
+.src-bar-fill { position: absolute; inset: 0 auto 0 0; border-radius: 2px; transition: width .4s; }
+.src-num { font-family: var(--mono); font-size: 11px; color: var(--fg-1); white-space: nowrap; }
+.src-delta { font-family: var(--mono); font-size: 10px; white-space: nowrap; }
+
+/* Top content */
+.top-row {
+  display: grid; grid-template-columns: 28px 1fr auto auto;
+  align-items: center; gap: 14px; padding: 12px 0;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.top-row:last-child { border-bottom: 0; }
+.top-rank { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.12em; color: var(--fg-4); }
+.top-title { font-size: 13px; color: var(--fg-1); line-height: 1.4; }
+.top-views { font-family: var(--mono); font-size: 11px; color: var(--fg-0); white-space: nowrap; }
+.top-chg { font-family: var(--mono); font-size: 10px; white-space: nowrap; }
+
+/* ── Tâches (checkboxes) ── */
+.task-row {
+  display: flex; align-items: flex-start; gap: 14px;
+  padding: 11px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.task-row:last-child { border-bottom: 0; }
+.task-check {
+  width: 17px; height: 17px; border-radius: 50%; flex-shrink: 0; margin-top: 1px;
+  border: 1.5px solid rgba(255,255,255,0.12); background: transparent;
+  cursor: pointer; transition: border-color .15s, background .15s;
+  position: relative;
+}
+.task-check:hover { border-color: rgba(var(--c-green), 0.45); }
+.task-row.done .task-check {
+  background: rgba(var(--c-green), 0.12);
+  border-color: rgba(var(--c-green), 0.55);
+}
+.task-row.done .task-check::after {
+  content: "";
+  position: absolute;
+  left: 4px; top: 1.5px;
+  width: 5px; height: 8px;
+  border-right: 1.5px solid var(--green);
+  border-bottom: 1.5px solid var(--green);
+  transform: rotate(40deg);
+}
+.task-label { font-size: 13px; color: var(--fg-1); line-height: 1.4; }
+.task-row.done .task-label { color: var(--fg-3); text-decoration: line-through; }
+.task-src { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; color: var(--fg-3); text-transform: uppercase; margin-top: 3px; }
+.task-del {
+  flex-shrink: 0; margin-top: 2px; width: 18px; height: 18px;
+  display: grid; place-items: center; border-radius: 4px;
+  font-size: 14px; color: var(--fg-3); cursor: pointer; opacity: 0;
+  transition: opacity .15s, color .15s;
+}
+.task-row:hover .task-del { opacity: 1; }
+.task-del:hover { color: #e05; }
+.task-new-input {
+  width: 100%; padding: 8px 12px; margin-bottom: 8px;
+  background: var(--bg-2); border: 0.5px solid var(--accent-line);
+  border-radius: 8px; color: var(--fg-1); font-size: 13px; outline: none;
+  box-sizing: border-box;
+}
+
+/* Done count chip */
+.done-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--fg-3); padding: 3px 8px; border: 0.5px solid var(--line-2); border-radius: 999px;
+}
+
+/* ── Add-item bar ── */
+.add-bar {
+  display: flex; gap: 10px; align-items: center;
+  padding: 10px 14px;
+  background: rgba(var(--c-fg), 0.02);
+  border: 0.5px dashed var(--line-2); border-radius: 10px;
+  cursor: pointer; transition: border-color .15s, background .15s;
+  margin-top: 8px;
+}
+.add-bar:hover { border-color: var(--accent-line); background: var(--accent-soft); }
+.add-bar span { font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3); }
+.add-bar:hover span { color: var(--accent); }
+
+/* ─────────────────────────────────────────────────────────────
+   PHASE 6 §10.1 — Badge "NIVEAU 5 — VALIDATION FORCÉE"
+   Affiché sur les initiatives EXTERNAL_ACTION pour matérialiser
+   visuellement que la validation humaine est obligatoire par
+   principe (needs_human_validation), quel que soit le flag
+   requires_validation. Couleur rouge — signal d'alerte.
+───────────────────────────────────────────────────────────── */
+
+.row-stripe-title-row {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.lvl5-badge {
+  display: inline-block;
+  padding: 3px 9px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  color: var(--red);
+  background: rgba(var(--c-red), 0.10);
+  border: 1px solid rgba(var(--c-red), 0.35);
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+/* Bloc gouvernance §10.1 dans le panel détail */
+.gov-panel .gov-chips {
+  display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px;
+}
+.gov-chip {
+  display: inline-block;
+  padding: 3px 9px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--fg-2);
+  background: rgba(var(--c-fg), 0.03);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+}
+.gov-chip.risk-low    { color: var(--green); border-color: rgba(var(--c-green), 0.30); }
+.gov-chip.risk-medium { color: var(--amber); border-color: rgba(251, 189, 35, 0.30); }
+.gov-chip.risk-high   { color: var(--red);   border-color: rgba(var(--c-red), 0.30); }
+
+.gov-next { margin-top: 8px; font-size: 12px; color: var(--fg-2); line-height: 1.5; }
+.gov-next-lbl {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  color: var(--fg-3);
+  margin-right: 8px;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Inbox unifiée — section "Skills à valider" (Skill Lab PHASE 4)
+   Badge violet pour distinguer visuellement les candidates d'une
+   initiative proactive classique.
+───────────────────────────────────────────────────────────── */
+
+.badge--skills {
+  background: rgba(155, 89, 182, 0.12);
+  color: #c193e2;
+  border: 1px solid rgba(155, 89, 182, 0.32);
+}
+
+/* ─────────────────────────────────────────────────────────────
+   Inbox unifiée — section "Maintenance" (Curator PHASE 6)
+   Badge neutre/gris pour signaler que la maintenance n'est jamais
+   urgente. Titre dégraissé visuellement pour ne pas concurrencer
+   les vraies initiatives proactives.
+───────────────────────────────────────────────────────────── */
+
+.badge--maintenance {
+  background: rgba(var(--c-fg), 0.05);
+  color: var(--fg-3);
+  border: 1px solid var(--line-2);
+}
+
+.skill-row .row-stripe-bar.med,
+.patch-row .row-stripe-bar.low {
+  /* Réutilise les barres latérales existantes — aucune surcharge. */
+}
+.patch-row .row-stripe-title {
+  font-weight: 400; /* moins de poids visuel — la maintenance n'est pas urgente */
+}

--- a/src/jarvis/interfaces/ui/static/dashboard.html
+++ b/src/jarvis/interfaces/ui/static/dashboard.html
@@ -9,11 +9,13 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
 <link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
 <link rel="stylesheet" href="/dashboard.css" />
 </head>
 <body data-mode="workspace">
 <div id="page-root"></div>
 <script src="/_shared.js"></script>
+<script src="/mission_control.js"></script>
 <script src="/dashboard.js"></script>
 </body>
 </html>

--- a/src/jarvis/interfaces/ui/static/dashboard.html.bak-1782249020
+++ b/src/jarvis/interfaces/ui/static/dashboard.html.bak-1782249020
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Pilotage</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/dashboard.css" />
+</head>
+<body data-mode="workspace">
+<div id="page-root"></div>
+<script src="/_shared.js"></script>
+<script src="/dashboard.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/globe.css
+++ b/src/jarvis/interfaces/ui/static/globe.css
@@ -25,28 +25,28 @@ body.globe-mode #globe-container {
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background: rgba(74, 158, 255, 0.08);
-  border: 1px solid rgba(74, 158, 255, 0.22);
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
-  color: rgba(74, 158, 255, 0.6);
+  color: rgba(var(--c-accent), 0.6);
 }
 
 #globe-toggle:hover {
-  background: rgba(74, 158, 255, 0.18);
-  border-color: rgba(74, 158, 255, 0.7);
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
   transform: scale(1.1);
   color: #4A9EFF;
 }
 
 #globe-toggle.active {
-  background: rgba(74, 158, 255, 0.20);
-  border-color: rgba(74, 158, 255, 0.8);
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
   color: #4A9EFF;
-  box-shadow: 0 0 12px rgba(74, 158, 255, 0.25);
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
 }
 
 
@@ -84,7 +84,7 @@ body.globe-mode #globe-data-panel {
 /* ── Globe data panel — header ──────────────────────────────────── */
 .gdp-header {
   padding: 14px 18px 10px;
-  border-bottom: 1px solid rgba(74, 158, 255, 0.08);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.08);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -93,10 +93,10 @@ body.globe-mode #globe-data-panel {
 
 .gdp-title {
   font-family: 'DM Mono', monospace;
-  font-size: 9px;
+  font-size: 0.5625rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(74, 158, 255, 0.55);
+  color: rgba(var(--c-accent), 0.55);
 }
 
 .gdp-live {
@@ -104,16 +104,16 @@ body.globe-mode #globe-data-panel {
   align-items: center;
   gap: 5px;
   font-family: 'DM Mono', monospace;
-  font-size: 8px;
+  font-size: 0.5rem;
   letter-spacing: 0.10em;
-  color: rgba(74, 158, 255, 0.40);
+  color: rgba(var(--c-accent), 0.40);
 }
 
 .gdp-live .pulse-dot {
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: rgba(74, 158, 255, 0.55);
+  background: rgba(var(--c-accent), 0.55);
   animation: gdp-pulse 2s ease-in-out infinite;
 }
 
@@ -133,7 +133,7 @@ body.globe-mode #globe-data-panel {
 
 /* ── Globe data panel — sections ────────────────────────────────── */
 .gdp-section {
-  border-bottom: 1px solid rgba(74, 158, 255, 0.06);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.06);
   flex-shrink: 0;
 }
 
@@ -154,16 +154,16 @@ body.globe-mode #globe-data-panel {
 .gdp-section-label {
   flex: 1;
   font-family: 'DM Mono', monospace;
-  font-size: 8.5px;
+  font-size: 0.5312rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(74, 158, 255, 0.45);
+  color: rgba(var(--c-accent), 0.45);
 }
 
 .gdp-section-count {
   font-family: 'DM Mono', monospace;
-  font-size: 9px;
-  color: rgba(74, 158, 255, 0.35);
+  font-size: 0.5625rem;
+  color: rgba(var(--c-accent), 0.35);
   min-width: 18px;
   text-align: right;
 }
@@ -172,8 +172,8 @@ body.globe-mode #globe-data-panel {
   background: none;
   border: none;
   cursor: pointer;
-  color: rgba(74, 158, 255, 0.35);
-  font-size: 9px;
+  color: rgba(var(--c-accent), 0.35);
+  font-size: 0.5625rem;
   padding: 0 0 0 4px;
   line-height: 1;
   transition: color 150ms ease;
@@ -181,7 +181,7 @@ body.globe-mode #globe-data-panel {
 }
 
 .gdp-section-toggle.active {
-  color: rgba(74, 158, 255, 0.8);
+  color: rgba(var(--c-accent), 0.8);
 }
 
 .gdp-section-toggle:hover {
@@ -202,7 +202,7 @@ body.globe-mode #globe-data-panel {
   align-items: center;
   gap: 8px;
   padding: 5px 0;
-  border-bottom: 1px solid rgba(74, 158, 255, 0.04);
+  border-bottom: 1px solid rgba(var(--c-accent), 0.04);
   cursor: pointer;
   transition: opacity 120ms ease;
 }
@@ -216,7 +216,7 @@ body.globe-mode #globe-data-panel {
 }
 
 .gdp-item-icon {
-  font-size: 11px;
+  font-size: 0.6875rem;
   opacity: 0.7;
   flex-shrink: 0;
   width: 14px;
@@ -230,7 +230,7 @@ body.globe-mode #globe-data-panel {
 
 .gdp-item-name {
   font-family: 'DM Mono', monospace;
-  font-size: 9.5px;
+  font-size: 0.5938rem;
   color: rgba(200, 218, 255, 0.70);
   white-space: nowrap;
   overflow: hidden;
@@ -239,8 +239,8 @@ body.globe-mode #globe-data-panel {
 
 .gdp-item-sub {
   font-family: 'DM Mono', monospace;
-  font-size: 8px;
-  color: rgba(74, 158, 255, 0.38);
+  font-size: 0.5rem;
+  color: rgba(var(--c-accent), 0.38);
   margin-top: 1px;
   white-space: nowrap;
   overflow: hidden;
@@ -249,15 +249,15 @@ body.globe-mode #globe-data-panel {
 
 .gdp-item-badge {
   font-family: 'DM Mono', monospace;
-  font-size: 8px;
-  color: rgba(74, 158, 255, 0.45);
+  font-size: 0.5rem;
+  color: rgba(var(--c-accent), 0.45);
   flex-shrink: 0;
 }
 
 .gdp-empty {
   font-family: 'DM Mono', monospace;
-  font-size: 9px;
-  color: rgba(74, 158, 255, 0.25);
+  font-size: 0.5625rem;
+  color: rgba(var(--c-accent), 0.25);
   padding: 4px 0 6px;
   text-align: center;
   letter-spacing: 0.08em;
@@ -273,12 +273,12 @@ body.globe-mode #globe-data-panel {
 
 .gdp-search-input {
   flex: 1;
-  background: rgba(74, 158, 255, 0.05);
-  border: 1px solid rgba(74, 158, 255, 0.15);
+  background: rgba(var(--c-accent), 0.05);
+  border: 1px solid rgba(var(--c-accent), 0.15);
   border-radius: 5px;
   padding: 5px 9px;
   font-family: 'DM Mono', monospace;
-  font-size: 9.5px;
+  font-size: 0.5938rem;
   letter-spacing: 0.06em;
   color: rgba(200, 218, 255, 0.80);
   outline: none;
@@ -287,21 +287,21 @@ body.globe-mode #globe-data-panel {
 }
 
 .gdp-search-input::placeholder {
-  color: rgba(74, 158, 255, 0.28);
+  color: rgba(var(--c-accent), 0.28);
   text-transform: none;
 }
 
 .gdp-search-input:focus {
-  border-color: rgba(74, 158, 255, 0.45);
-  background: rgba(74, 158, 255, 0.09);
+  border-color: rgba(var(--c-accent), 0.45);
+  background: rgba(var(--c-accent), 0.09);
 }
 
 .gdp-search-clear {
   background: none;
   border: none;
   cursor: pointer;
-  color: rgba(74, 158, 255, 0.30);
-  font-size: 9px;
+  color: rgba(var(--c-accent), 0.30);
+  font-size: 0.5625rem;
   padding: 0;
   line-height: 1;
   transition: color 150ms ease;
@@ -309,7 +309,7 @@ body.globe-mode #globe-data-panel {
 }
 
 .gdp-search-clear:hover {
-  color: rgba(74, 158, 255, 0.75);
+  color: rgba(var(--c-accent), 0.75);
 }
 
 /* ── Toggle switch ───────────────────────────────────────────────── */
@@ -327,8 +327,8 @@ body.globe-mode #globe-data-panel {
 .gdp-switch-track {
   width: 30px;
   height: 16px;
-  background: rgba(74, 158, 255, 0.10);
-  border: 1px solid rgba(74, 158, 255, 0.22);
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.22);
   border-radius: 8px;
   position: relative;
   transition: background 200ms ease, border-color 200ms ease;
@@ -340,15 +340,15 @@ body.globe-mode #globe-data-panel {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: rgba(74, 158, 255, 0.35);
+  background: rgba(var(--c-accent), 0.35);
   top: 2px;
   left: 2px;
   transition: transform 200ms ease, background 200ms ease;
 }
 
 .gdp-switch input:checked+.gdp-switch-track {
-  background: rgba(74, 158, 255, 0.22);
-  border-color: rgba(74, 158, 255, 0.60);
+  background: rgba(var(--c-accent), 0.22);
+  border-color: rgba(var(--c-accent), 0.60);
 }
 
 .gdp-switch input:checked+.gdp-switch-track::after {
@@ -366,18 +366,18 @@ body.globe-mode #globe-data-panel {
 
 .gdp-switch-label {
   font-family: 'DM Mono', monospace;
-  font-size: 8.5px;
+  font-size: 0.5312rem;
   letter-spacing: 0.10em;
   text-transform: uppercase;
-  color: rgba(74, 158, 255, 0.38);
+  color: rgba(var(--c-accent), 0.38);
 }
 
 /* ── Vessel status line ──────────────────────────────────────────── */
 .gdp-vessel-status {
   font-family: 'DM Mono', monospace;
-  font-size: 8.5px;
+  font-size: 0.5312rem;
   letter-spacing: 0.08em;
-  color: rgba(184, 150, 62, 0.50);
+  color: rgba(var(--c-gold), 0.50);
   padding: 0 18px 10px;
 }
 
@@ -390,8 +390,8 @@ body.globe-mode #globe-data-panel {
 }
 
 .gdp-weather-cell {
-  background: rgba(74, 158, 255, 0.04);
-  border: 1px solid rgba(74, 158, 255, 0.08);
+  background: rgba(var(--c-accent), 0.04);
+  border: 1px solid rgba(var(--c-accent), 0.08);
   border-radius: 6px;
   padding: 8px 10px;
   cursor: pointer;
@@ -399,30 +399,30 @@ body.globe-mode #globe-data-panel {
 }
 
 .gdp-weather-cell:hover {
-  border-color: rgba(74, 158, 255, 0.20);
-  background: rgba(74, 158, 255, 0.08);
+  border-color: rgba(var(--c-accent), 0.20);
+  background: rgba(var(--c-accent), 0.08);
 }
 
 .gdp-weather-city {
   font-family: 'DM Mono', monospace;
-  font-size: 8px;
+  font-size: 0.5rem;
   text-transform: uppercase;
   letter-spacing: 0.10em;
-  color: rgba(74, 158, 255, 0.40);
+  color: rgba(var(--c-accent), 0.40);
   margin-bottom: 4px;
 }
 
 .gdp-weather-temp {
   font-family: 'DM Mono', monospace;
-  font-size: 16px;
+  font-size: 1rem;
   color: rgba(200, 218, 255, 0.80);
   line-height: 1;
 }
 
 .gdp-weather-desc {
   font-family: 'DM Mono', monospace;
-  font-size: 7.5px;
-  color: rgba(74, 158, 255, 0.35);
+  font-size: 0.4688rem;
+  color: rgba(var(--c-accent), 0.35);
   margin-top: 3px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -439,14 +439,14 @@ body.globe-mode #globe-data-panel {
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background: rgba(74, 158, 255, 0.08);
-  border: 1px solid rgba(74, 158, 255, 0.22);
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
-  color: rgba(74, 158, 255, 0.6);
+  color: rgba(var(--c-accent), 0.6);
   padding: 0;
   margin: 0;
   outline: none;
@@ -456,8 +456,8 @@ body.globe-mode #globe-data-panel {
 #intel-toggle:hover,
 #dashboard-nav-btn:hover,
 #settings-nav-btn:hover {
-  background: rgba(74, 158, 255, 0.18);
-  border-color: rgba(74, 158, 255, 0.7);
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
   transform: scale(1.1);
   color: #4A9EFF;
 }
@@ -466,10 +466,10 @@ body.globe-mode #globe-data-panel {
 #intel-toggle.active,
 #dashboard-nav-btn.active,
 #settings-nav-btn.active {
-  background: rgba(74, 158, 255, 0.20);
-  border-color: rgba(74, 158, 255, 0.8);
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
   color: #4A9EFF;
-  box-shadow: 0 0 12px rgba(74, 158, 255, 0.25);
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
 }
 
 /* Positions — 5 boutons centrés, gap 8px (total 212px) */
@@ -558,23 +558,23 @@ body.intel-mode #intel-overlay {
 
 .intel-fallback-title {
   font-family: 'DM Mono', monospace;
-  font-size: 12px;
+  font-size: 0.75rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(74, 158, 255, 0.9);
+  color: rgba(var(--c-accent), 0.9);
   margin-bottom: 10px;
 }
 
 .intel-fallback-sub {
   font-family: 'DM Mono', monospace;
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: rgba(200, 218, 255, 0.55);
   margin: 0 0 28px;
 }
 
 .intel-fallback-steps {
   font-family: 'DM Mono', monospace;
-  font-size: 11px;
+  font-size: 0.6875rem;
   color: rgba(200, 218, 255, 0.75);
   line-height: 1.9;
 }
@@ -582,7 +582,7 @@ body.intel-mode #intel-overlay {
 .intel-fallback-steps p {
   margin: 0 0 6px;
   color: rgba(200, 218, 255, 0.5);
-  font-size: 10px;
+  font-size: 0.625rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -597,12 +597,12 @@ body.intel-mode #intel-overlay {
 }
 
 .intel-fallback-steps code {
-  background: rgba(74, 158, 255, 0.08);
-  border: 1px solid rgba(74, 158, 255, 0.22);
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
   border-radius: 3px;
   padding: 2px 7px;
-  font-size: 10px;
-  color: rgba(74, 158, 255, 0.95);
+  font-size: 0.625rem;
+  color: rgba(var(--c-accent), 0.95);
   display: inline-block;
   margin-top: 3px;
 }
@@ -660,11 +660,11 @@ body.globe-mode .cam-overlay {
   background: rgba(6, 8, 13, 0.90);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  border: 1px solid rgba(74, 158, 255, 0.25);
+  border: 1px solid rgba(var(--c-accent), 0.25);
   border-radius: 6px;
   padding: 7px 10px;
   font-family: 'DM Mono', monospace;
-  font-size: 10px;
+  font-size: 0.625rem;
   letter-spacing: 0.05em;
   color: rgba(200, 218, 255, 0.85);
   line-height: 1.55;

--- a/src/jarvis/interfaces/ui/static/globe.css.bak-1782254922
+++ b/src/jarvis/interfaces/ui/static/globe.css.bak-1782254922
@@ -1,0 +1,677 @@
+/* ── Globe container (Mapbox GL) ────────────────────────────────── */
+#globe-container {
+  position: fixed;
+  inset: 0;
+  z-index: 2;
+  display: none;
+  opacity: 0;
+  transition: opacity 400ms ease;
+  pointer-events: none;
+}
+
+/* En mode globe : passe au-dessus de l'UI (z-index: 10 dans home.css)
+   et active les événements souris pour Mapbox */
+body.globe-mode #globe-container {
+  z-index: 15;
+  pointer-events: auto;
+}
+
+/* ── Bottom nav buttons — each independently positioned ─────────── */
+#globe-toggle {
+  position: fixed;
+  bottom: 52px;
+  left: calc(50% - 18px);
+  z-index: 9990;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(74, 158, 255, 0.08);
+  border: 1px solid rgba(74, 158, 255, 0.22);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(74, 158, 255, 0.6);
+}
+
+#globe-toggle:hover {
+  background: rgba(74, 158, 255, 0.18);
+  border-color: rgba(74, 158, 255, 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+
+#globe-toggle.active {
+  background: rgba(74, 158, 255, 0.20);
+  border-color: rgba(74, 158, 255, 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(74, 158, 255, 0.25);
+}
+
+
+/* ── Left panel swap — globe mode ──────────────────────────────── */
+
+/* Normal mode: left-scroll visible, globe-data-panel hidden */
+.left-scroll {
+  /* flex: 1 and overflow already set in index.html */
+  display: flex !important;
+}
+
+body.globe-mode .left-scroll {
+  display: none !important;
+}
+
+/* Globe data panel — flex child (below brand header) */
+#globe-data-panel {
+  display: none;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  flex-direction: column;
+  scrollbar-width: none;
+}
+
+#globe-data-panel::-webkit-scrollbar {
+  display: none;
+}
+
+body.globe-mode #globe-data-panel {
+  display: flex;
+}
+
+/* ── Globe data panel — header ──────────────────────────────────── */
+.gdp-header {
+  padding: 14px 18px 10px;
+  border-bottom: 1px solid rgba(74, 158, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.gdp-title {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(74, 158, 255, 0.55);
+}
+
+.gdp-live {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-family: 'DM Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.10em;
+  color: rgba(74, 158, 255, 0.40);
+}
+
+.gdp-live .pulse-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: rgba(74, 158, 255, 0.55);
+  animation: gdp-pulse 2s ease-in-out infinite;
+}
+
+@keyframes gdp-pulse {
+
+  0%,
+  100% {
+    opacity: 0.5;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.35);
+  }
+}
+
+/* ── Globe data panel — sections ────────────────────────────────── */
+.gdp-section {
+  border-bottom: 1px solid rgba(74, 158, 255, 0.06);
+  flex-shrink: 0;
+}
+
+.gdp-section-hd {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 12px 18px 8px;
+}
+
+.gdp-section-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.gdp-section-label {
+  flex: 1;
+  font-family: 'DM Mono', monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(74, 158, 255, 0.45);
+}
+
+.gdp-section-count {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  color: rgba(74, 158, 255, 0.35);
+  min-width: 18px;
+  text-align: right;
+}
+
+.gdp-section-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: rgba(74, 158, 255, 0.35);
+  font-size: 9px;
+  padding: 0 0 0 4px;
+  line-height: 1;
+  transition: color 150ms ease;
+  flex-shrink: 0;
+}
+
+.gdp-section-toggle.active {
+  color: rgba(74, 158, 255, 0.8);
+}
+
+.gdp-section-toggle:hover {
+  color: #4A9EFF;
+}
+
+/* ── Globe data panel — list items ─────────────────────────────── */
+.gdp-list {
+  padding: 0 18px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 32px;
+}
+
+.gdp-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+  border-bottom: 1px solid rgba(74, 158, 255, 0.04);
+  cursor: pointer;
+  transition: opacity 120ms ease;
+}
+
+.gdp-item:last-child {
+  border-bottom: none;
+}
+
+.gdp-item:hover {
+  opacity: 0.75;
+}
+
+.gdp-item-icon {
+  font-size: 11px;
+  opacity: 0.7;
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+}
+
+.gdp-item-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.gdp-item-name {
+  font-family: 'DM Mono', monospace;
+  font-size: 9.5px;
+  color: rgba(200, 218, 255, 0.70);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gdp-item-sub {
+  font-family: 'DM Mono', monospace;
+  font-size: 8px;
+  color: rgba(74, 158, 255, 0.38);
+  margin-top: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gdp-item-badge {
+  font-family: 'DM Mono', monospace;
+  font-size: 8px;
+  color: rgba(74, 158, 255, 0.45);
+  flex-shrink: 0;
+}
+
+.gdp-empty {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  color: rgba(74, 158, 255, 0.25);
+  padding: 4px 0 6px;
+  text-align: center;
+  letter-spacing: 0.08em;
+}
+
+/* ── Flight search ──────────────────────────────────────────────── */
+.gdp-search-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 18px 10px;
+}
+
+.gdp-search-input {
+  flex: 1;
+  background: rgba(74, 158, 255, 0.05);
+  border: 1px solid rgba(74, 158, 255, 0.15);
+  border-radius: 5px;
+  padding: 5px 9px;
+  font-family: 'DM Mono', monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.06em;
+  color: rgba(200, 218, 255, 0.80);
+  outline: none;
+  transition: border-color 150ms ease, background 150ms ease;
+  text-transform: uppercase;
+}
+
+.gdp-search-input::placeholder {
+  color: rgba(74, 158, 255, 0.28);
+  text-transform: none;
+}
+
+.gdp-search-input:focus {
+  border-color: rgba(74, 158, 255, 0.45);
+  background: rgba(74, 158, 255, 0.09);
+}
+
+.gdp-search-clear {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: rgba(74, 158, 255, 0.30);
+  font-size: 9px;
+  padding: 0;
+  line-height: 1;
+  transition: color 150ms ease;
+  flex-shrink: 0;
+}
+
+.gdp-search-clear:hover {
+  color: rgba(74, 158, 255, 0.75);
+}
+
+/* ── Toggle switch ───────────────────────────────────────────────── */
+.gdp-switch {
+  position: relative;
+  display: inline-flex;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.gdp-switch input {
+  display: none;
+}
+
+.gdp-switch-track {
+  width: 30px;
+  height: 16px;
+  background: rgba(74, 158, 255, 0.10);
+  border: 1px solid rgba(74, 158, 255, 0.22);
+  border-radius: 8px;
+  position: relative;
+  transition: background 200ms ease, border-color 200ms ease;
+}
+
+.gdp-switch-track::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(74, 158, 255, 0.35);
+  top: 2px;
+  left: 2px;
+  transition: transform 200ms ease, background 200ms ease;
+}
+
+.gdp-switch input:checked+.gdp-switch-track {
+  background: rgba(74, 158, 255, 0.22);
+  border-color: rgba(74, 158, 255, 0.60);
+}
+
+.gdp-switch input:checked+.gdp-switch-track::after {
+  transform: translateX(14px);
+  background: #4A9EFF;
+}
+
+/* ── Switch row (label + switch) ─────────────────────────────────── */
+.gdp-switch-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 18px 10px;
+}
+
+.gdp-switch-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: rgba(74, 158, 255, 0.38);
+}
+
+/* ── Vessel status line ──────────────────────────────────────────── */
+.gdp-vessel-status {
+  font-family: 'DM Mono', monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.08em;
+  color: rgba(184, 150, 62, 0.50);
+  padding: 0 18px 10px;
+}
+
+/* ── Weather grid ───────────────────────────────────────────────── */
+.gdp-weather-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 0 18px 12px;
+}
+
+.gdp-weather-cell {
+  background: rgba(74, 158, 255, 0.04);
+  border: 1px solid rgba(74, 158, 255, 0.08);
+  border-radius: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition: border-color 150ms ease, background 150ms ease;
+}
+
+.gdp-weather-cell:hover {
+  border-color: rgba(74, 158, 255, 0.20);
+  background: rgba(74, 158, 255, 0.08);
+}
+
+.gdp-weather-city {
+  font-family: 'DM Mono', monospace;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  color: rgba(74, 158, 255, 0.40);
+  margin-bottom: 4px;
+}
+
+.gdp-weather-temp {
+  font-family: 'DM Mono', monospace;
+  font-size: 16px;
+  color: rgba(200, 218, 255, 0.80);
+  line-height: 1;
+}
+
+.gdp-weather-desc {
+  font-family: 'DM Mono', monospace;
+  font-size: 7.5px;
+  color: rgba(74, 158, 255, 0.35);
+  margin-top: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ── Shared style pour les 5 nav buttons du bas ─────────────────── */
+#jarvis-toggle,
+#intel-toggle,
+#dashboard-nav-btn,
+#settings-nav-btn {
+  position: fixed;
+  bottom: 52px;
+  z-index: 9990;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(74, 158, 255, 0.08);
+  border: 1px solid rgba(74, 158, 255, 0.22);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(74, 158, 255, 0.6);
+  padding: 0;
+  margin: 0;
+  outline: none;
+}
+
+#jarvis-toggle:hover,
+#intel-toggle:hover,
+#dashboard-nav-btn:hover,
+#settings-nav-btn:hover {
+  background: rgba(74, 158, 255, 0.18);
+  border-color: rgba(74, 158, 255, 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+
+#jarvis-toggle.active,
+#intel-toggle.active,
+#dashboard-nav-btn.active,
+#settings-nav-btn.active {
+  background: rgba(74, 158, 255, 0.20);
+  border-color: rgba(74, 158, 255, 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(74, 158, 255, 0.25);
+}
+
+/* Positions — 5 boutons centrés, gap 8px (total 212px) */
+#jarvis-toggle {
+  right: calc(50% + 70px);
+}
+
+/* center 50%−88 */
+#dashboard-nav-btn {
+  right: calc(50% + 26px);
+}
+
+/* center 50%−44 */
+/* globe-toggle:  left: calc(50% - 18px)  center 50%  — own block above */
+#intel-toggle {
+  left: calc(50% + 26px);
+}
+
+/* center 50%+44 */
+#settings-nav-btn {
+  left: calc(50% + 70px);
+}
+
+/* center 50%+88 */
+
+/* ── Settings overlay (iframe plein écran) ───────────────────────── */
+#settings-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 600;
+  display: none;
+}
+
+#settings-iframe {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  border: none;
+  outline: none;
+  border-radius: 0;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── Intel overlay (iframe plein écran) ─────────────────────────── */
+#intel-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  display: none;
+  opacity: 0;
+}
+
+body.intel-mode #intel-overlay {
+  display: block;
+}
+
+#intel-iframe {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  border: none;
+  outline: none;
+  border-radius: 0;
+  margin: 0;
+  padding: 0;
+}
+
+#intel-fallback {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgb(4, 8, 20);
+}
+
+#intel-fallback.visible {
+  display: flex;
+}
+
+.intel-fallback-inner {
+  max-width: 540px;
+  padding: 40px;
+}
+
+.intel-fallback-title {
+  font-family: 'DM Mono', monospace;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(74, 158, 255, 0.9);
+  margin-bottom: 10px;
+}
+
+.intel-fallback-sub {
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  color: rgba(200, 218, 255, 0.55);
+  margin: 0 0 28px;
+}
+
+.intel-fallback-steps {
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  color: rgba(200, 218, 255, 0.75);
+  line-height: 1.9;
+}
+
+.intel-fallback-steps p {
+  margin: 0 0 6px;
+  color: rgba(200, 218, 255, 0.5);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.intel-fallback-steps ol {
+  padding-left: 18px;
+  margin: 0;
+}
+
+.intel-fallback-steps li {
+  margin-bottom: 12px;
+}
+
+.intel-fallback-steps code {
+  background: rgba(74, 158, 255, 0.08);
+  border: 1px solid rgba(74, 158, 255, 0.22);
+  border-radius: 3px;
+  padding: 2px 7px;
+  font-size: 10px;
+  color: rgba(74, 158, 255, 0.95);
+  display: inline-block;
+  margin-top: 3px;
+}
+
+/* intel-nav-hub supprimé — la nav principale reste visible en mode Intel */
+#intel-nav-hub {
+  display: none !important;
+}
+
+/* En mode Intel : backdrop-blur sur les nav buttons pour lisibilité */
+body.intel-mode #jarvis-toggle,
+body.intel-mode #globe-toggle,
+body.intel-mode #intel-toggle,
+body.intel-mode #dashboard-nav-btn,
+body.intel-mode #settings-nav-btn {
+  background: rgba(4, 8, 20, 0.70);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+}
+
+/* ── Globe mode : laisser passer les clics vers Mapbox ──────────── */
+
+/* Dashboard (index.html) */
+body.globe-mode .layout {
+  pointer-events: none;
+}
+
+body.globe-mode .panel-left,
+body.globe-mode .panel-right {
+  pointer-events: auto;
+}
+
+/* Home (home.html) */
+body.globe-mode .home-shell {
+  pointer-events: none;
+}
+
+body.globe-mode .home-controls,
+body.globe-mode .hc-widget,
+body.globe-mode .cam-overlay {
+  pointer-events: auto;
+}
+
+/* ── Legacy floating legend (unused in globe-mode) ─────────────── */
+#globe-legend {
+  display: none;
+}
+
+#globe-tooltip {
+  position: fixed;
+  z-index: 200;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  background: rgba(6, 8, 13, 0.90);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(74, 158, 255, 0.25);
+  border-radius: 6px;
+  padding: 7px 10px;
+  font-family: 'DM Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  color: rgba(200, 218, 255, 0.85);
+  line-height: 1.55;
+  max-width: 200px;
+  white-space: nowrap;
+}
+
+#globe-tooltip.visible {
+  opacity: 1;
+}

--- a/src/jarvis/interfaces/ui/static/globe.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/globe.css.bak-1782259625
@@ -1,0 +1,677 @@
+/* ── Globe container (Mapbox GL) ────────────────────────────────── */
+#globe-container {
+  position: fixed;
+  inset: 0;
+  z-index: 2;
+  display: none;
+  opacity: 0;
+  transition: opacity 400ms ease;
+  pointer-events: none;
+}
+
+/* En mode globe : passe au-dessus de l'UI (z-index: 10 dans home.css)
+   et active les événements souris pour Mapbox */
+body.globe-mode #globe-container {
+  z-index: 15;
+  pointer-events: auto;
+}
+
+/* ── Bottom nav buttons — each independently positioned ─────────── */
+#globe-toggle {
+  position: fixed;
+  bottom: 52px;
+  left: calc(50% - 18px);
+  z-index: 9990;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+}
+
+#globe-toggle:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+
+#globe-toggle.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+
+/* ── Left panel swap — globe mode ──────────────────────────────── */
+
+/* Normal mode: left-scroll visible, globe-data-panel hidden */
+.left-scroll {
+  /* flex: 1 and overflow already set in index.html */
+  display: flex !important;
+}
+
+body.globe-mode .left-scroll {
+  display: none !important;
+}
+
+/* Globe data panel — flex child (below brand header) */
+#globe-data-panel {
+  display: none;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  flex-direction: column;
+  scrollbar-width: none;
+}
+
+#globe-data-panel::-webkit-scrollbar {
+  display: none;
+}
+
+body.globe-mode #globe-data-panel {
+  display: flex;
+}
+
+/* ── Globe data panel — header ──────────────────────────────────── */
+.gdp-header {
+  padding: 14px 18px 10px;
+  border-bottom: 1px solid rgba(var(--c-accent), 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-shrink: 0;
+}
+
+.gdp-title {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-accent), 0.55);
+}
+
+.gdp-live {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-family: 'DM Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.10em;
+  color: rgba(var(--c-accent), 0.40);
+}
+
+.gdp-live .pulse-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.55);
+  animation: gdp-pulse 2s ease-in-out infinite;
+}
+
+@keyframes gdp-pulse {
+
+  0%,
+  100% {
+    opacity: 0.5;
+    transform: scale(1);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1.35);
+  }
+}
+
+/* ── Globe data panel — sections ────────────────────────────────── */
+.gdp-section {
+  border-bottom: 1px solid rgba(var(--c-accent), 0.06);
+  flex-shrink: 0;
+}
+
+.gdp-section-hd {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 12px 18px 8px;
+}
+
+.gdp-section-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.gdp-section-label {
+  flex: 1;
+  font-family: 'DM Mono', monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(var(--c-accent), 0.45);
+}
+
+.gdp-section-count {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  color: rgba(var(--c-accent), 0.35);
+  min-width: 18px;
+  text-align: right;
+}
+
+.gdp-section-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: rgba(var(--c-accent), 0.35);
+  font-size: 9px;
+  padding: 0 0 0 4px;
+  line-height: 1;
+  transition: color 150ms ease;
+  flex-shrink: 0;
+}
+
+.gdp-section-toggle.active {
+  color: rgba(var(--c-accent), 0.8);
+}
+
+.gdp-section-toggle:hover {
+  color: #4A9EFF;
+}
+
+/* ── Globe data panel — list items ─────────────────────────────── */
+.gdp-list {
+  padding: 0 18px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-height: 32px;
+}
+
+.gdp-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 0;
+  border-bottom: 1px solid rgba(var(--c-accent), 0.04);
+  cursor: pointer;
+  transition: opacity 120ms ease;
+}
+
+.gdp-item:last-child {
+  border-bottom: none;
+}
+
+.gdp-item:hover {
+  opacity: 0.75;
+}
+
+.gdp-item-icon {
+  font-size: 11px;
+  opacity: 0.7;
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+}
+
+.gdp-item-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.gdp-item-name {
+  font-family: 'DM Mono', monospace;
+  font-size: 9.5px;
+  color: rgba(200, 218, 255, 0.70);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gdp-item-sub {
+  font-family: 'DM Mono', monospace;
+  font-size: 8px;
+  color: rgba(var(--c-accent), 0.38);
+  margin-top: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.gdp-item-badge {
+  font-family: 'DM Mono', monospace;
+  font-size: 8px;
+  color: rgba(var(--c-accent), 0.45);
+  flex-shrink: 0;
+}
+
+.gdp-empty {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  color: rgba(var(--c-accent), 0.25);
+  padding: 4px 0 6px;
+  text-align: center;
+  letter-spacing: 0.08em;
+}
+
+/* ── Flight search ──────────────────────────────────────────────── */
+.gdp-search-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 18px 10px;
+}
+
+.gdp-search-input {
+  flex: 1;
+  background: rgba(var(--c-accent), 0.05);
+  border: 1px solid rgba(var(--c-accent), 0.15);
+  border-radius: 5px;
+  padding: 5px 9px;
+  font-family: 'DM Mono', monospace;
+  font-size: 9.5px;
+  letter-spacing: 0.06em;
+  color: rgba(200, 218, 255, 0.80);
+  outline: none;
+  transition: border-color 150ms ease, background 150ms ease;
+  text-transform: uppercase;
+}
+
+.gdp-search-input::placeholder {
+  color: rgba(var(--c-accent), 0.28);
+  text-transform: none;
+}
+
+.gdp-search-input:focus {
+  border-color: rgba(var(--c-accent), 0.45);
+  background: rgba(var(--c-accent), 0.09);
+}
+
+.gdp-search-clear {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: rgba(var(--c-accent), 0.30);
+  font-size: 9px;
+  padding: 0;
+  line-height: 1;
+  transition: color 150ms ease;
+  flex-shrink: 0;
+}
+
+.gdp-search-clear:hover {
+  color: rgba(var(--c-accent), 0.75);
+}
+
+/* ── Toggle switch ───────────────────────────────────────────────── */
+.gdp-switch {
+  position: relative;
+  display: inline-flex;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.gdp-switch input {
+  display: none;
+}
+
+.gdp-switch-track {
+  width: 30px;
+  height: 16px;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  border-radius: 8px;
+  position: relative;
+  transition: background 200ms ease, border-color 200ms ease;
+}
+
+.gdp-switch-track::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.35);
+  top: 2px;
+  left: 2px;
+  transition: transform 200ms ease, background 200ms ease;
+}
+
+.gdp-switch input:checked+.gdp-switch-track {
+  background: rgba(var(--c-accent), 0.22);
+  border-color: rgba(var(--c-accent), 0.60);
+}
+
+.gdp-switch input:checked+.gdp-switch-track::after {
+  transform: translateX(14px);
+  background: #4A9EFF;
+}
+
+/* ── Switch row (label + switch) ─────────────────────────────────── */
+.gdp-switch-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 18px 10px;
+}
+
+.gdp-switch-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: rgba(var(--c-accent), 0.38);
+}
+
+/* ── Vessel status line ──────────────────────────────────────────── */
+.gdp-vessel-status {
+  font-family: 'DM Mono', monospace;
+  font-size: 8.5px;
+  letter-spacing: 0.08em;
+  color: rgba(var(--c-gold), 0.50);
+  padding: 0 18px 10px;
+}
+
+/* ── Weather grid ───────────────────────────────────────────────── */
+.gdp-weather-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 0 18px 12px;
+}
+
+.gdp-weather-cell {
+  background: rgba(var(--c-accent), 0.04);
+  border: 1px solid rgba(var(--c-accent), 0.08);
+  border-radius: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition: border-color 150ms ease, background 150ms ease;
+}
+
+.gdp-weather-cell:hover {
+  border-color: rgba(var(--c-accent), 0.20);
+  background: rgba(var(--c-accent), 0.08);
+}
+
+.gdp-weather-city {
+  font-family: 'DM Mono', monospace;
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  color: rgba(var(--c-accent), 0.40);
+  margin-bottom: 4px;
+}
+
+.gdp-weather-temp {
+  font-family: 'DM Mono', monospace;
+  font-size: 16px;
+  color: rgba(200, 218, 255, 0.80);
+  line-height: 1;
+}
+
+.gdp-weather-desc {
+  font-family: 'DM Mono', monospace;
+  font-size: 7.5px;
+  color: rgba(var(--c-accent), 0.35);
+  margin-top: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* ── Shared style pour les 5 nav buttons du bas ─────────────────── */
+#jarvis-toggle,
+#intel-toggle,
+#dashboard-nav-btn,
+#settings-nav-btn {
+  position: fixed;
+  bottom: 52px;
+  z-index: 9990;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 200ms, border-color 200ms, transform 200ms, box-shadow 200ms;
+  color: rgba(var(--c-accent), 0.6);
+  padding: 0;
+  margin: 0;
+  outline: none;
+}
+
+#jarvis-toggle:hover,
+#intel-toggle:hover,
+#dashboard-nav-btn:hover,
+#settings-nav-btn:hover {
+  background: rgba(var(--c-accent), 0.18);
+  border-color: rgba(var(--c-accent), 0.7);
+  transform: scale(1.1);
+  color: #4A9EFF;
+}
+
+#jarvis-toggle.active,
+#intel-toggle.active,
+#dashboard-nav-btn.active,
+#settings-nav-btn.active {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.8);
+  color: #4A9EFF;
+  box-shadow: 0 0 12px rgba(var(--c-accent), 0.25);
+}
+
+/* Positions — 5 boutons centrés, gap 8px (total 212px) */
+#jarvis-toggle {
+  right: calc(50% + 70px);
+}
+
+/* center 50%−88 */
+#dashboard-nav-btn {
+  right: calc(50% + 26px);
+}
+
+/* center 50%−44 */
+/* globe-toggle:  left: calc(50% - 18px)  center 50%  — own block above */
+#intel-toggle {
+  left: calc(50% + 26px);
+}
+
+/* center 50%+44 */
+#settings-nav-btn {
+  left: calc(50% + 70px);
+}
+
+/* center 50%+88 */
+
+/* ── Settings overlay (iframe plein écran) ───────────────────────── */
+#settings-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 600;
+  display: none;
+}
+
+#settings-iframe {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  border: none;
+  outline: none;
+  border-radius: 0;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── Intel overlay (iframe plein écran) ─────────────────────────── */
+#intel-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  display: none;
+  opacity: 0;
+}
+
+body.intel-mode #intel-overlay {
+  display: block;
+}
+
+#intel-iframe {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  border: none;
+  outline: none;
+  border-radius: 0;
+  margin: 0;
+  padding: 0;
+}
+
+#intel-fallback {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgb(4, 8, 20);
+}
+
+#intel-fallback.visible {
+  display: flex;
+}
+
+.intel-fallback-inner {
+  max-width: 540px;
+  padding: 40px;
+}
+
+.intel-fallback-title {
+  font-family: 'DM Mono', monospace;
+  font-size: 12px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(var(--c-accent), 0.9);
+  margin-bottom: 10px;
+}
+
+.intel-fallback-sub {
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  color: rgba(200, 218, 255, 0.55);
+  margin: 0 0 28px;
+}
+
+.intel-fallback-steps {
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  color: rgba(200, 218, 255, 0.75);
+  line-height: 1.9;
+}
+
+.intel-fallback-steps p {
+  margin: 0 0 6px;
+  color: rgba(200, 218, 255, 0.5);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.intel-fallback-steps ol {
+  padding-left: 18px;
+  margin: 0;
+}
+
+.intel-fallback-steps li {
+  margin-bottom: 12px;
+}
+
+.intel-fallback-steps code {
+  background: rgba(var(--c-accent), 0.08);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  border-radius: 3px;
+  padding: 2px 7px;
+  font-size: 10px;
+  color: rgba(var(--c-accent), 0.95);
+  display: inline-block;
+  margin-top: 3px;
+}
+
+/* intel-nav-hub supprimé — la nav principale reste visible en mode Intel */
+#intel-nav-hub {
+  display: none !important;
+}
+
+/* En mode Intel : backdrop-blur sur les nav buttons pour lisibilité */
+body.intel-mode #jarvis-toggle,
+body.intel-mode #globe-toggle,
+body.intel-mode #intel-toggle,
+body.intel-mode #dashboard-nav-btn,
+body.intel-mode #settings-nav-btn {
+  background: rgba(4, 8, 20, 0.70);
+  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(8px);
+}
+
+/* ── Globe mode : laisser passer les clics vers Mapbox ──────────── */
+
+/* Dashboard (index.html) */
+body.globe-mode .layout {
+  pointer-events: none;
+}
+
+body.globe-mode .panel-left,
+body.globe-mode .panel-right {
+  pointer-events: auto;
+}
+
+/* Home (home.html) */
+body.globe-mode .home-shell {
+  pointer-events: none;
+}
+
+body.globe-mode .home-controls,
+body.globe-mode .hc-widget,
+body.globe-mode .cam-overlay {
+  pointer-events: auto;
+}
+
+/* ── Legacy floating legend (unused in globe-mode) ─────────────── */
+#globe-legend {
+  display: none;
+}
+
+#globe-tooltip {
+  position: fixed;
+  z-index: 200;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  background: rgba(6, 8, 13, 0.90);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(var(--c-accent), 0.25);
+  border-radius: 6px;
+  padding: 7px 10px;
+  font-family: 'DM Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  color: rgba(200, 218, 255, 0.85);
+  line-height: 1.55;
+  max-width: 200px;
+  white-space: nowrap;
+}
+
+#globe-tooltip.visible {
+  opacity: 1;
+}

--- a/src/jarvis/interfaces/ui/static/home.css
+++ b/src/jarvis/interfaces/ui/static/home.css
@@ -14,21 +14,21 @@
   align-items: center;
   gap: 2px;
   padding: 5px;
-  background: rgba(12, 15, 28, 0.88);
-  border: 1px solid rgba(220, 232, 255, 0.15);
+  background: var(--bg-0);
+  border: 1px solid var(--line-3);
   border-radius: 17px;
   backdrop-filter: blur(40px) saturate(200%);
   -webkit-backdrop-filter: blur(40px) saturate(200%);
   box-shadow:
     0 24px 64px rgba(0, 0, 0, 0.75),
-    inset 0 1px 0 rgba(220, 232, 255, 0.13);
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
 }
 
 /* Séparateur vertical entre les groupes */
 .hc-sep {
   width: 1px;
   height: 22px;
-  background: rgba(220, 232, 255, 0.13);
+  background: rgba(var(--c-fg), 0.13);
   margin: 0 4px;
   flex-shrink: 0;
 }
@@ -45,7 +45,7 @@
   border-radius: 12px;
   background: transparent;
   cursor: pointer;
-  color: rgba(220, 232, 255, 0.55);
+  color: var(--accent-icon);
   transition:
     color      0.16s ease,
     background 0.16s ease,
@@ -54,8 +54,8 @@
 }
 
 .hc-btn:hover {
-  color: rgba(220, 232, 255, 0.92);
-  background: rgba(220, 232, 255, 0.09);
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
   transform: scale(1.12);
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
 }
@@ -66,14 +66,14 @@
 }
 
 .hc-btn.active {
-  color: var(--accent);
-  background: rgba(74, 158, 255, 0.14);
+  color: var(--accent-icon);
+  background: rgba(var(--c-accent), 0.14);
 }
 
 .hc-btn.active:hover {
-  background: rgba(74, 158, 255, 0.22);
+  background: rgba(var(--c-accent), 0.22);
   transform: scale(1.12);
-  box-shadow: 0 0 16px -3px rgba(74, 158, 255, 0.55);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
 }
 
 /* Micro actif : pulse lent */
@@ -81,8 +81,8 @@
   animation: hcMicPulse 2.2s ease-in-out infinite;
 }
 @keyframes hcMicPulse {
-  0%,100% { background: rgba(74, 158, 255, 0.10); box-shadow: 0 0 0 0 rgba(74,158,255,0); }
-  50%      { background: rgba(74, 158, 255, 0.20); box-shadow: 0 0 10px -2px rgba(74,158,255,0.45); }
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
 }
 
 /* ── Poignees de redimensionnement ── */
@@ -107,8 +107,8 @@
   display: block;
   width: 9px;
   height: 9px;
-  border-right: 1.5px solid rgba(220,232,255,0.30);
-  border-bottom: 1.5px solid rgba(220,232,255,0.30);
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
   border-radius: 0 0 2px 0;
 }
 
@@ -122,13 +122,13 @@
   position: fixed;
   z-index: 20;
   background: rgba(9, 12, 22, 0.92);
-  border: 1px solid rgba(220, 232, 255, 0.09);
+  border: 1px solid rgba(var(--c-fg), 0.09);
   border-radius: 14px;
   backdrop-filter: blur(24px) saturate(160%);
   -webkit-backdrop-filter: blur(24px) saturate(160%);
   box-shadow:
     0 24px 64px -16px rgba(0,0,0,.80),
-    inset 0 1px 0 rgba(220,232,255,0.06);
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
   overflow: hidden;
   pointer-events: none;
   opacity: 0;
@@ -163,7 +163,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 9px 13px 8px;
-  border-bottom: 1px solid rgba(220, 232, 255, 0.05);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
 }
 
 .hcw-hd-right {
@@ -182,27 +182,27 @@
   border-radius: 5px;
   background: transparent;
   cursor: pointer;
-  color: rgba(220, 232, 255, 0.28);
+  color: rgba(var(--c-fg), 0.28);
   padding: 0;
   transition: color 0.14s ease, background 0.14s ease;
 }
 .hcw-new-session:hover {
-  color: rgba(220, 232, 255, 0.75);
-  background: rgba(220, 232, 255, 0.07);
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
 }
 
 .hcw-eyebrow {
   font-family: var(--mono);
-  font-size: 8px;
+  font-size: 0.5rem;
   letter-spacing: 0.28em;
   text-transform: uppercase;
-  color: rgba(220, 232, 255, 0.35);
+  color: rgba(var(--c-fg), 0.35);
 }
 
 .hcw-meta {
   font-family: var(--mono);
-  font-size: 8px;
-  color: rgba(220, 232, 255, 0.22);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
   letter-spacing: 0.10em;
 }
 
@@ -221,8 +221,8 @@
   width: 40px;
   height: 40px;
   border-radius: 6px;
-  background: rgba(220, 232, 255, 0.05);
-  border: 1px solid rgba(220, 232, 255, 0.08);
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
   flex-shrink: 0;
   object-fit: cover;
   display: none;
@@ -234,9 +234,10 @@
 .hcw-track-name {
   font-family: var(--serif);
   font-weight: 300;
-  font-size: 13.5px;
+  font-size: 0.8438rem;
   letter-spacing: -0.015em;
-  color: var(--fg-0);
+  color: var(--accent);
+  filter: brightness(2);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -244,9 +245,9 @@
 
 .hcw-track-artist {
   font-family: var(--mono);
-  font-size: 9px;
+  font-size: 0.5625rem;
   letter-spacing: 0.06em;
-  color: rgba(220, 232, 255, 0.42);
+  color: rgba(var(--c-fg), 0.42);
   margin-top: 2px;
   white-space: nowrap;
   overflow: hidden;
@@ -257,7 +258,7 @@
 .hcw-progress-wrap {
   margin-top: 10px;
   height: 2px;
-  background: rgba(220, 232, 255, 0.07);
+  background: rgba(var(--c-fg), 0.07);
   border-radius: 2px;
   overflow: hidden;
 }
@@ -267,7 +268,7 @@
   border-radius: 2px;
   width: 0%;
   transition: width 1s linear;
-  box-shadow: 0 0 6px rgba(74,158,255,0.50);
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
 }
 
 /* Controls */
@@ -281,34 +282,36 @@
 
 .hcw-ctl {
   appearance: none;
-  background: rgba(220, 232, 255, 0.04);
-  border: 1px solid rgba(220, 232, 255, 0.08);
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
   border-radius: 8px;
   width: 32px; height: 32px;
   display: flex; align-items: center; justify-content: center;
   cursor: pointer;
-  color: rgba(220, 232, 255, 0.45);
+  color: rgba(var(--c-fg), 0.45);
   transition: all 0.14s ease;
   flex-shrink: 0;
 }
 
 .hcw-ctl:hover {
-  background: rgba(220, 232, 255, 0.08);
-  color: var(--fg-0);
-  border-color: rgba(220, 232, 255, 0.14);
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--accent);
+  filter: brightness(2);
+  border-color: rgba(var(--c-fg), 0.14);
 }
 
 .hcw-play {
   width: 36px; height: 36px;
-  background: rgba(74, 158, 255, 0.10);
-  border-color: rgba(74, 158, 255, 0.30);
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
   color: var(--accent);
+  filter: brightness(2);
 }
 
 .hcw-play:hover {
-  background: rgba(74, 158, 255, 0.20);
-  border-color: rgba(74, 158, 255, 0.50);
-  box-shadow: 0 0 12px -4px rgba(74,158,255,0.50);
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
 }
 
 /* Chat */
@@ -320,10 +323,10 @@
   overflow-y: auto;
   flex: 1;
   scrollbar-width: thin;
-  scrollbar-color: rgba(220, 232, 255, 0.06) transparent;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
 }
 .hcw-messages::-webkit-scrollbar { width: 3px; }
-.hcw-messages::-webkit-scrollbar-thumb { background: rgba(220,232,255,0.08); border-radius: 2px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
 
 .hcw-msg {
   display: flex;
@@ -333,28 +336,28 @@
 
 .hcw-msg-role {
   font-family: var(--mono);
-  font-size: 7.5px;
+  font-size: 0.4688rem;
   letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: rgba(220, 232, 255, 0.28);
+  color: rgba(var(--c-fg), 0.28);
 }
-.hcw-msg-role.assistant { color: rgba(74, 158, 255, 0.65); }
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
 
 .hcw-msg-text {
   font-family: var(--serif);
   font-weight: 300;
-  font-size: 12px;
-  color: rgba(220, 232, 255, 0.75);
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
   line-height: 1.5;
   letter-spacing: -0.005em;
 }
 
 .hcw-empty {
   font-family: var(--mono);
-  font-size: 9px;
+  font-size: 0.5625rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(220, 232, 255, 0.22);
+  color: rgba(var(--c-fg), 0.22);
   text-align: center;
   padding: 14px 0;
 }
@@ -365,31 +368,32 @@
   align-items: center;
   gap: 6px;
   padding: 8px 10px 10px;
-  border-top: 1px solid rgba(220, 232, 255, 0.05);
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
 }
 
 .hcw-input {
   flex: 1;
-  background: rgba(220, 232, 255, 0.04);
-  border: 1px solid rgba(220, 232, 255, 0.09);
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
   border-radius: 8px;
   padding: 6px 10px;
   font-family: var(--serif);
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 300;
-  color: var(--fg-0);
+  color: var(--accent);
+  filter: brightness(2);
   outline: none;
   transition: border-color 0.15s ease, background 0.15s ease;
 }
 
 .hcw-input::placeholder {
-  color: rgba(220, 232, 255, 0.22);
+  color: rgba(var(--c-fg), 0.22);
   font-style: italic;
 }
 
 .hcw-input:focus {
-  border-color: rgba(74, 158, 255, 0.35);
-  background: rgba(74, 158, 255, 0.05);
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
 }
 
 .hcw-send {
@@ -399,18 +403,18 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(74, 158, 255, 0.10);
-  border: 1px solid rgba(74, 158, 255, 0.28);
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
   border-radius: 8px;
   cursor: pointer;
-  color: var(--accent);
+  color: var(--accent-icon);
   transition: all 0.14s ease;
 }
 
 .hcw-send:hover {
-  background: rgba(74, 158, 255, 0.20);
-  border-color: rgba(74, 158, 255, 0.50);
-  box-shadow: 0 0 10px -4px rgba(74,158,255,0.50);
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
 }
 
 .hcw-send:active {
@@ -437,10 +441,10 @@
   border-radius: 14px;
   overflow: hidden;
   background: #000;
-  border: 1px solid rgba(220, 232, 255, 0.09);
+  border: 1px solid rgba(var(--c-fg), 0.09);
   box-shadow:
     0 24px 64px -16px rgba(0,0,0,.80),
-    inset 0 1px 0 rgba(220,232,255,0.06);
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
   pointer-events: none;
   opacity: 0;
   transform: translateY(10px) scale(0.98);
@@ -463,25 +467,25 @@
   gap: 8px;
   padding: 7px 10px;
   background: rgba(9, 12, 22, 0.90);
-  border-bottom: 1px solid rgba(220, 232, 255, 0.06);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
 }
 
 .cam-label {
   font-family: var(--mono);
-  font-size: 8px;
+  font-size: 0.5rem;
   letter-spacing: 0.30em;
   text-transform: uppercase;
-  color: rgba(220, 232, 255, 0.35);
+  color: rgba(var(--c-fg), 0.35);
 }
 
 .mp-status {
   font-family: var(--mono);
-  font-size: 8px;
+  font-size: 0.5rem;
   letter-spacing: 0.20em;
   text-transform: uppercase;
-  color: rgba(220, 232, 255, 0.30);
+  color: rgba(var(--c-fg), 0.30);
 }
 .mp-status.active { color: var(--green); }
 .mp-status.error  { color: var(--red); }
@@ -489,10 +493,11 @@
 .mp-gesture-label {
   margin-left: auto;
   font-family: var(--mono);
-  font-size: 8.5px;
+  font-size: 0.5312rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--accent);
+  filter: brightness(2);
   opacity: 0;
   transition: opacity 0.2s;
 }
@@ -605,7 +610,7 @@ body[data-mode="home"] #j-rooms-mc {
 .home-hint {
   position: fixed; bottom: 24px; right: 28px; z-index: 10;
   display: flex; align-items: center; gap: 8px;
-  font-family: var(--mono); font-size: 9.5px;
+  font-family: var(--mono); font-size: 0.5938rem;
   letter-spacing: 0.14em; text-transform: uppercase;
   color: var(--fg-4);
   pointer-events: none;
@@ -613,7 +618,7 @@ body[data-mode="home"] #j-rooms-mc {
 .home-hint kbd {
   padding: 2px 6px;
   border: 0.5px solid var(--line-2); border-radius: 4px;
-  font-family: var(--mono); font-size: 9.5px;
+  font-family: var(--mono); font-size: 0.5938rem;
   color: var(--fg-3);
 }
 

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782254922
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782254922
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: rgba(12, 15, 28, 0.88);
+  border: 1px solid rgba(220, 232, 255, 0.15);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(220, 232, 255, 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(220, 232, 255, 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(220, 232, 255, 0.55);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(220, 232, 255, 0.92);
+  background: rgba(220, 232, 255, 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  background: rgba(74, 158, 255, 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(74, 158, 255, 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(74, 158, 255, 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(74, 158, 255, 0.10); box-shadow: 0 0 0 0 rgba(74,158,255,0); }
+  50%      { background: rgba(74, 158, 255, 0.20); box-shadow: 0 0 10px -2px rgba(74,158,255,0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(220,232,255,0.30);
+  border-bottom: 1.5px solid rgba(220,232,255,0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(220, 232, 255, 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(220,232,255,0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(220, 232, 255, 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(220, 232, 255, 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(220, 232, 255, 0.75);
+  background: rgba(220, 232, 255, 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(220, 232, 255, 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 8px;
+  color: rgba(220, 232, 255, 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(220, 232, 255, 0.05);
+  border: 1px solid rgba(220, 232, 255, 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 13.5px;
+  letter-spacing: -0.015em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  color: rgba(220, 232, 255, 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(220, 232, 255, 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(74,158,255,0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(220, 232, 255, 0.04);
+  border: 1px solid rgba(220, 232, 255, 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(220, 232, 255, 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(220, 232, 255, 0.08);
+  color: var(--fg-0);
+  border-color: rgba(220, 232, 255, 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(74, 158, 255, 0.10);
+  border-color: rgba(74, 158, 255, 0.30);
+  color: var(--accent);
+}
+
+.hcw-play:hover {
+  background: rgba(74, 158, 255, 0.20);
+  border-color: rgba(74, 158, 255, 0.50);
+  box-shadow: 0 0 12px -4px rgba(74,158,255,0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(220, 232, 255, 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(220,232,255,0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 7.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(220, 232, 255, 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(74, 158, 255, 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 12px;
+  color: rgba(220, 232, 255, 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(220, 232, 255, 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(220, 232, 255, 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(220, 232, 255, 0.04);
+  border: 1px solid rgba(220, 232, 255, 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 12px;
+  font-weight: 300;
+  color: var(--fg-0);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(220, 232, 255, 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(74, 158, 255, 0.35);
+  background: rgba(74, 158, 255, 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(74, 158, 255, 0.10);
+  border: 1px solid rgba(74, 158, 255, 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(74, 158, 255, 0.20);
+  border-color: rgba(74, 158, 255, 0.50);
+  box-shadow: 0 0 10px -4px rgba(74,158,255,0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(220, 232, 255, 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(220,232,255,0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(220, 232, 255, 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(220, 232, 255, 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(220, 232, 255, 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 8.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782259625
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: rgba(12, 15, 28, 0.88);
+  border: 1px solid rgba(var(--c-fg), 0.15);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.55);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 8px;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 13.5px;
+  letter-spacing: -0.015em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--fg-0);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 7.5px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 12px;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 12px;
+  font-weight: 300;
+  color: var(--fg-0);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 8px;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 8.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782260738
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782260738
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: rgba(12, 15, 28, 0.88);
+  border: 1px solid rgba(var(--c-fg), 0.15);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.55);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--fg-0);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--fg-0);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782260744
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782260744
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.55);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--fg-0);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--fg-0);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782260805
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782260805
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--accent-soft);
+  border: 1px solid var(--accent-line);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--accent);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--fg-0);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--fg-0);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782260854
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782260854
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: rgba(var(--c-accent), 0.07);
+  border: 1px solid var(--accent-line);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--accent);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--fg-0);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--fg-0);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782260919
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782260919
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: rgba(var(--c-accent), 0.03);
+  border: 1px solid var(--accent-line);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--accent);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--fg-0);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--fg-0);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782261035
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782261035
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--accent-line);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--accent);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--fg-0);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--fg-0);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782261075
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782261075
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-2);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--fg-2);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--fg-2);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--fg-0);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--fg-2);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--fg-0);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--fg-2);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-2);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782261105
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782261105
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-3);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--fg-0);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--fg-0);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--fg-0);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--fg-0);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--fg-0);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--fg-0);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--fg-0);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-0);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782261316
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782261316
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-3);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--fg-1);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--fg-1);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--fg-1);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--fg-1);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--fg-1);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--fg-1);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--fg-1);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-1);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782261426
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782261426
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-3);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--accent);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--accent);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--accent);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782261598
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782261598
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-3);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-accent), 0.65);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: rgba(var(--c-accent), 0.65);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: rgba(var(--c-accent), 0.65);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: rgba(var(--c-accent), 0.65);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: rgba(var(--c-accent), 0.65);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: rgba(var(--c-accent), 0.65);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: rgba(var(--c-accent), 0.65);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(var(--c-accent), 0.65);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782261679
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782261679
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-3);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--accent);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--accent);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--accent);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782261730
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782261730
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-3);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: color-mix(in srgb, var(--accent) 70%, white 30%);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: color-mix(in srgb, var(--accent) 70%, white 30%);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: color-mix(in srgb, var(--accent) 70%, white 30%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: color-mix(in srgb, var(--accent) 70%, white 30%);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: color-mix(in srgb, var(--accent) 70%, white 30%);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: color-mix(in srgb, var(--accent) 70%, white 30%);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: color-mix(in srgb, var(--accent) 70%, white 30%);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--accent) 70%, white 30%);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782261759
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782261759
@@ -1,0 +1,676 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-3);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: color-mix(in srgb, var(--accent) 85%, white 15%);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: color-mix(in srgb, var(--accent) 85%, white 15%);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: color-mix(in srgb, var(--accent) 85%, white 15%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: color-mix(in srgb, var(--accent) 85%, white 15%);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: color-mix(in srgb, var(--accent) 85%, white 15%);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: color-mix(in srgb, var(--accent) 85%, white 15%);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: color-mix(in srgb, var(--accent) 85%, white 15%);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--accent) 85%, white 15%);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782261906
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782261906
@@ -1,0 +1,684 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-3);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--accent);
+  opacity: 0.8;
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  opacity: 0.8;
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--accent);
+  opacity: 0.8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--accent);
+  opacity: 0.8;
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+  opacity: 0.8;
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--accent);
+  opacity: 0.8;
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  opacity: 0.8;
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0.8;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.css.bak-1782262198
+++ b/src/jarvis/interfaces/ui/static/home.css.bak-1782262198
@@ -1,0 +1,684 @@
+/* home.css — page Home (sphère Three.js + présence ambient) */
+
+/* ── Home Controls ── */
+.home-controls {
+  pointer-events: auto;
+  padding: 22px 24px;
+  transform-origin: top left;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* Pill unique — verre dépoli macOS renforcé */
+.hc-pill {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 5px;
+  background: var(--bg-0);
+  border: 1px solid var(--line-3);
+  border-radius: 17px;
+  backdrop-filter: blur(40px) saturate(200%);
+  -webkit-backdrop-filter: blur(40px) saturate(200%);
+  box-shadow:
+    0 24px 64px rgba(0, 0, 0, 0.75),
+    inset 0 1px 0 rgba(var(--c-fg), 0.13);
+}
+
+/* Séparateur vertical entre les groupes */
+.hc-sep {
+  width: 1px;
+  height: 22px;
+  background: rgba(var(--c-fg), 0.13);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+/* Bouton icone — compact, sans bordure */
+.hc-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: none;
+  border-radius: 12px;
+  background: transparent;
+  cursor: pointer;
+  color: var(--accent);
+  filter: brightness(2);
+  transition:
+    color      0.16s ease,
+    background 0.16s ease,
+    transform  0.20s cubic-bezier(.2,.8,.25,1),
+    box-shadow 0.16s ease;
+}
+
+.hc-btn:hover {
+  color: rgba(var(--c-fg), 0.92);
+  background: rgba(var(--c-fg), 0.09);
+  transform: scale(1.12);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+}
+
+.hc-btn:active {
+  transform: scale(0.90);
+  transition-duration: 0.08s;
+}
+
+.hc-btn.active {
+  color: var(--accent);
+  filter: brightness(2);
+  background: rgba(var(--c-accent), 0.14);
+}
+
+.hc-btn.active:hover {
+  background: rgba(var(--c-accent), 0.22);
+  transform: scale(1.12);
+  box-shadow: 0 0 16px -3px rgba(var(--c-accent), 0.55);
+}
+
+/* Micro actif : pulse lent */
+#hc-mic.active {
+  animation: hcMicPulse 2.2s ease-in-out infinite;
+}
+@keyframes hcMicPulse {
+  0%,100% { background: rgba(var(--c-accent), 0.10); box-shadow: 0 0 0 0 rgba(var(--c-accent), 0); }
+  50%      { background: rgba(var(--c-accent), 0.20); box-shadow: 0 0 10px -2px rgba(var(--c-accent), 0.45); }
+}
+
+/* ── Poignees de redimensionnement ── */
+.hcw-resize-handle {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 22px;
+  height: 22px;
+  cursor: se-resize;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: 5px;
+}
+
+.hcw-resize-handle::before {
+  content: '';
+  display: block;
+  width: 9px;
+  height: 9px;
+  border-right: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-bottom: 1.5px solid rgba(var(--c-fg), 0.30);
+  border-radius: 0 0 2px 0;
+}
+
+.hc-widget:hover .hcw-resize-handle,
+.cam-overlay:hover .hcw-resize-handle {
+  opacity: 1;
+}
+
+/* ── Widgets flottants (commune) ── */
+.hc-widget {
+  position: fixed;
+  z-index: 20;
+  background: rgba(9, 12, 22, 0.92);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 14px;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+}
+
+.hc-widget.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.hc-widget--music {
+  bottom: 88px;
+  left: 32px;
+  width: 232px;
+}
+
+.hc-widget--chat {
+  bottom: 88px;
+  left: 290px;
+  width: 292px;
+  display: flex;
+  flex-direction: column;
+  min-height: 200px;
+}
+
+/* Header widget */
+.hcw-hd {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 13px 8px;
+  border-bottom: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-hd-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hcw-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.28);
+  padding: 0;
+  transition: color 0.14s ease, background 0.14s ease;
+}
+.hcw-new-session:hover {
+  color: rgba(var(--c-fg), 0.75);
+  background: rgba(var(--c-fg), 0.07);
+}
+
+.hcw-eyebrow {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.hcw-meta {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  color: rgba(var(--c-fg), 0.22);
+  letter-spacing: 0.10em;
+}
+
+.hcw-body {
+  padding: 12px 13px;
+}
+
+/* Music: album art + track info */
+.hcw-music-top {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.hcw-album-art {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: none;
+}
+.hcw-album-art.loaded { display: block; }
+
+.hcw-music-info { min-width: 0; flex: 1; }
+
+.hcw-track-name {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.8438rem;
+  letter-spacing: -0.015em;
+  color: var(--accent);
+  filter: brightness(2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hcw-track-artist {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.06em;
+  color: rgba(var(--c-fg), 0.42);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Progress bar */
+.hcw-progress-wrap {
+  margin-top: 10px;
+  height: 2px;
+  background: rgba(var(--c-fg), 0.07);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.hcw-progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  width: 0%;
+  transition: width 1s linear;
+  box-shadow: 0 0 6px rgba(var(--c-accent), 0.50);
+}
+
+/* Controls */
+.hcw-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.hcw-ctl {
+  appearance: none;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.08);
+  border-radius: 8px;
+  width: 32px; height: 32px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  color: rgba(var(--c-fg), 0.45);
+  transition: all 0.14s ease;
+  flex-shrink: 0;
+}
+
+.hcw-ctl:hover {
+  background: rgba(var(--c-fg), 0.08);
+  color: var(--accent);
+  filter: brightness(2);
+  border-color: rgba(var(--c-fg), 0.14);
+}
+
+.hcw-play {
+  width: 36px; height: 36px;
+  background: rgba(var(--c-accent), 0.10);
+  border-color: rgba(var(--c-accent), 0.30);
+  color: var(--accent);
+  filter: brightness(2);
+}
+
+.hcw-play:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 12px -4px rgba(var(--c-accent), 0.50);
+}
+
+/* Chat */
+.hcw-messages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  flex: 1;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.06) transparent;
+}
+.hcw-messages::-webkit-scrollbar { width: 3px; }
+.hcw-messages::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 2px; }
+
+.hcw-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.hcw-msg-role {
+  font-family: var(--mono);
+  font-size: 0.4688rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.28);
+}
+.hcw-msg-role.assistant { color: rgba(var(--c-accent), 0.65); }
+
+.hcw-msg-text {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 0.75rem;
+  color: rgba(var(--c-fg), 0.75);
+  line-height: 1.5;
+  letter-spacing: -0.005em;
+}
+
+.hcw-empty {
+  font-family: var(--mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.22);
+  text-align: center;
+  padding: 14px 0;
+}
+
+/* Chat input */
+.hcw-input-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border-top: 1px solid rgba(var(--c-fg), 0.05);
+}
+
+.hcw-input {
+  flex: 1;
+  background: rgba(var(--c-fg), 0.04);
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-family: var(--serif);
+  font-size: 0.75rem;
+  font-weight: 300;
+  color: var(--accent);
+  filter: brightness(2);
+  outline: none;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.hcw-input::placeholder {
+  color: rgba(var(--c-fg), 0.22);
+  font-style: italic;
+}
+
+.hcw-input:focus {
+  border-color: rgba(var(--c-accent), 0.35);
+  background: rgba(var(--c-accent), 0.05);
+}
+
+.hcw-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.28);
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--accent);
+  filter: brightness(2);
+  transition: all 0.14s ease;
+}
+
+.hcw-send:hover {
+  background: rgba(var(--c-accent), 0.20);
+  border-color: rgba(var(--c-accent), 0.50);
+  box-shadow: 0 0 10px -4px rgba(var(--c-accent), 0.50);
+}
+
+.hcw-send:active {
+  transform: scale(0.93);
+}
+
+.hcw-send:disabled {
+  opacity: 0.35;
+  cursor: default;
+  pointer-events: none;
+}
+
+.hcw-widget--chat {
+  min-height: unset;
+}
+
+/* ── Overlay caméra ── */
+.cam-overlay {
+  position: fixed;
+  bottom: 88px;
+  right: 32px;
+  z-index: 20;
+  width: 300px;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid rgba(var(--c-fg), 0.09);
+  box-shadow:
+    0 24px 64px -16px rgba(0,0,0,.80),
+    inset 0 1px 0 rgba(var(--c-fg), 0.06);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(10px) scale(0.98);
+  transition: opacity 0.22s ease, transform 0.22s cubic-bezier(.2,.8,.25,1);
+  cursor: grab;
+}
+
+.cam-overlay.is-open {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.cam-overlay.dragging { cursor: grabbing; transition: none; }
+
+.cam-topbar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: rgba(9, 12, 22, 0.90);
+  border-bottom: 1px solid rgba(var(--c-fg), 0.06);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+.cam-label {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.30em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+.mp-status {
+  font-family: var(--mono);
+  font-size: 0.5rem;
+  letter-spacing: 0.20em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.30);
+}
+.mp-status.active { color: var(--green); }
+.mp-status.error  { color: var(--red); }
+
+.mp-gesture-label {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 0.5312rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  filter: brightness(2);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.mp-gesture-label.triggered { color: var(--green); }
+
+.cam-feed {
+  position: relative;
+  aspect-ratio: 4/3;
+  background: #000;
+}
+
+#cam-video {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1); /* miroir */
+  display: block;
+}
+
+#cam-canvas {
+  position: absolute; inset: 0;
+  width: 100%; height: 100%;
+  pointer-events: none;
+  transform: scaleX(-1);
+}
+
+/* Widgets draggables */
+.hc-widget.dragging,
+.cam-overlay.dragging {
+  transition: none;
+  user-select: none;
+}
+
+
+
+body[data-mode="home"] {
+  overflow: hidden;
+}
+
+/* ── Page frame (iframe shell) ── */
+.page-frame {
+  position: fixed;
+  inset: 0;
+  z-index: 4;           /* au-dessus du home-shell (3) */
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: var(--bg, #08090f);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+.page-frame.is-active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* Les widgets flottants passent au-dessus de l'iframe */
+.hc-widget,
+.cam-overlay,
+.home-shell {
+  z-index: 10;
+}
+
+/* Canvas orb — fullscreen behind UI */
+.home-orb-wrap {
+  position: fixed;
+  inset: 0;
+  z-index: 1;       /* below .atmo grain/vignette (z-index:2) */
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.4s ease;
+}
+.home-orb-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 38% 38% at 50% 50%,
+    rgba(40, 100, 255, 0.22) 0%,
+    rgba(20, 60, 200, 0.08) 50%,
+    transparent 100%
+  );
+  pointer-events: none;
+}
+#orb-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: auto;   /* canvas receives drag + wheel */
+}
+
+/* ── Topbar home — pas de sidebar ── */
+body[data-mode="home"] .app {
+  display: block;
+}
+
+/* Rooms nav masqué en home (pas de sous-pages) */
+body[data-mode="home"] #j-rooms-pages { display: none; }
+
+/* Rooms chapter en home : position différente */
+body[data-mode="home"] #j-rooms-chapter { display: none; }
+
+/* Mission Control trigger */
+body[data-mode="home"] #j-rooms-mc {
+  bottom: 28px; left: 28px;
+}
+
+/* ⌘K shortcut hint bottom-right */
+.home-hint {
+  position: fixed; bottom: 24px; right: 28px; z-index: 10;
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-4);
+  pointer-events: none;
+}
+.home-hint kbd {
+  padding: 2px 6px;
+  border: 0.5px solid var(--line-2); border-radius: 4px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  color: var(--fg-3);
+}
+
+/* Status dot animations */
+.status-dot.blue   { animation: pulseBlue   2.4s ease-in-out infinite; }
+.status-dot.purple { animation: pulsePurple 1.8s ease-in-out infinite; }
+.status-dot.green  { animation: pulseGreen  2s   ease-in-out infinite; }
+
+@keyframes pulseBlue {
+  0%,100% { box-shadow: 0 0 6px var(--accent);  opacity: 1; }
+  50%      { box-shadow: 0 0 14px var(--accent); opacity: 0.7; }
+}
+@keyframes pulsePurple {
+  0%,100% { box-shadow: 0 0 6px var(--purple);  opacity: 1; }
+  50%      { box-shadow: 0 0 16px var(--purple); opacity: 0.7; }
+}
+@keyframes pulseGreen {
+  0%,100% { box-shadow: 0 0 6px var(--green);  opacity: 1; }
+  50%      { box-shadow: 0 0 12px var(--green); opacity: 0.7; }
+}
+
+/* home-shell overlays the canvas, spans full viewport */
+.home-shell {
+  position: fixed;
+  inset: 0;
+  z-index: 3;             /* above canvas (1) and atmo (2) */
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;   /* transparent by default */
+  animation: homeIn .6s cubic-bezier(.2,.8,.25,1) both;
+}
+/* Re-enable events only on interactive zones */
+.home-top,
+.home-channel {
+  pointer-events: auto;
+}
+@keyframes homeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Channel animation */
+.home-channel { animation: channelIn .5s .3s cubic-bezier(.2,.8,.25,1) both; }
+@keyframes channelIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Signature top-right ── */
+.home-signature {
+  transform-origin: top right;
+  transition: transform 0.35s cubic-bezier(.2,.8,.25,1);
+}
+
+/* ── Vue active : source de vérité unique ── */
+body.view-active .home-orb-wrap  { opacity: 0; }
+body.view-active #orb-canvas     { pointer-events: none; }   /* le canvas a pointer-events:auto explicite, la règle sur le parent ne suffit pas */
+body.view-active .home-controls  { transform: scale(0.6); }
+body.view-active .home-signature { transform: scale(0.6); }

--- a/src/jarvis/interfaces/ui/static/home.html
+++ b/src/jarvis/interfaces/ui/static/home.html
@@ -9,6 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
 <link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
 <link rel="stylesheet" href="/home.css" />
 <!-- globe.css chargé dynamiquement si le skill globe-view est installé -->
 </head>
@@ -27,7 +28,7 @@
       <div class="hc-pill">
 
         <button class="hc-btn" id="hc-mic" data-key="mic" title="Microphone">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
             <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/>
             <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
             <line x1="12" y1="19" x2="12" y2="22"/>
@@ -35,20 +36,20 @@
           </svg>
         </button>
         <button class="hc-btn" id="hc-screen" data-key="screen" title="Capture d'&#233;cran">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
             <rect x="2" y="3" width="20" height="14" rx="2"/>
             <path d="M8 21h8"/>
             <line x1="12" y1="17" x2="12" y2="21"/>
           </svg>
         </button>
         <button class="hc-btn" id="hc-cam" data-key="cam" title="Cam&#233;ra">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
             <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3L14.5 4z"/>
             <circle cx="12" cy="13" r="3"/>
           </svg>
         </button>
         <button class="hc-btn" id="hc-files" data-key="files" title="Acc&#232;s fichiers">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
             <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
           </svg>
         </button>
@@ -56,14 +57,14 @@
         <div class="hc-sep"></div>
 
         <button class="hc-btn" id="hc-music" data-key="music" title="Musique">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
             <path d="M9 18V5l12-2v13"/>
             <circle cx="6" cy="18" r="3"/>
             <circle cx="18" cy="16" r="3"/>
           </svg>
         </button>
         <button class="hc-btn" id="hc-chat" data-key="chat" title="Chat">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
           </svg>
         </button>
@@ -174,7 +175,7 @@
     <div class="msg" id="channel-msg"></div>
     <div class="meta">
       <span id="channel-time"></span>
-      <a id="channel-cta" href="/dashboard">OUVRIR &#8594;</a>
+      <a id="channel-cta" href="/mc#workspace">OUVRIR &#8594;</a>
     </div>
   </div>
 </div>
@@ -184,6 +185,7 @@
 
 <script src="/three.min.js"></script>
 <script src="/_shared.js"></script>
+<script src="/mission_control.js"></script>
 <script src="/gesture_router.js"></script>
 <script src="/config/sphereStyle.js"></script>
 <script src="/orb.js"></script>

--- a/src/jarvis/interfaces/ui/static/home.html.bak-1782249020
+++ b/src/jarvis/interfaces/ui/static/home.html.bak-1782249020
@@ -1,0 +1,382 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/home.css" />
+<!-- globe.css chargé dynamiquement si le skill globe-view est installé -->
+</head>
+<body data-mode="home">
+
+<iframe id="page-frame" class="page-frame" src="about:blank" frameborder="0" allowfullscreen></iframe>
+
+<div class="home-shell" id="home-shell">
+  <!-- Top bar -->
+  <div class="home-top">
+    <div class="home-controls" id="home-controls">
+
+      <span id="status-dot" style="display:none"></span>
+      <span id="status-label" style="display:none"></span>
+
+      <div class="hc-pill">
+
+        <button class="hc-btn" id="hc-mic" data-key="mic" title="Microphone">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/>
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+            <line x1="12" y1="19" x2="12" y2="22"/>
+            <line x1="8" y1="22" x2="16" y2="22"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-screen" data-key="screen" title="Capture d'&#233;cran">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2"/>
+            <path d="M8 21h8"/>
+            <line x1="12" y1="17" x2="12" y2="21"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-cam" data-key="cam" title="Cam&#233;ra">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3L14.5 4z"/>
+            <circle cx="12" cy="13" r="3"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-files" data-key="files" title="Acc&#232;s fichiers">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+          </svg>
+        </button>
+
+        <div class="hc-sep"></div>
+
+        <button class="hc-btn" id="hc-music" data-key="music" title="Musique">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 18V5l12-2v13"/>
+            <circle cx="6" cy="18" r="3"/>
+            <circle cx="18" cy="16" r="3"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-chat" data-key="chat" title="Chat">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+          </svg>
+        </button>
+
+      </div>
+
+    </div>
+    <div class="home-signature">
+      <div class="brand">JARVIS</div>
+      <div class="clock-row">
+        <div class="clock" id="home-clock">00:00</div>
+      </div>
+      <div class="date" id="home-date"></div>
+    </div>
+  </div>
+
+  <!-- Three.js canvas -->
+  <div class="home-orb-wrap">
+    <canvas id="orb-canvas"></canvas>
+  </div>
+
+  <!-- Overlay camera (MediaPipe vision) -->
+  <div class="cam-overlay" id="cam-overlay">
+    <div class="cam-inner" id="cam-drag-handle">
+      <div class="cam-topbar">
+        <span class="cam-label">VISION</span>
+        <span id="mp-status" class="mp-status"></span>
+        <span id="mp-gesture-label" class="mp-gesture-label"></span>
+      </div>
+      <div class="cam-feed">
+        <video id="cam-video" autoplay muted playsinline></video>
+        <canvas id="cam-canvas"></canvas>
+      </div>
+    </div>
+    <div class="hcw-resize-handle" id="cam-resize-handle"></div>
+  </div>
+
+  <!-- Widget : Musique -->
+  <div class="hc-widget hc-widget--music" id="hc-widget-music">
+    <div class="hcw-hd">
+      <span class="hcw-eyebrow">En &#233;coute</span>
+      <span class="hcw-meta" id="hcw-music-source">&#8212;</span>
+    </div>
+    <div class="hcw-body">
+      <div class="hcw-music-top">
+        <img class="hcw-album-art" id="hcw-album-art" alt=""/>
+        <div class="hcw-music-info">
+          <div class="hcw-track-name" id="hcw-music-track">Aucune lecture</div>
+          <div class="hcw-track-artist" id="hcw-music-artist">&#8212;</div>
+        </div>
+      </div>
+      <div class="hcw-progress-wrap">
+        <div class="hcw-progress-fill" id="hcw-progress-fill"></div>
+      </div>
+      <div class="hcw-controls">
+        <button class="hcw-ctl" id="hcw-prev" title="Pr&#233;c&#233;dent">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="2" y1="1.5" x2="2" y2="10.5"/>
+            <path d="M10 1.5L4 6L10 10.5V1.5Z"/>
+          </svg>
+        </button>
+        <button class="hcw-ctl hcw-play" id="hcw-play" title="Lecture / Pause">
+          <svg width="14" height="14" viewBox="0 0 14 14" id="hcw-play-icon">
+            <path fill="currentColor" d="M3 2l9 5-9 5V2z"/>
+          </svg>
+        </button>
+        <button class="hcw-ctl" id="hcw-next" title="Suivant">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="10" y1="1.5" x2="10" y2="10.5"/>
+            <path d="M2 1.5L8 6L2 10.5V1.5Z"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hcw-resize-handle" id="music-resize-handle"></div>
+  </div>
+
+  <!-- Widget : Chat -->
+  <div class="hc-widget hc-widget--chat" id="hc-widget-chat">
+    <div class="hcw-hd">
+      <span class="hcw-eyebrow">Conversation</span>
+      <div class="hcw-hd-right">
+        <span class="hcw-meta" id="hcw-chat-count">&#8212;</span>
+        <button class="hcw-new-session" id="hcw-new-session" title="Nouvelle session">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+            <line x1="12" y1="5" x2="12" y2="19"/>
+            <line x1="5" y1="12" x2="19" y2="12"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hcw-body hcw-messages" id="hcw-chat-msgs">
+      <div class="hcw-empty">Aucun message</div>
+    </div>
+    <div class="hcw-input-row" id="hcw-input-row">
+      <input class="hcw-input" id="hcw-input" type="text" placeholder="&#201;crire &#224; Jarvis&#8230;" autocomplete="off" />
+      <button class="hcw-send" id="hcw-send" title="Envoyer">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 7H2M7 2l5 5-5 5"/>
+        </svg>
+      </button>
+    </div>
+    <div class="hcw-resize-handle" id="chat-resize-handle"></div>
+  </div>
+
+  <!-- Canal passif (dernier message Jarvis) -->
+  <div class="home-channel" id="home-channel" style="display:none">
+    <div class="msg" id="channel-msg"></div>
+    <div class="meta">
+      <span id="channel-time"></span>
+      <a id="channel-cta" href="/dashboard">OUVRIR &#8594;</a>
+    </div>
+  </div>
+</div>
+
+<!-- View layer — vues plein-écran enregistrées via Jarvis.views -->
+<div id="globe-container"></div>
+
+<script src="/three.min.js"></script>
+<script src="/_shared.js"></script>
+<script src="/gesture_router.js"></script>
+<script src="/config/sphereStyle.js"></script>
+<script src="/orb.js"></script>
+<script src="/wake_sequence.js"></script>
+<script>
+// ── Cold boot — étape 1 : flag AVANT home.js + masque la shell ─────────
+// Comportement par défaut : sleep screen, clap double pour wake.
+// ?wake=0 → skip tout (dashboard direct, pour dev)
+// ?wake=1 → bypass sleep, wake immédiat (pour dev sans micro)
+(function () {
+  const params = new URLSearchParams(location.search);
+  const mode   = params.get('wake');
+  if (mode === '0') return;             // skip total (dev)
+  // WAKEUP_ENABLED=false → accès direct au dashboard, aucune séquence de veille.
+  // Sans ce garde-fou, sur une install sans micro (VPS/headless) l'écran
+  // « double clap pour réveiller » bloque tout accès (le seul déclencheur est
+  // le clap, désactivé). ?wake=1 force quand même la séquence (dev).
+  if (mode !== '1' && window.JARVIS_WAKEUP_ENABLED === false) return;
+  window.__jarvisWakeActive = true;
+  window.__jarvisWakeForceImmediate = (mode === '1');
+  // Cache TOUT le chrome dashboard sauf l'orbe (le wake utilise #orb-canvas).
+  // Cible les éléments un-à-un pour ne pas masquer .home-orb-wrap qui est
+  // dans #home-shell. Inclut les éléments appendChild'és sur document.body
+  // par _shared.js (Mission Control, watermark, rooms nav, etc.).
+  const css = document.createElement('style');
+  css.id = 'wake-shell-hider';
+  css.textContent = ''
+    + '.home-top, .cam-overlay, .hc-widget, .home-channel,'
+    + ' .rooms-mc, .rooms-pages, .mode-watermark, .scene-card,'
+    + ' .mission-overlay, .cmdk-root, .notif-stack, .inspect-hint,'
+    + ' .mode-glow, #globe-container, #page-frame {'
+    + ' opacity: 0 !important; pointer-events: none !important;'
+    + ' transition: opacity 0.4s cubic-bezier(0.32,0.72,0,1); }';
+  document.head.appendChild(css);
+}());
+</script>
+<!-- Voix : pipeline temps réel LiveKit (remplace l'ancien voice.js in-house). -->
+<script src="https://cdn.jsdelivr.net/npm/livekit-client/dist/livekit-client.umd.min.js"></script>
+<script src="/voice_livekit.js"></script>
+<script src="/mediapipe_vision.js"></script>
+<script src="/home.js"></script>
+<script>
+// ── Cold boot — étape 2 : sleep screen → clap → wake_sequence ─────────
+// Cycle complet :
+//   1. À l'arrivée : sleep screen (z-index 9500, sleep visible)
+//   2. CustomEvent 'jarvis-wake' (clap backend OU window.triggerWake() dev)
+//      → fade out sleep, mount wake_sequence
+//   3a. wake_sequence onComplete : inject orb dashboard, fade in shell
+//   3b. wake_sequence onFailure (FACE refusée) : destroy wake, re-mount sleep
+(function () {
+  if (!window.__jarvisWakeActive) return;
+  if (typeof window.createWakeSequence !== 'function' ||
+      typeof window.createSleepScreen  !== 'function') return;
+
+  let sleep = null;
+  let seq   = null;
+  // Prénom configuré (USER_FIRSTNAME) — récupéré tôt, fire-and-forget, pour que
+  // mountWake() reste synchrone (le crossfade sleep/wake ne tolère aucun délai).
+  // Repli sur '' (le wake n'affiche alors aucun nom).
+  let _userName = '';
+  fetch('/api/wakeup/status', { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} })
+    .then(function (r) { return r.json(); })
+    .then(function (s) { _userName = (s && s.user_firstname) || ''; })
+    .catch(function () {});
+
+  function mountSleep() {
+    const sleepRoot = document.createElement('div');
+    sleepRoot.id = 'wake-sleep-root';
+    document.body.appendChild(sleepRoot);
+    sleep = window.createSleepScreen(sleepRoot, { onWake: enterWake });
+  }
+
+  function enterWake() {
+    if (!sleep) return;
+    const oldSleep = sleep;
+    sleep = null;
+    // Fade out sleep + mount wake en parallèle (crossfade)
+    // Sleep fade 200ms (court) — le wake est mounté INSTANTANÉMENT en-dessous,
+    // donc dès que le sleep s'efface, le wake est déjà entièrement rendu.
+    // Pas de zone de transparence pendant laquelle on verrait juste le bg sombre.
+    oldSleep.fadeOut(200, function () { oldSleep.destroy(); });
+    mountWake();
+  }
+
+  function mountWake() {
+    const root = document.createElement('div');
+    root.id = 'wake-cold-boot-root';
+    // Mount INSTANT (pas de fade-in) : le sleep par-dessus gère le crossfade.
+    // Comme ça il n'y a jamais un moment où ni sleep ni wake n'est entièrement
+    // rendu, donc pas de moment où on voit le fond noir.
+    document.body.appendChild(root);
+
+    seq = window.createWakeSequence(root, {
+      userName:     _userName,
+      // Scan facial cinématique toujours actif quand la séquence de veille tourne.
+      // FACE_RECOGNITION_ENABLED ne gate PAS l'affichage : le backend auto-valide
+      // (recognized:true) si la reconnaissance est off, et l'absence de caméra est
+      // gérée à l'exécution (dérogation). Le no-veille se règle via WAKEUP_ENABLED.
+      requireFace:  true,
+      targetCanvas: document.getElementById('orb-canvas'),
+      onComplete:   onWakeComplete,
+      onFailure:    onWakeFailure,
+    });
+
+    if (!seq) onWakeFailure();
+  }
+
+  function onWakeComplete() {
+    window.__jarvisWakeActive = false;
+    if (typeof window.__jarvisInjectOrb === 'function' && seq && seq.getOrb) {
+      window.__jarvisInjectOrb(seq.getOrb());
+    }
+    // Shell + chrome via transition opacité 0→1 (mêmes cibles que le masquage)
+    const hider = document.getElementById('wake-shell-hider');
+    if (hider) {
+      hider.textContent = ''
+        + '.home-top, .cam-overlay, .hc-widget, .home-channel,'
+        + ' .rooms-mc, .rooms-pages, .mode-watermark, .scene-card,'
+        + ' .mission-overlay, .cmdk-root, .notif-stack, .inspect-hint,'
+        + ' #globe-container, #page-frame {'
+        + ' opacity: 1; transition: opacity 0.4s cubic-bezier(0.32,0.72,0,1); }';
+      setTimeout(function () { if (hider.parentNode) hider.parentNode.removeChild(hider); }, 450);
+    }
+    // Fade out overlay wake (UI uniquement, l'orbe reste sur #orb-canvas)
+    const r = document.getElementById('wake-cold-boot-root');
+    if (r) {
+      r.style.transition = 'opacity 0.35s cubic-bezier(0.32,0.72,0,1)';
+      r.style.opacity = '0';
+      setTimeout(function () {
+        try { seq.destroy(); } catch (e) {}
+        seq = null;
+        if (r.parentNode) r.parentNode.removeChild(r);
+      }, 400);
+    }
+  }
+
+  function onWakeFailure() {
+    // BLOCAGE accès. Détruit wake (et l'orbe partagé pour libérer canvas),
+    // re-monte le sleep screen.
+    const orbRef = seq && seq.getOrb ? seq.getOrb() : null;
+    const r = document.getElementById('wake-cold-boot-root');
+    if (r) {
+      r.style.transition = 'opacity 0.35s cubic-bezier(0.32,0.72,0,1)';
+      r.style.opacity = '0';
+      setTimeout(function () {
+        try { if (seq) seq.destroy(); } catch (e) {}
+        try { if (orbRef && orbRef.destroy) orbRef.destroy(); } catch (e) {}
+        seq = null;
+        if (r.parentNode) r.parentNode.removeChild(r);
+        mountSleep();
+      }, 400);
+    } else {
+      try { if (seq) seq.destroy(); } catch (e) {}
+      seq = null;
+      mountSleep();
+    }
+  }
+
+  // Lancement
+  if (window.__jarvisWakeForceImmediate) {
+    mountWake();   // ?wake=1 : bypass sleep
+  } else {
+    mountSleep(); // défaut : attente clap
+  }
+})();
+</script>
+<script>
+window.loadViewSkills = async function () {
+  try {
+    const r = await fetch('/api/skills/view-scripts', { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} });
+    if (!r.ok) return;
+    const { styles = [], scripts = [] } = await r.json();
+
+    // Retire les anciens assets de vues (data-view-skill="1")
+    document.querySelectorAll('[data-view-skill]').forEach(el => el.remove());
+
+    styles.forEach(href => {
+      const l = document.createElement('link');
+      l.rel = 'stylesheet'; l.href = href;
+      l.dataset.viewSkill = '1';
+      document.head.appendChild(l);
+    });
+    for (const src of scripts) {
+      await new Promise((ok, err) => {
+        const s = document.createElement('script');
+        s.src = src; s.onload = ok; s.onerror = err;
+        s.dataset.viewSkill = '1';
+        document.body.appendChild(s);
+      });
+    }
+  } catch (e) { console.warn('[Jarvis] view skills load error:', e); }
+};
+window.loadViewSkills();
+</script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/home.html.bak-1782252245
+++ b/src/jarvis/interfaces/ui/static/home.html.bak-1782252245
@@ -1,0 +1,384 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
+<link rel="stylesheet" href="/home.css" />
+<!-- globe.css chargé dynamiquement si le skill globe-view est installé -->
+</head>
+<body data-mode="home">
+
+<iframe id="page-frame" class="page-frame" src="about:blank" frameborder="0" allowfullscreen></iframe>
+
+<div class="home-shell" id="home-shell">
+  <!-- Top bar -->
+  <div class="home-top">
+    <div class="home-controls" id="home-controls">
+
+      <span id="status-dot" style="display:none"></span>
+      <span id="status-label" style="display:none"></span>
+
+      <div class="hc-pill">
+
+        <button class="hc-btn" id="hc-mic" data-key="mic" title="Microphone">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/>
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+            <line x1="12" y1="19" x2="12" y2="22"/>
+            <line x1="8" y1="22" x2="16" y2="22"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-screen" data-key="screen" title="Capture d'&#233;cran">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2"/>
+            <path d="M8 21h8"/>
+            <line x1="12" y1="17" x2="12" y2="21"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-cam" data-key="cam" title="Cam&#233;ra">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3L14.5 4z"/>
+            <circle cx="12" cy="13" r="3"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-files" data-key="files" title="Acc&#232;s fichiers">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+          </svg>
+        </button>
+
+        <div class="hc-sep"></div>
+
+        <button class="hc-btn" id="hc-music" data-key="music" title="Musique">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 18V5l12-2v13"/>
+            <circle cx="6" cy="18" r="3"/>
+            <circle cx="18" cy="16" r="3"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-chat" data-key="chat" title="Chat">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+          </svg>
+        </button>
+
+      </div>
+
+    </div>
+    <div class="home-signature">
+      <div class="brand">JARVIS</div>
+      <div class="clock-row">
+        <div class="clock" id="home-clock">00:00</div>
+      </div>
+      <div class="date" id="home-date"></div>
+    </div>
+  </div>
+
+  <!-- Three.js canvas -->
+  <div class="home-orb-wrap">
+    <canvas id="orb-canvas"></canvas>
+  </div>
+
+  <!-- Overlay camera (MediaPipe vision) -->
+  <div class="cam-overlay" id="cam-overlay">
+    <div class="cam-inner" id="cam-drag-handle">
+      <div class="cam-topbar">
+        <span class="cam-label">VISION</span>
+        <span id="mp-status" class="mp-status"></span>
+        <span id="mp-gesture-label" class="mp-gesture-label"></span>
+      </div>
+      <div class="cam-feed">
+        <video id="cam-video" autoplay muted playsinline></video>
+        <canvas id="cam-canvas"></canvas>
+      </div>
+    </div>
+    <div class="hcw-resize-handle" id="cam-resize-handle"></div>
+  </div>
+
+  <!-- Widget : Musique -->
+  <div class="hc-widget hc-widget--music" id="hc-widget-music">
+    <div class="hcw-hd">
+      <span class="hcw-eyebrow">En &#233;coute</span>
+      <span class="hcw-meta" id="hcw-music-source">&#8212;</span>
+    </div>
+    <div class="hcw-body">
+      <div class="hcw-music-top">
+        <img class="hcw-album-art" id="hcw-album-art" alt=""/>
+        <div class="hcw-music-info">
+          <div class="hcw-track-name" id="hcw-music-track">Aucune lecture</div>
+          <div class="hcw-track-artist" id="hcw-music-artist">&#8212;</div>
+        </div>
+      </div>
+      <div class="hcw-progress-wrap">
+        <div class="hcw-progress-fill" id="hcw-progress-fill"></div>
+      </div>
+      <div class="hcw-controls">
+        <button class="hcw-ctl" id="hcw-prev" title="Pr&#233;c&#233;dent">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="2" y1="1.5" x2="2" y2="10.5"/>
+            <path d="M10 1.5L4 6L10 10.5V1.5Z"/>
+          </svg>
+        </button>
+        <button class="hcw-ctl hcw-play" id="hcw-play" title="Lecture / Pause">
+          <svg width="14" height="14" viewBox="0 0 14 14" id="hcw-play-icon">
+            <path fill="currentColor" d="M3 2l9 5-9 5V2z"/>
+          </svg>
+        </button>
+        <button class="hcw-ctl" id="hcw-next" title="Suivant">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="10" y1="1.5" x2="10" y2="10.5"/>
+            <path d="M2 1.5L8 6L2 10.5V1.5Z"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hcw-resize-handle" id="music-resize-handle"></div>
+  </div>
+
+  <!-- Widget : Chat -->
+  <div class="hc-widget hc-widget--chat" id="hc-widget-chat">
+    <div class="hcw-hd">
+      <span class="hcw-eyebrow">Conversation</span>
+      <div class="hcw-hd-right">
+        <span class="hcw-meta" id="hcw-chat-count">&#8212;</span>
+        <button class="hcw-new-session" id="hcw-new-session" title="Nouvelle session">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+            <line x1="12" y1="5" x2="12" y2="19"/>
+            <line x1="5" y1="12" x2="19" y2="12"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hcw-body hcw-messages" id="hcw-chat-msgs">
+      <div class="hcw-empty">Aucun message</div>
+    </div>
+    <div class="hcw-input-row" id="hcw-input-row">
+      <input class="hcw-input" id="hcw-input" type="text" placeholder="&#201;crire &#224; Jarvis&#8230;" autocomplete="off" />
+      <button class="hcw-send" id="hcw-send" title="Envoyer">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 7H2M7 2l5 5-5 5"/>
+        </svg>
+      </button>
+    </div>
+    <div class="hcw-resize-handle" id="chat-resize-handle"></div>
+  </div>
+
+  <!-- Canal passif (dernier message Jarvis) -->
+  <div class="home-channel" id="home-channel" style="display:none">
+    <div class="msg" id="channel-msg"></div>
+    <div class="meta">
+      <span id="channel-time"></span>
+      <a id="channel-cta" href="/dashboard">OUVRIR &#8594;</a>
+    </div>
+  </div>
+</div>
+
+<!-- View layer — vues plein-écran enregistrées via Jarvis.views -->
+<div id="globe-container"></div>
+
+<script src="/three.min.js"></script>
+<script src="/_shared.js"></script>
+<script src="/mission_control.js"></script>
+<script src="/gesture_router.js"></script>
+<script src="/config/sphereStyle.js"></script>
+<script src="/orb.js"></script>
+<script src="/wake_sequence.js"></script>
+<script>
+// ── Cold boot — étape 1 : flag AVANT home.js + masque la shell ─────────
+// Comportement par défaut : sleep screen, clap double pour wake.
+// ?wake=0 → skip tout (dashboard direct, pour dev)
+// ?wake=1 → bypass sleep, wake immédiat (pour dev sans micro)
+(function () {
+  const params = new URLSearchParams(location.search);
+  const mode   = params.get('wake');
+  if (mode === '0') return;             // skip total (dev)
+  // WAKEUP_ENABLED=false → accès direct au dashboard, aucune séquence de veille.
+  // Sans ce garde-fou, sur une install sans micro (VPS/headless) l'écran
+  // « double clap pour réveiller » bloque tout accès (le seul déclencheur est
+  // le clap, désactivé). ?wake=1 force quand même la séquence (dev).
+  if (mode !== '1' && window.JARVIS_WAKEUP_ENABLED === false) return;
+  window.__jarvisWakeActive = true;
+  window.__jarvisWakeForceImmediate = (mode === '1');
+  // Cache TOUT le chrome dashboard sauf l'orbe (le wake utilise #orb-canvas).
+  // Cible les éléments un-à-un pour ne pas masquer .home-orb-wrap qui est
+  // dans #home-shell. Inclut les éléments appendChild'és sur document.body
+  // par _shared.js (Mission Control, watermark, rooms nav, etc.).
+  const css = document.createElement('style');
+  css.id = 'wake-shell-hider';
+  css.textContent = ''
+    + '.home-top, .cam-overlay, .hc-widget, .home-channel,'
+    + ' .rooms-mc, .rooms-pages, .mode-watermark, .scene-card,'
+    + ' .mission-overlay, .cmdk-root, .notif-stack, .inspect-hint,'
+    + ' .mode-glow, #globe-container, #page-frame {'
+    + ' opacity: 0 !important; pointer-events: none !important;'
+    + ' transition: opacity 0.4s cubic-bezier(0.32,0.72,0,1); }';
+  document.head.appendChild(css);
+}());
+</script>
+<!-- Voix : pipeline temps réel LiveKit (remplace l'ancien voice.js in-house). -->
+<script src="https://cdn.jsdelivr.net/npm/livekit-client/dist/livekit-client.umd.min.js"></script>
+<script src="/voice_livekit.js"></script>
+<script src="/mediapipe_vision.js"></script>
+<script src="/home.js"></script>
+<script>
+// ── Cold boot — étape 2 : sleep screen → clap → wake_sequence ─────────
+// Cycle complet :
+//   1. À l'arrivée : sleep screen (z-index 9500, sleep visible)
+//   2. CustomEvent 'jarvis-wake' (clap backend OU window.triggerWake() dev)
+//      → fade out sleep, mount wake_sequence
+//   3a. wake_sequence onComplete : inject orb dashboard, fade in shell
+//   3b. wake_sequence onFailure (FACE refusée) : destroy wake, re-mount sleep
+(function () {
+  if (!window.__jarvisWakeActive) return;
+  if (typeof window.createWakeSequence !== 'function' ||
+      typeof window.createSleepScreen  !== 'function') return;
+
+  let sleep = null;
+  let seq   = null;
+  // Prénom configuré (USER_FIRSTNAME) — récupéré tôt, fire-and-forget, pour que
+  // mountWake() reste synchrone (le crossfade sleep/wake ne tolère aucun délai).
+  // Repli sur '' (le wake n'affiche alors aucun nom).
+  let _userName = '';
+  fetch('/api/wakeup/status', { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} })
+    .then(function (r) { return r.json(); })
+    .then(function (s) { _userName = (s && s.user_firstname) || ''; })
+    .catch(function () {});
+
+  function mountSleep() {
+    const sleepRoot = document.createElement('div');
+    sleepRoot.id = 'wake-sleep-root';
+    document.body.appendChild(sleepRoot);
+    sleep = window.createSleepScreen(sleepRoot, { onWake: enterWake });
+  }
+
+  function enterWake() {
+    if (!sleep) return;
+    const oldSleep = sleep;
+    sleep = null;
+    // Fade out sleep + mount wake en parallèle (crossfade)
+    // Sleep fade 200ms (court) — le wake est mounté INSTANTANÉMENT en-dessous,
+    // donc dès que le sleep s'efface, le wake est déjà entièrement rendu.
+    // Pas de zone de transparence pendant laquelle on verrait juste le bg sombre.
+    oldSleep.fadeOut(200, function () { oldSleep.destroy(); });
+    mountWake();
+  }
+
+  function mountWake() {
+    const root = document.createElement('div');
+    root.id = 'wake-cold-boot-root';
+    // Mount INSTANT (pas de fade-in) : le sleep par-dessus gère le crossfade.
+    // Comme ça il n'y a jamais un moment où ni sleep ni wake n'est entièrement
+    // rendu, donc pas de moment où on voit le fond noir.
+    document.body.appendChild(root);
+
+    seq = window.createWakeSequence(root, {
+      userName:     _userName,
+      // Scan facial cinématique toujours actif quand la séquence de veille tourne.
+      // FACE_RECOGNITION_ENABLED ne gate PAS l'affichage : le backend auto-valide
+      // (recognized:true) si la reconnaissance est off, et l'absence de caméra est
+      // gérée à l'exécution (dérogation). Le no-veille se règle via WAKEUP_ENABLED.
+      requireFace:  true,
+      targetCanvas: document.getElementById('orb-canvas'),
+      onComplete:   onWakeComplete,
+      onFailure:    onWakeFailure,
+    });
+
+    if (!seq) onWakeFailure();
+  }
+
+  function onWakeComplete() {
+    window.__jarvisWakeActive = false;
+    if (typeof window.__jarvisInjectOrb === 'function' && seq && seq.getOrb) {
+      window.__jarvisInjectOrb(seq.getOrb());
+    }
+    // Shell + chrome via transition opacité 0→1 (mêmes cibles que le masquage)
+    const hider = document.getElementById('wake-shell-hider');
+    if (hider) {
+      hider.textContent = ''
+        + '.home-top, .cam-overlay, .hc-widget, .home-channel,'
+        + ' .rooms-mc, .rooms-pages, .mode-watermark, .scene-card,'
+        + ' .mission-overlay, .cmdk-root, .notif-stack, .inspect-hint,'
+        + ' #globe-container, #page-frame {'
+        + ' opacity: 1; transition: opacity 0.4s cubic-bezier(0.32,0.72,0,1); }';
+      setTimeout(function () { if (hider.parentNode) hider.parentNode.removeChild(hider); }, 450);
+    }
+    // Fade out overlay wake (UI uniquement, l'orbe reste sur #orb-canvas)
+    const r = document.getElementById('wake-cold-boot-root');
+    if (r) {
+      r.style.transition = 'opacity 0.35s cubic-bezier(0.32,0.72,0,1)';
+      r.style.opacity = '0';
+      setTimeout(function () {
+        try { seq.destroy(); } catch (e) {}
+        seq = null;
+        if (r.parentNode) r.parentNode.removeChild(r);
+      }, 400);
+    }
+  }
+
+  function onWakeFailure() {
+    // BLOCAGE accès. Détruit wake (et l'orbe partagé pour libérer canvas),
+    // re-monte le sleep screen.
+    const orbRef = seq && seq.getOrb ? seq.getOrb() : null;
+    const r = document.getElementById('wake-cold-boot-root');
+    if (r) {
+      r.style.transition = 'opacity 0.35s cubic-bezier(0.32,0.72,0,1)';
+      r.style.opacity = '0';
+      setTimeout(function () {
+        try { if (seq) seq.destroy(); } catch (e) {}
+        try { if (orbRef && orbRef.destroy) orbRef.destroy(); } catch (e) {}
+        seq = null;
+        if (r.parentNode) r.parentNode.removeChild(r);
+        mountSleep();
+      }, 400);
+    } else {
+      try { if (seq) seq.destroy(); } catch (e) {}
+      seq = null;
+      mountSleep();
+    }
+  }
+
+  // Lancement
+  if (window.__jarvisWakeForceImmediate) {
+    mountWake();   // ?wake=1 : bypass sleep
+  } else {
+    mountSleep(); // défaut : attente clap
+  }
+})();
+</script>
+<script>
+window.loadViewSkills = async function () {
+  try {
+    const r = await fetch('/api/skills/view-scripts', { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} });
+    if (!r.ok) return;
+    const { styles = [], scripts = [] } = await r.json();
+
+    // Retire les anciens assets de vues (data-view-skill="1")
+    document.querySelectorAll('[data-view-skill]').forEach(el => el.remove());
+
+    styles.forEach(href => {
+      const l = document.createElement('link');
+      l.rel = 'stylesheet'; l.href = href;
+      l.dataset.viewSkill = '1';
+      document.head.appendChild(l);
+    });
+    for (const src of scripts) {
+      await new Promise((ok, err) => {
+        const s = document.createElement('script');
+        s.src = src; s.onload = ok; s.onerror = err;
+        s.dataset.viewSkill = '1';
+        document.body.appendChild(s);
+      });
+    }
+  } catch (e) { console.warn('[Jarvis] view skills load error:', e); }
+};
+window.loadViewSkills();
+</script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/home.html.bak-1782262378
+++ b/src/jarvis/interfaces/ui/static/home.html.bak-1782262378
@@ -1,0 +1,384 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
+<link rel="stylesheet" href="/home.css" />
+<!-- globe.css chargé dynamiquement si le skill globe-view est installé -->
+</head>
+<body data-mode="home">
+
+<iframe id="page-frame" class="page-frame" src="about:blank" frameborder="0" allowfullscreen></iframe>
+
+<div class="home-shell" id="home-shell">
+  <!-- Top bar -->
+  <div class="home-top">
+    <div class="home-controls" id="home-controls">
+
+      <span id="status-dot" style="display:none"></span>
+      <span id="status-label" style="display:none"></span>
+
+      <div class="hc-pill">
+
+        <button class="hc-btn" id="hc-mic" data-key="mic" title="Microphone">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/>
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+            <line x1="12" y1="19" x2="12" y2="22"/>
+            <line x1="8" y1="22" x2="16" y2="22"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-screen" data-key="screen" title="Capture d'&#233;cran">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2"/>
+            <path d="M8 21h8"/>
+            <line x1="12" y1="17" x2="12" y2="21"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-cam" data-key="cam" title="Cam&#233;ra">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3L14.5 4z"/>
+            <circle cx="12" cy="13" r="3"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-files" data-key="files" title="Acc&#232;s fichiers">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+          </svg>
+        </button>
+
+        <div class="hc-sep"></div>
+
+        <button class="hc-btn" id="hc-music" data-key="music" title="Musique">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 18V5l12-2v13"/>
+            <circle cx="6" cy="18" r="3"/>
+            <circle cx="18" cy="16" r="3"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-chat" data-key="chat" title="Chat">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+          </svg>
+        </button>
+
+      </div>
+
+    </div>
+    <div class="home-signature">
+      <div class="brand">JARVIS</div>
+      <div class="clock-row">
+        <div class="clock" id="home-clock">00:00</div>
+      </div>
+      <div class="date" id="home-date"></div>
+    </div>
+  </div>
+
+  <!-- Three.js canvas -->
+  <div class="home-orb-wrap">
+    <canvas id="orb-canvas"></canvas>
+  </div>
+
+  <!-- Overlay camera (MediaPipe vision) -->
+  <div class="cam-overlay" id="cam-overlay">
+    <div class="cam-inner" id="cam-drag-handle">
+      <div class="cam-topbar">
+        <span class="cam-label">VISION</span>
+        <span id="mp-status" class="mp-status"></span>
+        <span id="mp-gesture-label" class="mp-gesture-label"></span>
+      </div>
+      <div class="cam-feed">
+        <video id="cam-video" autoplay muted playsinline></video>
+        <canvas id="cam-canvas"></canvas>
+      </div>
+    </div>
+    <div class="hcw-resize-handle" id="cam-resize-handle"></div>
+  </div>
+
+  <!-- Widget : Musique -->
+  <div class="hc-widget hc-widget--music" id="hc-widget-music">
+    <div class="hcw-hd">
+      <span class="hcw-eyebrow">En &#233;coute</span>
+      <span class="hcw-meta" id="hcw-music-source">&#8212;</span>
+    </div>
+    <div class="hcw-body">
+      <div class="hcw-music-top">
+        <img class="hcw-album-art" id="hcw-album-art" alt=""/>
+        <div class="hcw-music-info">
+          <div class="hcw-track-name" id="hcw-music-track">Aucune lecture</div>
+          <div class="hcw-track-artist" id="hcw-music-artist">&#8212;</div>
+        </div>
+      </div>
+      <div class="hcw-progress-wrap">
+        <div class="hcw-progress-fill" id="hcw-progress-fill"></div>
+      </div>
+      <div class="hcw-controls">
+        <button class="hcw-ctl" id="hcw-prev" title="Pr&#233;c&#233;dent">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="2" y1="1.5" x2="2" y2="10.5"/>
+            <path d="M10 1.5L4 6L10 10.5V1.5Z"/>
+          </svg>
+        </button>
+        <button class="hcw-ctl hcw-play" id="hcw-play" title="Lecture / Pause">
+          <svg width="14" height="14" viewBox="0 0 14 14" id="hcw-play-icon">
+            <path fill="currentColor" d="M3 2l9 5-9 5V2z"/>
+          </svg>
+        </button>
+        <button class="hcw-ctl" id="hcw-next" title="Suivant">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="10" y1="1.5" x2="10" y2="10.5"/>
+            <path d="M2 1.5L8 6L2 10.5V1.5Z"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hcw-resize-handle" id="music-resize-handle"></div>
+  </div>
+
+  <!-- Widget : Chat -->
+  <div class="hc-widget hc-widget--chat" id="hc-widget-chat">
+    <div class="hcw-hd">
+      <span class="hcw-eyebrow">Conversation</span>
+      <div class="hcw-hd-right">
+        <span class="hcw-meta" id="hcw-chat-count">&#8212;</span>
+        <button class="hcw-new-session" id="hcw-new-session" title="Nouvelle session">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+            <line x1="12" y1="5" x2="12" y2="19"/>
+            <line x1="5" y1="12" x2="19" y2="12"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hcw-body hcw-messages" id="hcw-chat-msgs">
+      <div class="hcw-empty">Aucun message</div>
+    </div>
+    <div class="hcw-input-row" id="hcw-input-row">
+      <input class="hcw-input" id="hcw-input" type="text" placeholder="&#201;crire &#224; Jarvis&#8230;" autocomplete="off" />
+      <button class="hcw-send" id="hcw-send" title="Envoyer">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 7H2M7 2l5 5-5 5"/>
+        </svg>
+      </button>
+    </div>
+    <div class="hcw-resize-handle" id="chat-resize-handle"></div>
+  </div>
+
+  <!-- Canal passif (dernier message Jarvis) -->
+  <div class="home-channel" id="home-channel" style="display:none">
+    <div class="msg" id="channel-msg"></div>
+    <div class="meta">
+      <span id="channel-time"></span>
+      <a id="channel-cta" href="/mc#workspace">OUVRIR &#8594;</a>
+    </div>
+  </div>
+</div>
+
+<!-- View layer — vues plein-écran enregistrées via Jarvis.views -->
+<div id="globe-container"></div>
+
+<script src="/three.min.js"></script>
+<script src="/_shared.js"></script>
+<script src="/mission_control.js"></script>
+<script src="/gesture_router.js"></script>
+<script src="/config/sphereStyle.js"></script>
+<script src="/orb.js"></script>
+<script src="/wake_sequence.js"></script>
+<script>
+// ── Cold boot — étape 1 : flag AVANT home.js + masque la shell ─────────
+// Comportement par défaut : sleep screen, clap double pour wake.
+// ?wake=0 → skip tout (dashboard direct, pour dev)
+// ?wake=1 → bypass sleep, wake immédiat (pour dev sans micro)
+(function () {
+  const params = new URLSearchParams(location.search);
+  const mode   = params.get('wake');
+  if (mode === '0') return;             // skip total (dev)
+  // WAKEUP_ENABLED=false → accès direct au dashboard, aucune séquence de veille.
+  // Sans ce garde-fou, sur une install sans micro (VPS/headless) l'écran
+  // « double clap pour réveiller » bloque tout accès (le seul déclencheur est
+  // le clap, désactivé). ?wake=1 force quand même la séquence (dev).
+  if (mode !== '1' && window.JARVIS_WAKEUP_ENABLED === false) return;
+  window.__jarvisWakeActive = true;
+  window.__jarvisWakeForceImmediate = (mode === '1');
+  // Cache TOUT le chrome dashboard sauf l'orbe (le wake utilise #orb-canvas).
+  // Cible les éléments un-à-un pour ne pas masquer .home-orb-wrap qui est
+  // dans #home-shell. Inclut les éléments appendChild'és sur document.body
+  // par _shared.js (Mission Control, watermark, rooms nav, etc.).
+  const css = document.createElement('style');
+  css.id = 'wake-shell-hider';
+  css.textContent = ''
+    + '.home-top, .cam-overlay, .hc-widget, .home-channel,'
+    + ' .rooms-mc, .rooms-pages, .mode-watermark, .scene-card,'
+    + ' .mission-overlay, .cmdk-root, .notif-stack, .inspect-hint,'
+    + ' .mode-glow, #globe-container, #page-frame {'
+    + ' opacity: 0 !important; pointer-events: none !important;'
+    + ' transition: opacity 0.4s cubic-bezier(0.32,0.72,0,1); }';
+  document.head.appendChild(css);
+}());
+</script>
+<!-- Voix : pipeline temps réel LiveKit (remplace l'ancien voice.js in-house). -->
+<script src="https://cdn.jsdelivr.net/npm/livekit-client/dist/livekit-client.umd.min.js"></script>
+<script src="/voice_livekit.js"></script>
+<script src="/mediapipe_vision.js"></script>
+<script src="/home.js"></script>
+<script>
+// ── Cold boot — étape 2 : sleep screen → clap → wake_sequence ─────────
+// Cycle complet :
+//   1. À l'arrivée : sleep screen (z-index 9500, sleep visible)
+//   2. CustomEvent 'jarvis-wake' (clap backend OU window.triggerWake() dev)
+//      → fade out sleep, mount wake_sequence
+//   3a. wake_sequence onComplete : inject orb dashboard, fade in shell
+//   3b. wake_sequence onFailure (FACE refusée) : destroy wake, re-mount sleep
+(function () {
+  if (!window.__jarvisWakeActive) return;
+  if (typeof window.createWakeSequence !== 'function' ||
+      typeof window.createSleepScreen  !== 'function') return;
+
+  let sleep = null;
+  let seq   = null;
+  // Prénom configuré (USER_FIRSTNAME) — récupéré tôt, fire-and-forget, pour que
+  // mountWake() reste synchrone (le crossfade sleep/wake ne tolère aucun délai).
+  // Repli sur '' (le wake n'affiche alors aucun nom).
+  let _userName = '';
+  fetch('/api/wakeup/status', { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} })
+    .then(function (r) { return r.json(); })
+    .then(function (s) { _userName = (s && s.user_firstname) || ''; })
+    .catch(function () {});
+
+  function mountSleep() {
+    const sleepRoot = document.createElement('div');
+    sleepRoot.id = 'wake-sleep-root';
+    document.body.appendChild(sleepRoot);
+    sleep = window.createSleepScreen(sleepRoot, { onWake: enterWake });
+  }
+
+  function enterWake() {
+    if (!sleep) return;
+    const oldSleep = sleep;
+    sleep = null;
+    // Fade out sleep + mount wake en parallèle (crossfade)
+    // Sleep fade 200ms (court) — le wake est mounté INSTANTANÉMENT en-dessous,
+    // donc dès que le sleep s'efface, le wake est déjà entièrement rendu.
+    // Pas de zone de transparence pendant laquelle on verrait juste le bg sombre.
+    oldSleep.fadeOut(200, function () { oldSleep.destroy(); });
+    mountWake();
+  }
+
+  function mountWake() {
+    const root = document.createElement('div');
+    root.id = 'wake-cold-boot-root';
+    // Mount INSTANT (pas de fade-in) : le sleep par-dessus gère le crossfade.
+    // Comme ça il n'y a jamais un moment où ni sleep ni wake n'est entièrement
+    // rendu, donc pas de moment où on voit le fond noir.
+    document.body.appendChild(root);
+
+    seq = window.createWakeSequence(root, {
+      userName:     _userName,
+      // Scan facial cinématique toujours actif quand la séquence de veille tourne.
+      // FACE_RECOGNITION_ENABLED ne gate PAS l'affichage : le backend auto-valide
+      // (recognized:true) si la reconnaissance est off, et l'absence de caméra est
+      // gérée à l'exécution (dérogation). Le no-veille se règle via WAKEUP_ENABLED.
+      requireFace:  true,
+      targetCanvas: document.getElementById('orb-canvas'),
+      onComplete:   onWakeComplete,
+      onFailure:    onWakeFailure,
+    });
+
+    if (!seq) onWakeFailure();
+  }
+
+  function onWakeComplete() {
+    window.__jarvisWakeActive = false;
+    if (typeof window.__jarvisInjectOrb === 'function' && seq && seq.getOrb) {
+      window.__jarvisInjectOrb(seq.getOrb());
+    }
+    // Shell + chrome via transition opacité 0→1 (mêmes cibles que le masquage)
+    const hider = document.getElementById('wake-shell-hider');
+    if (hider) {
+      hider.textContent = ''
+        + '.home-top, .cam-overlay, .hc-widget, .home-channel,'
+        + ' .rooms-mc, .rooms-pages, .mode-watermark, .scene-card,'
+        + ' .mission-overlay, .cmdk-root, .notif-stack, .inspect-hint,'
+        + ' #globe-container, #page-frame {'
+        + ' opacity: 1; transition: opacity 0.4s cubic-bezier(0.32,0.72,0,1); }';
+      setTimeout(function () { if (hider.parentNode) hider.parentNode.removeChild(hider); }, 450);
+    }
+    // Fade out overlay wake (UI uniquement, l'orbe reste sur #orb-canvas)
+    const r = document.getElementById('wake-cold-boot-root');
+    if (r) {
+      r.style.transition = 'opacity 0.35s cubic-bezier(0.32,0.72,0,1)';
+      r.style.opacity = '0';
+      setTimeout(function () {
+        try { seq.destroy(); } catch (e) {}
+        seq = null;
+        if (r.parentNode) r.parentNode.removeChild(r);
+      }, 400);
+    }
+  }
+
+  function onWakeFailure() {
+    // BLOCAGE accès. Détruit wake (et l'orbe partagé pour libérer canvas),
+    // re-monte le sleep screen.
+    const orbRef = seq && seq.getOrb ? seq.getOrb() : null;
+    const r = document.getElementById('wake-cold-boot-root');
+    if (r) {
+      r.style.transition = 'opacity 0.35s cubic-bezier(0.32,0.72,0,1)';
+      r.style.opacity = '0';
+      setTimeout(function () {
+        try { if (seq) seq.destroy(); } catch (e) {}
+        try { if (orbRef && orbRef.destroy) orbRef.destroy(); } catch (e) {}
+        seq = null;
+        if (r.parentNode) r.parentNode.removeChild(r);
+        mountSleep();
+      }, 400);
+    } else {
+      try { if (seq) seq.destroy(); } catch (e) {}
+      seq = null;
+      mountSleep();
+    }
+  }
+
+  // Lancement
+  if (window.__jarvisWakeForceImmediate) {
+    mountWake();   // ?wake=1 : bypass sleep
+  } else {
+    mountSleep(); // défaut : attente clap
+  }
+})();
+</script>
+<script>
+window.loadViewSkills = async function () {
+  try {
+    const r = await fetch('/api/skills/view-scripts', { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} });
+    if (!r.ok) return;
+    const { styles = [], scripts = [] } = await r.json();
+
+    // Retire les anciens assets de vues (data-view-skill="1")
+    document.querySelectorAll('[data-view-skill]').forEach(el => el.remove());
+
+    styles.forEach(href => {
+      const l = document.createElement('link');
+      l.rel = 'stylesheet'; l.href = href;
+      l.dataset.viewSkill = '1';
+      document.head.appendChild(l);
+    });
+    for (const src of scripts) {
+      await new Promise((ok, err) => {
+        const s = document.createElement('script');
+        s.src = src; s.onload = ok; s.onerror = err;
+        s.dataset.viewSkill = '1';
+        document.body.appendChild(s);
+      });
+    }
+  } catch (e) { console.warn('[Jarvis] view skills load error:', e); }
+};
+window.loadViewSkills();
+</script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/home.html.bak-20260620-153117
+++ b/src/jarvis/interfaces/ui/static/home.html.bak-20260620-153117
@@ -1,0 +1,370 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/home.css" />
+<!-- globe.css chargé dynamiquement si le skill globe-view est installé -->
+</head>
+<body data-mode="home">
+
+<iframe id="page-frame" class="page-frame" src="about:blank" frameborder="0" allowfullscreen></iframe>
+
+<div class="home-shell" id="home-shell">
+  <!-- Top bar -->
+  <div class="home-top">
+    <div class="home-controls" id="home-controls">
+
+      <span id="status-dot" style="display:none"></span>
+      <span id="status-label" style="display:none"></span>
+
+      <div class="hc-pill">
+
+        <button class="hc-btn" id="hc-mic" data-key="mic" title="Microphone">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/>
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+            <line x1="12" y1="19" x2="12" y2="22"/>
+            <line x1="8" y1="22" x2="16" y2="22"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-screen" data-key="screen" title="Capture d'&#233;cran">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2"/>
+            <path d="M8 21h8"/>
+            <line x1="12" y1="17" x2="12" y2="21"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-cam" data-key="cam" title="Cam&#233;ra">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3L14.5 4z"/>
+            <circle cx="12" cy="13" r="3"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-files" data-key="files" title="Acc&#232;s fichiers">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+          </svg>
+        </button>
+
+        <div class="hc-sep"></div>
+
+        <button class="hc-btn" id="hc-music" data-key="music" title="Musique">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 18V5l12-2v13"/>
+            <circle cx="6" cy="18" r="3"/>
+            <circle cx="18" cy="16" r="3"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-chat" data-key="chat" title="Chat">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+          </svg>
+        </button>
+
+      </div>
+
+    </div>
+    <div class="home-signature">
+      <div class="brand">JARVIS</div>
+      <div class="clock-row">
+        <div class="clock" id="home-clock">00:00</div>
+      </div>
+      <div class="date" id="home-date"></div>
+    </div>
+  </div>
+
+  <!-- Three.js canvas -->
+  <div class="home-orb-wrap">
+    <canvas id="orb-canvas"></canvas>
+  </div>
+
+  <!-- Overlay camera (MediaPipe vision) -->
+  <div class="cam-overlay" id="cam-overlay">
+    <div class="cam-inner" id="cam-drag-handle">
+      <div class="cam-topbar">
+        <span class="cam-label">VISION</span>
+        <span id="mp-status" class="mp-status"></span>
+        <span id="mp-gesture-label" class="mp-gesture-label"></span>
+      </div>
+      <div class="cam-feed">
+        <video id="cam-video" autoplay muted playsinline></video>
+        <canvas id="cam-canvas"></canvas>
+      </div>
+    </div>
+    <div class="hcw-resize-handle" id="cam-resize-handle"></div>
+  </div>
+
+  <!-- Widget : Musique -->
+  <div class="hc-widget hc-widget--music" id="hc-widget-music">
+    <div class="hcw-hd">
+      <span class="hcw-eyebrow">En &#233;coute</span>
+      <span class="hcw-meta" id="hcw-music-source">&#8212;</span>
+    </div>
+    <div class="hcw-body">
+      <div class="hcw-music-top">
+        <img class="hcw-album-art" id="hcw-album-art" alt=""/>
+        <div class="hcw-music-info">
+          <div class="hcw-track-name" id="hcw-music-track">Aucune lecture</div>
+          <div class="hcw-track-artist" id="hcw-music-artist">&#8212;</div>
+        </div>
+      </div>
+      <div class="hcw-progress-wrap">
+        <div class="hcw-progress-fill" id="hcw-progress-fill"></div>
+      </div>
+      <div class="hcw-controls">
+        <button class="hcw-ctl" id="hcw-prev" title="Pr&#233;c&#233;dent">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="2" y1="1.5" x2="2" y2="10.5"/>
+            <path d="M10 1.5L4 6L10 10.5V1.5Z"/>
+          </svg>
+        </button>
+        <button class="hcw-ctl hcw-play" id="hcw-play" title="Lecture / Pause">
+          <svg width="14" height="14" viewBox="0 0 14 14" id="hcw-play-icon">
+            <path fill="currentColor" d="M3 2l9 5-9 5V2z"/>
+          </svg>
+        </button>
+        <button class="hcw-ctl" id="hcw-next" title="Suivant">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="10" y1="1.5" x2="10" y2="10.5"/>
+            <path d="M2 1.5L8 6L2 10.5V1.5Z"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hcw-resize-handle" id="music-resize-handle"></div>
+  </div>
+
+  <!-- Widget : Chat -->
+  <div class="hc-widget hc-widget--chat" id="hc-widget-chat">
+    <div class="hcw-hd">
+      <span class="hcw-eyebrow">Conversation</span>
+      <div class="hcw-hd-right">
+        <span class="hcw-meta" id="hcw-chat-count">&#8212;</span>
+        <button class="hcw-new-session" id="hcw-new-session" title="Nouvelle session">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+            <line x1="12" y1="5" x2="12" y2="19"/>
+            <line x1="5" y1="12" x2="19" y2="12"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hcw-body hcw-messages" id="hcw-chat-msgs">
+      <div class="hcw-empty">Aucun message</div>
+    </div>
+    <div class="hcw-input-row" id="hcw-input-row">
+      <input class="hcw-input" id="hcw-input" type="text" placeholder="&#201;crire &#224; Jarvis&#8230;" autocomplete="off" />
+      <button class="hcw-send" id="hcw-send" title="Envoyer">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 7H2M7 2l5 5-5 5"/>
+        </svg>
+      </button>
+    </div>
+    <div class="hcw-resize-handle" id="chat-resize-handle"></div>
+  </div>
+
+  <!-- Canal passif (dernier message Jarvis) -->
+  <div class="home-channel" id="home-channel" style="display:none">
+    <div class="msg" id="channel-msg"></div>
+    <div class="meta">
+      <span id="channel-time"></span>
+      <a id="channel-cta" href="/dashboard">OUVRIR &#8594;</a>
+    </div>
+  </div>
+</div>
+
+<!-- View layer — vues plein-écran enregistrées via Jarvis.views -->
+<div id="globe-container"></div>
+
+<script src="/three.min.js"></script>
+<script src="/_shared.js"></script>
+<script src="/config/sphereStyle.js"></script>
+<script src="/orb.js"></script>
+<script src="/wake_sequence.js"></script>
+<script>
+// ── Cold boot — étape 1 : flag AVANT home.js + masque la shell ─────────
+// Comportement par défaut : sleep screen, clap double pour wake.
+// ?wake=0 → skip tout (dashboard direct, pour dev)
+// ?wake=1 → bypass sleep, wake immédiat (pour dev sans micro)
+(function () {
+  const params = new URLSearchParams(location.search);
+  const mode   = params.get('wake');
+  if (mode === '0') return;             // skip total
+  window.__jarvisWakeActive = true;
+  window.__jarvisWakeForceImmediate = (mode === '1');
+  // Cache TOUT le chrome dashboard sauf l'orbe (le wake utilise #orb-canvas).
+  // Cible les éléments un-à-un pour ne pas masquer .home-orb-wrap qui est
+  // dans #home-shell. Inclut les éléments appendChild'és sur document.body
+  // par _shared.js (Mission Control, watermark, rooms nav, etc.).
+  const css = document.createElement('style');
+  css.id = 'wake-shell-hider';
+  css.textContent = ''
+    + '.home-top, .cam-overlay, .hc-widget, .home-channel,'
+    + ' .rooms-mc, .rooms-pages, .mode-watermark, .scene-card,'
+    + ' .mission-overlay, .cmdk-root, .notif-stack, .inspect-hint,'
+    + ' .mode-glow, #globe-container, #page-frame {'
+    + ' opacity: 0 !important; pointer-events: none !important;'
+    + ' transition: opacity 0.4s cubic-bezier(0.32,0.72,0,1); }';
+  document.head.appendChild(css);
+}());
+</script>
+<script src="/voice.js"></script>
+<script src="/mediapipe_vision.js"></script>
+<script src="/home.js"></script>
+<script>
+// ── Cold boot — étape 2 : sleep screen → clap → wake_sequence ─────────
+// Cycle complet :
+//   1. À l'arrivée : sleep screen (z-index 9500, sleep visible)
+//   2. CustomEvent 'jarvis-wake' (clap backend OU window.triggerWake() dev)
+//      → fade out sleep, mount wake_sequence
+//   3a. wake_sequence onComplete : inject orb dashboard, fade in shell
+//   3b. wake_sequence onFailure (FACE refusée) : destroy wake, re-mount sleep
+(function () {
+  if (!window.__jarvisWakeActive) return;
+  if (typeof window.createWakeSequence !== 'function' ||
+      typeof window.createSleepScreen  !== 'function') return;
+
+  let sleep = null;
+  let seq   = null;
+  // Prénom configuré (USER_FIRSTNAME) — récupéré tôt, fire-and-forget, pour que
+  // mountWake() reste synchrone (le crossfade sleep/wake ne tolère aucun délai).
+  // Repli sur '' (le wake n'affiche alors aucun nom).
+  let _userName = '';
+  fetch('/api/wakeup/status')
+    .then(function (r) { return r.json(); })
+    .then(function (s) { _userName = (s && s.user_firstname) || ''; })
+    .catch(function () {});
+
+  function mountSleep() {
+    const sleepRoot = document.createElement('div');
+    sleepRoot.id = 'wake-sleep-root';
+    document.body.appendChild(sleepRoot);
+    sleep = window.createSleepScreen(sleepRoot, { onWake: enterWake });
+  }
+
+  function enterWake() {
+    if (!sleep) return;
+    const oldSleep = sleep;
+    sleep = null;
+    // Fade out sleep + mount wake en parallèle (crossfade)
+    // Sleep fade 200ms (court) — le wake est mounté INSTANTANÉMENT en-dessous,
+    // donc dès que le sleep s'efface, le wake est déjà entièrement rendu.
+    // Pas de zone de transparence pendant laquelle on verrait juste le bg sombre.
+    oldSleep.fadeOut(200, function () { oldSleep.destroy(); });
+    mountWake();
+  }
+
+  function mountWake() {
+    const root = document.createElement('div');
+    root.id = 'wake-cold-boot-root';
+    // Mount INSTANT (pas de fade-in) : le sleep par-dessus gère le crossfade.
+    // Comme ça il n'y a jamais un moment où ni sleep ni wake n'est entièrement
+    // rendu, donc pas de moment où on voit le fond noir.
+    document.body.appendChild(root);
+
+    seq = window.createWakeSequence(root, {
+      userName:     _userName,
+      requireFace:  true,
+      targetCanvas: document.getElementById('orb-canvas'),
+      onComplete:   onWakeComplete,
+      onFailure:    onWakeFailure,
+    });
+
+    if (!seq) onWakeFailure();
+  }
+
+  function onWakeComplete() {
+    window.__jarvisWakeActive = false;
+    if (typeof window.__jarvisInjectOrb === 'function' && seq && seq.getOrb) {
+      window.__jarvisInjectOrb(seq.getOrb());
+    }
+    // Shell + chrome via transition opacité 0→1 (mêmes cibles que le masquage)
+    const hider = document.getElementById('wake-shell-hider');
+    if (hider) {
+      hider.textContent = ''
+        + '.home-top, .cam-overlay, .hc-widget, .home-channel,'
+        + ' .rooms-mc, .rooms-pages, .mode-watermark, .scene-card,'
+        + ' .mission-overlay, .cmdk-root, .notif-stack, .inspect-hint,'
+        + ' #globe-container, #page-frame {'
+        + ' opacity: 1; transition: opacity 0.4s cubic-bezier(0.32,0.72,0,1); }';
+      setTimeout(function () { if (hider.parentNode) hider.parentNode.removeChild(hider); }, 450);
+    }
+    // Fade out overlay wake (UI uniquement, l'orbe reste sur #orb-canvas)
+    const r = document.getElementById('wake-cold-boot-root');
+    if (r) {
+      r.style.transition = 'opacity 0.35s cubic-bezier(0.32,0.72,0,1)';
+      r.style.opacity = '0';
+      setTimeout(function () {
+        try { seq.destroy(); } catch (e) {}
+        seq = null;
+        if (r.parentNode) r.parentNode.removeChild(r);
+      }, 400);
+    }
+  }
+
+  function onWakeFailure() {
+    // BLOCAGE accès. Détruit wake (et l'orbe partagé pour libérer canvas),
+    // re-monte le sleep screen.
+    const orbRef = seq && seq.getOrb ? seq.getOrb() : null;
+    const r = document.getElementById('wake-cold-boot-root');
+    if (r) {
+      r.style.transition = 'opacity 0.35s cubic-bezier(0.32,0.72,0,1)';
+      r.style.opacity = '0';
+      setTimeout(function () {
+        try { if (seq) seq.destroy(); } catch (e) {}
+        try { if (orbRef && orbRef.destroy) orbRef.destroy(); } catch (e) {}
+        seq = null;
+        if (r.parentNode) r.parentNode.removeChild(r);
+        mountSleep();
+      }, 400);
+    } else {
+      try { if (seq) seq.destroy(); } catch (e) {}
+      seq = null;
+      mountSleep();
+    }
+  }
+
+  // Lancement
+  if (window.__jarvisWakeForceImmediate) {
+    mountWake();   // ?wake=1 : bypass sleep
+  } else {
+    mountSleep(); // défaut : attente clap
+  }
+})();
+</script>
+<script>
+window.loadViewSkills = async function () {
+  try {
+    const r = await fetch('/api/skills/view-scripts');
+    if (!r.ok) return;
+    const { styles = [], scripts = [] } = await r.json();
+
+    // Retire les anciens assets de vues (data-view-skill="1")
+    document.querySelectorAll('[data-view-skill]').forEach(el => el.remove());
+
+    styles.forEach(href => {
+      const l = document.createElement('link');
+      l.rel = 'stylesheet'; l.href = href;
+      l.dataset.viewSkill = '1';
+      document.head.appendChild(l);
+    });
+    for (const src of scripts) {
+      await new Promise((ok, err) => {
+        const s = document.createElement('script');
+        s.src = src; s.onload = ok; s.onerror = err;
+        s.dataset.viewSkill = '1';
+        document.body.appendChild(s);
+      });
+    }
+  } catch (e) { console.warn('[Jarvis] view skills load error:', e); }
+};
+window.loadViewSkills();
+</script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/home.html.bak-20260620-180911
+++ b/src/jarvis/interfaces/ui/static/home.html.bak-20260620-180911
@@ -1,0 +1,370 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/home.css" />
+<!-- globe.css chargé dynamiquement si le skill globe-view est installé -->
+</head>
+<body data-mode="home">
+
+<iframe id="page-frame" class="page-frame" src="about:blank" frameborder="0" allowfullscreen></iframe>
+
+<div class="home-shell" id="home-shell">
+  <!-- Top bar -->
+  <div class="home-top">
+    <div class="home-controls" id="home-controls">
+
+      <span id="status-dot" style="display:none"></span>
+      <span id="status-label" style="display:none"></span>
+
+      <div class="hc-pill">
+
+        <button class="hc-btn" id="hc-mic" data-key="mic" title="Microphone">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z"/>
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+            <line x1="12" y1="19" x2="12" y2="22"/>
+            <line x1="8" y1="22" x2="16" y2="22"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-screen" data-key="screen" title="Capture d'&#233;cran">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2"/>
+            <path d="M8 21h8"/>
+            <line x1="12" y1="17" x2="12" y2="21"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-cam" data-key="cam" title="Cam&#233;ra">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3L14.5 4z"/>
+            <circle cx="12" cy="13" r="3"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-files" data-key="files" title="Acc&#232;s fichiers">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
+          </svg>
+        </button>
+
+        <div class="hc-sep"></div>
+
+        <button class="hc-btn" id="hc-music" data-key="music" title="Musique">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 18V5l12-2v13"/>
+            <circle cx="6" cy="18" r="3"/>
+            <circle cx="18" cy="16" r="3"/>
+          </svg>
+        </button>
+        <button class="hc-btn" id="hc-chat" data-key="chat" title="Chat">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+          </svg>
+        </button>
+
+      </div>
+
+    </div>
+    <div class="home-signature">
+      <div class="brand">JARVIS</div>
+      <div class="clock-row">
+        <div class="clock" id="home-clock">00:00</div>
+      </div>
+      <div class="date" id="home-date"></div>
+    </div>
+  </div>
+
+  <!-- Three.js canvas -->
+  <div class="home-orb-wrap">
+    <canvas id="orb-canvas"></canvas>
+  </div>
+
+  <!-- Overlay camera (MediaPipe vision) -->
+  <div class="cam-overlay" id="cam-overlay">
+    <div class="cam-inner" id="cam-drag-handle">
+      <div class="cam-topbar">
+        <span class="cam-label">VISION</span>
+        <span id="mp-status" class="mp-status"></span>
+        <span id="mp-gesture-label" class="mp-gesture-label"></span>
+      </div>
+      <div class="cam-feed">
+        <video id="cam-video" autoplay muted playsinline></video>
+        <canvas id="cam-canvas"></canvas>
+      </div>
+    </div>
+    <div class="hcw-resize-handle" id="cam-resize-handle"></div>
+  </div>
+
+  <!-- Widget : Musique -->
+  <div class="hc-widget hc-widget--music" id="hc-widget-music">
+    <div class="hcw-hd">
+      <span class="hcw-eyebrow">En &#233;coute</span>
+      <span class="hcw-meta" id="hcw-music-source">&#8212;</span>
+    </div>
+    <div class="hcw-body">
+      <div class="hcw-music-top">
+        <img class="hcw-album-art" id="hcw-album-art" alt=""/>
+        <div class="hcw-music-info">
+          <div class="hcw-track-name" id="hcw-music-track">Aucune lecture</div>
+          <div class="hcw-track-artist" id="hcw-music-artist">&#8212;</div>
+        </div>
+      </div>
+      <div class="hcw-progress-wrap">
+        <div class="hcw-progress-fill" id="hcw-progress-fill"></div>
+      </div>
+      <div class="hcw-controls">
+        <button class="hcw-ctl" id="hcw-prev" title="Pr&#233;c&#233;dent">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="2" y1="1.5" x2="2" y2="10.5"/>
+            <path d="M10 1.5L4 6L10 10.5V1.5Z"/>
+          </svg>
+        </button>
+        <button class="hcw-ctl hcw-play" id="hcw-play" title="Lecture / Pause">
+          <svg width="14" height="14" viewBox="0 0 14 14" id="hcw-play-icon">
+            <path fill="currentColor" d="M3 2l9 5-9 5V2z"/>
+          </svg>
+        </button>
+        <button class="hcw-ctl" id="hcw-next" title="Suivant">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="10" y1="1.5" x2="10" y2="10.5"/>
+            <path d="M2 1.5L8 6L2 10.5V1.5Z"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hcw-resize-handle" id="music-resize-handle"></div>
+  </div>
+
+  <!-- Widget : Chat -->
+  <div class="hc-widget hc-widget--chat" id="hc-widget-chat">
+    <div class="hcw-hd">
+      <span class="hcw-eyebrow">Conversation</span>
+      <div class="hcw-hd-right">
+        <span class="hcw-meta" id="hcw-chat-count">&#8212;</span>
+        <button class="hcw-new-session" id="hcw-new-session" title="Nouvelle session">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round">
+            <line x1="12" y1="5" x2="12" y2="19"/>
+            <line x1="5" y1="12" x2="19" y2="12"/>
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div class="hcw-body hcw-messages" id="hcw-chat-msgs">
+      <div class="hcw-empty">Aucun message</div>
+    </div>
+    <div class="hcw-input-row" id="hcw-input-row">
+      <input class="hcw-input" id="hcw-input" type="text" placeholder="&#201;crire &#224; Jarvis&#8230;" autocomplete="off" />
+      <button class="hcw-send" id="hcw-send" title="Envoyer">
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 7H2M7 2l5 5-5 5"/>
+        </svg>
+      </button>
+    </div>
+    <div class="hcw-resize-handle" id="chat-resize-handle"></div>
+  </div>
+
+  <!-- Canal passif (dernier message Jarvis) -->
+  <div class="home-channel" id="home-channel" style="display:none">
+    <div class="msg" id="channel-msg"></div>
+    <div class="meta">
+      <span id="channel-time"></span>
+      <a id="channel-cta" href="/dashboard">OUVRIR &#8594;</a>
+    </div>
+  </div>
+</div>
+
+<!-- View layer — vues plein-écran enregistrées via Jarvis.views -->
+<div id="globe-container"></div>
+
+<script src="/three.min.js"></script>
+<script src="/_shared.js"></script>
+<script src="/config/sphereStyle.js"></script>
+<script src="/orb.js"></script>
+<script src="/wake_sequence.js"></script>
+<script>
+// ── Cold boot — étape 1 : flag AVANT home.js + masque la shell ─────────
+// Comportement par défaut : sleep screen, clap double pour wake.
+// ?wake=0 → skip tout (dashboard direct, pour dev)
+// ?wake=1 → bypass sleep, wake immédiat (pour dev sans micro)
+(function () {
+  const params = new URLSearchParams(location.search);
+  const mode   = params.get('wake');
+  if (mode === '0') return;             // skip total
+  window.__jarvisWakeActive = true;
+  window.__jarvisWakeForceImmediate = (mode === '1');
+  // Cache TOUT le chrome dashboard sauf l'orbe (le wake utilise #orb-canvas).
+  // Cible les éléments un-à-un pour ne pas masquer .home-orb-wrap qui est
+  // dans #home-shell. Inclut les éléments appendChild'és sur document.body
+  // par _shared.js (Mission Control, watermark, rooms nav, etc.).
+  const css = document.createElement('style');
+  css.id = 'wake-shell-hider';
+  css.textContent = ''
+    + '.home-top, .cam-overlay, .hc-widget, .home-channel,'
+    + ' .rooms-mc, .rooms-pages, .mode-watermark, .scene-card,'
+    + ' .mission-overlay, .cmdk-root, .notif-stack, .inspect-hint,'
+    + ' .mode-glow, #globe-container, #page-frame {'
+    + ' opacity: 0 !important; pointer-events: none !important;'
+    + ' transition: opacity 0.4s cubic-bezier(0.32,0.72,0,1); }';
+  document.head.appendChild(css);
+}());
+</script>
+<script src="/voice.js"></script>
+<script src="/mediapipe_vision.js"></script>
+<script src="/home.js"></script>
+<script>
+// ── Cold boot — étape 2 : sleep screen → clap → wake_sequence ─────────
+// Cycle complet :
+//   1. À l'arrivée : sleep screen (z-index 9500, sleep visible)
+//   2. CustomEvent 'jarvis-wake' (clap backend OU window.triggerWake() dev)
+//      → fade out sleep, mount wake_sequence
+//   3a. wake_sequence onComplete : inject orb dashboard, fade in shell
+//   3b. wake_sequence onFailure (FACE refusée) : destroy wake, re-mount sleep
+(function () {
+  if (!window.__jarvisWakeActive) return;
+  if (typeof window.createWakeSequence !== 'function' ||
+      typeof window.createSleepScreen  !== 'function') return;
+
+  let sleep = null;
+  let seq   = null;
+  // Prénom configuré (USER_FIRSTNAME) — récupéré tôt, fire-and-forget, pour que
+  // mountWake() reste synchrone (le crossfade sleep/wake ne tolère aucun délai).
+  // Repli sur '' (le wake n'affiche alors aucun nom).
+  let _userName = '';
+  fetch('/api/wakeup/status', { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} })
+    .then(function (r) { return r.json(); })
+    .then(function (s) { _userName = (s && s.user_firstname) || ''; })
+    .catch(function () {});
+
+  function mountSleep() {
+    const sleepRoot = document.createElement('div');
+    sleepRoot.id = 'wake-sleep-root';
+    document.body.appendChild(sleepRoot);
+    sleep = window.createSleepScreen(sleepRoot, { onWake: enterWake });
+  }
+
+  function enterWake() {
+    if (!sleep) return;
+    const oldSleep = sleep;
+    sleep = null;
+    // Fade out sleep + mount wake en parallèle (crossfade)
+    // Sleep fade 200ms (court) — le wake est mounté INSTANTANÉMENT en-dessous,
+    // donc dès que le sleep s'efface, le wake est déjà entièrement rendu.
+    // Pas de zone de transparence pendant laquelle on verrait juste le bg sombre.
+    oldSleep.fadeOut(200, function () { oldSleep.destroy(); });
+    mountWake();
+  }
+
+  function mountWake() {
+    const root = document.createElement('div');
+    root.id = 'wake-cold-boot-root';
+    // Mount INSTANT (pas de fade-in) : le sleep par-dessus gère le crossfade.
+    // Comme ça il n'y a jamais un moment où ni sleep ni wake n'est entièrement
+    // rendu, donc pas de moment où on voit le fond noir.
+    document.body.appendChild(root);
+
+    seq = window.createWakeSequence(root, {
+      userName:     _userName,
+      requireFace:  true,
+      targetCanvas: document.getElementById('orb-canvas'),
+      onComplete:   onWakeComplete,
+      onFailure:    onWakeFailure,
+    });
+
+    if (!seq) onWakeFailure();
+  }
+
+  function onWakeComplete() {
+    window.__jarvisWakeActive = false;
+    if (typeof window.__jarvisInjectOrb === 'function' && seq && seq.getOrb) {
+      window.__jarvisInjectOrb(seq.getOrb());
+    }
+    // Shell + chrome via transition opacité 0→1 (mêmes cibles que le masquage)
+    const hider = document.getElementById('wake-shell-hider');
+    if (hider) {
+      hider.textContent = ''
+        + '.home-top, .cam-overlay, .hc-widget, .home-channel,'
+        + ' .rooms-mc, .rooms-pages, .mode-watermark, .scene-card,'
+        + ' .mission-overlay, .cmdk-root, .notif-stack, .inspect-hint,'
+        + ' #globe-container, #page-frame {'
+        + ' opacity: 1; transition: opacity 0.4s cubic-bezier(0.32,0.72,0,1); }';
+      setTimeout(function () { if (hider.parentNode) hider.parentNode.removeChild(hider); }, 450);
+    }
+    // Fade out overlay wake (UI uniquement, l'orbe reste sur #orb-canvas)
+    const r = document.getElementById('wake-cold-boot-root');
+    if (r) {
+      r.style.transition = 'opacity 0.35s cubic-bezier(0.32,0.72,0,1)';
+      r.style.opacity = '0';
+      setTimeout(function () {
+        try { seq.destroy(); } catch (e) {}
+        seq = null;
+        if (r.parentNode) r.parentNode.removeChild(r);
+      }, 400);
+    }
+  }
+
+  function onWakeFailure() {
+    // BLOCAGE accès. Détruit wake (et l'orbe partagé pour libérer canvas),
+    // re-monte le sleep screen.
+    const orbRef = seq && seq.getOrb ? seq.getOrb() : null;
+    const r = document.getElementById('wake-cold-boot-root');
+    if (r) {
+      r.style.transition = 'opacity 0.35s cubic-bezier(0.32,0.72,0,1)';
+      r.style.opacity = '0';
+      setTimeout(function () {
+        try { if (seq) seq.destroy(); } catch (e) {}
+        try { if (orbRef && orbRef.destroy) orbRef.destroy(); } catch (e) {}
+        seq = null;
+        if (r.parentNode) r.parentNode.removeChild(r);
+        mountSleep();
+      }, 400);
+    } else {
+      try { if (seq) seq.destroy(); } catch (e) {}
+      seq = null;
+      mountSleep();
+    }
+  }
+
+  // Lancement
+  if (window.__jarvisWakeForceImmediate) {
+    mountWake();   // ?wake=1 : bypass sleep
+  } else {
+    mountSleep(); // défaut : attente clap
+  }
+})();
+</script>
+<script>
+window.loadViewSkills = async function () {
+  try {
+    const r = await fetch('/api/skills/view-scripts', { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} });
+    if (!r.ok) return;
+    const { styles = [], scripts = [] } = await r.json();
+
+    // Retire les anciens assets de vues (data-view-skill="1")
+    document.querySelectorAll('[data-view-skill]').forEach(el => el.remove());
+
+    styles.forEach(href => {
+      const l = document.createElement('link');
+      l.rel = 'stylesheet'; l.href = href;
+      l.dataset.viewSkill = '1';
+      document.head.appendChild(l);
+    });
+    for (const src of scripts) {
+      await new Promise((ok, err) => {
+        const s = document.createElement('script');
+        s.src = src; s.onload = ok; s.onerror = err;
+        s.dataset.viewSkill = '1';
+        document.body.appendChild(s);
+      });
+    }
+  } catch (e) { console.warn('[Jarvis] view skills load error:', e); }
+};
+window.loadViewSkills();
+</script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/home.js.bak-1782169034
+++ b/src/jarvis/interfaces/ui/static/home.js.bak-1782169034
@@ -1,0 +1,906 @@
+/* home.js — page Home runtime */
+(function () {
+  "use strict";
+
+  const J = window.Jarvis;
+
+  // ── Atmosphere + Mission Control ──────────────────────────────────
+  J.mountAtmosphere();
+  J.mountRooms({ mode: "home", pages: [], activePage: null, onNav: () => {} });
+
+  // ── Stubs pour voice.js (tourne aussi dans cette page) ───────────
+  // voice.js cherche addMsg / checkForMindmap en global
+  window.addMsg = function (role, text = "", streaming = false) {
+    if (streaming) {
+      // Retourne une div temporaire que le VoiceClient remplit de chunks
+      const div = document.createElement("div");
+      div.className = "hcw-msg";
+      div.dataset.streaming = "1";
+      const roleEl = document.createElement("span");
+      roleEl.className = "hcw-msg-role " + (role === "jarvis" ? "assistant" : "");
+      roleEl.textContent = role === "jarvis" ? "JARVIS" : "VOUS";
+      const textEl = document.createElement("span");
+      textEl.className = "hcw-msg-text";
+      div.appendChild(roleEl);
+      div.appendChild(textEl);
+      // Si le widget chat est ouvert, on append
+      const msgsEl = document.getElementById("hcw-chat-msgs");
+      if (msgsEl && _ctrlState.chat) {
+        msgsEl.appendChild(div);
+        msgsEl.scrollTop = msgsEl.scrollHeight;
+      }
+      return textEl; // voice.js écrit dans .textContent de ce noeud
+    }
+    // Non-streaming : on recharge le widget si ouvert
+    if (_ctrlState.chat) setTimeout(loadChatWidget, 800);
+    return null;
+  };
+  window.checkForMindmap = function () {};
+
+  // ── WebSocket session ID / send (pour mediapipe_vision.js) ───────
+  let _ws = null;
+  window._jarvisSessionId = () => null;
+  window._jarvisWsSend = (data) => {
+    if (_ws && _ws.readyState === WebSocket.OPEN) {
+      _ws.send(JSON.stringify(data));
+    }
+  };
+
+  // ── Clock + date ──────────────────────────────────────────────────
+  const JOURS = ["DIMANCHE","LUNDI","MARDI","MERCREDI","JEUDI","VENDREDI","SAMEDI"];
+  const MOIS  = ["JANVIER","FÉVRIER","MARS","AVRIL","MAI","JUIN","JUILLET","AOÛT","SEPTEMBRE","OCTOBRE","NOVEMBRE","DÉCEMBRE"];
+
+  function updateClock() {
+    const t   = new Date();
+    const pad = n => String(n).padStart(2, "0");
+    const cl  = document.getElementById("home-clock");
+    const dt  = document.getElementById("home-date");
+    if (cl) cl.textContent = pad(t.getHours()) + ":" + pad(t.getMinutes());
+    if (dt) dt.textContent = JOURS[t.getDay()] + ", " + t.getDate() + " " + MOIS[t.getMonth()] + " " + t.getFullYear();
+  }
+  updateClock();
+  setInterval(updateClock, 1000);
+
+  // ── État orbe ─────────────────────────────────────────────────────
+  const STATE_DOTS = {
+    idle:      { cls: "blue",   label: "AU REPOS" },
+    listening: { cls: "blue",   label: "EN ÉCOUTE" },
+    thinking:  { cls: "purple", label: "RÉFLEXION" },
+    speaking:  { cls: "purple", label: "PARLE" },
+    success:   { cls: "green",  label: "SUCCÈS" },
+    offline:   { cls: "gray",   label: "HORS LIGNE" },
+  };
+
+  let _orb = null;
+  let _currentState = "idle";
+
+  function setOrbState(state) {
+    _currentState = state;
+    const meta = STATE_DOTS[state] || STATE_DOTS.idle;
+    const dot = document.getElementById("status-dot");
+    const lbl = document.getElementById("status-label");
+    if (dot) dot.className = "status-dot " + meta.cls;
+    if (lbl) lbl.textContent = meta.label;
+    if (_orb) _orb.setState(state);
+  }
+
+  function initOrb() {
+    if (typeof THREE === "undefined" || typeof JarvisOrb === "undefined") {
+      setTimeout(initOrb, 100);
+      return;
+    }
+    // Cold boot wake : la séquence va mounter l'orbe sur #orb-canvas en
+    // frozen, puis nous le rendra via injectWakeOrb() à l'entrée ONLINE.
+    if (window.__jarvisWakeActive) return;
+    const canvas = document.getElementById("orb-canvas");
+    if (!canvas) return;
+    _orb = new JarvisOrb(canvas);
+    setOrbState("idle");
+  }
+  initOrb();
+
+  // ── Bascule depuis la séquence de réveil ────────────────────────────
+  // wake_sequence.js appelle ça à l'entrée ONLINE : l'orbe partagé est
+  // remis à home.js, qui prend la main pour les states voice/audio/music.
+  window.__jarvisInjectOrb = function (orb) {
+    _orb = orb;
+    setOrbState("idle");
+  };
+
+  // ── body.view-active : source de vérité unique pour toutes les vues ─
+  const _origViewActivate   = J.views.activate.bind(J.views);
+  const _origViewDeactivate = J.views.deactivate.bind(J.views);
+  J.views.activate = function (id, params) {
+    _origViewActivate(id, params);
+    document.body.classList.add("view-active");
+  };
+  J.views.deactivate = function (id) {
+    _origViewDeactivate(id);
+    // Différé : si activate() enchaîne, _active est déjà re-setté quand le check tourne
+    Promise.resolve().then(() => {
+      if (!J.views._active) document.body.classList.remove("view-active");
+    });
+  };
+
+  // ── Sync état orbe depuis les events voice.js ─────────────────────
+  const VOICE_ORB_MAP = {
+    vad_start:   "listening",
+    stt_done:    "thinking",
+    llm_start:   "thinking",
+    tts_start:   "speaking",
+    tts_done:    "idle",
+    interrupted: "listening",
+  };
+  window.addEventListener("jarvis:ws", (e) => {
+    const msg = e.detail;
+    if (VOICE_ORB_MAP[msg.type]) setOrbState(VOICE_ORB_MAP[msg.type]);
+    if (msg.type === "tts_done" || msg.type === "done") {
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  });
+
+  // ── Controls (pictos haut-gauche) ─────────────────────────────────
+  const CTRL_DEFS = [
+    { key: "mic",    id: "hc-mic" },
+    { key: "screen", id: "hc-screen" },
+    { key: "cam",    id: "hc-cam" },
+    { key: "files",  id: "hc-files" },
+    { key: "music",  id: "hc-music",  widget: "hc-widget-music" },
+    { key: "chat",   id: "hc-chat",   widget: "hc-widget-chat" },
+  ];
+
+  const _ctrlState = {};
+  CTRL_DEFS.forEach(c => { _ctrlState[c.key] = false; });
+
+  function setCtrl(key, val) {
+    _ctrlState[key] = val;
+    const def = CTRL_DEFS.find(c => c.key === key);
+    if (!def) return;
+    const btn = document.getElementById(def.id);
+    if (btn) btn.classList.toggle("active", val);
+    if (def.widget) {
+      const w = document.getElementById(def.widget);
+      if (w) w.classList.toggle("is-open", val);
+    }
+  }
+
+  async function toggleCtrl(key) {
+    const next = !_ctrlState[key];
+
+    if (key === "mic") {
+      _ctrlState.mic = next;
+      const vc = window._voiceClient;
+      if (!vc) return;
+      if (next) {
+        await playGreeting();
+        try {
+          await vc._start();
+        } catch (err) {
+          console.error("[Mic] Erreur demarrage :", err);
+          _ctrlState.mic = false;
+          setOrbState("offline");
+          setTimeout(() => setOrbState("idle"), 2000);
+        }
+      } else {
+        vc._stop();
+        setOrbState("idle");
+      }
+      return;
+    }
+
+    if (key === "cam") {
+      if (next) {
+        setCtrl("cam", true);  // marque actif immédiatement pour que le 2e clic puisse désactiver
+        const ok = await startCamera();
+        if (!ok) {
+          setCtrl("cam", false);
+          return;
+        }
+        J.api.patch("/api/permissions/camera", { enabled: true }).catch(() => {});
+      } else {
+        stopCamera();
+        setCtrl("cam", false);
+        J.api.patch("/api/permissions/camera", { enabled: false }).catch(() => {});
+      }
+      return;
+    }
+
+    if (key === "screen") {
+      setCtrl("screen", next);
+      J.api.patch("/api/permissions/screen", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "files") {
+      setCtrl("files", next);
+      J.api.patch("/api/permissions/files", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "music") {
+      setCtrl("music", next);
+      if (next) startMusicPoll();
+      else stopMusicPoll();
+      return;
+    }
+
+    if (key === "chat") {
+      setCtrl("chat", next);
+      if (next) loadChatWidget();
+      return;
+    }
+  }
+
+  // Charge l'etat initial des permissions depuis le serveur
+  (async function loadPermissions() {
+    try {
+      const perms = await J.api.get("/api/permissions");
+      if (perms.screen   != null) setCtrl("screen", perms.screen);
+      if (perms.camera   != null) setCtrl("cam",    perms.camera);
+      if (perms.files    != null) setCtrl("files",  perms.files);
+    } catch (_) {}
+  })();
+
+  CTRL_DEFS.forEach(c => {
+    const btn = document.getElementById(c.id);
+    if (btn) btn.addEventListener("click", () => toggleCtrl(c.key));
+  });
+
+  // Lier le bouton mic au VoiceClient après DOMContentLoaded
+  document.addEventListener("DOMContentLoaded", () => {
+    const vc = window._voiceClient;
+    if (vc) {
+      vc._btn = document.getElementById("hc-mic");
+    }
+  }, { once: true });
+
+  // ── Greeting vocal (comme l'ancien repo) ──────────────────────────
+  async function playGreeting() {
+    try {
+      let fn = "";
+      try {
+        const s = await fetch("/api/wakeup/status").then((r) => r.json());
+        fn = (s && s.user_firstname) || "";
+      } catch { /* repli sans prénom */ }
+      const greeting = fn ? `Systèmes en ligne. Bonjour ${fn}.` : "Systèmes en ligne.";
+      const resp = await fetch("/api/voice/speak", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: greeting }),
+      });
+      const data = await resp.json();
+      if (!data.audio_b64) return;
+
+      // Décoder le base64 → ArrayBuffer → AudioContext
+      const binary = atob(data.audio_b64);
+      const bytes  = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+      const audioCtx = new AudioContext();
+      const buffer   = await audioCtx.decodeAudioData(bytes.buffer);
+      const source   = audioCtx.createBufferSource();
+      source.buffer  = buffer;
+      source.connect(audioCtx.destination);
+
+      setOrbState("speaking");
+
+      await new Promise((resolve) => {
+        source.onended = resolve;
+        source.start();
+      });
+      audioCtx.close();
+    } catch (err) {
+      console.warn("[Greeting] Erreur :", err);
+    } finally {
+      setOrbState("listening");
+    }
+  }
+
+  // ── Caméra (MediaPipe) ─────────────────────────────────────────────
+  let _camStream = null;
+
+  async function startCamera() {
+    try {
+      _camStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "user", width: { ideal: 640 }, height: { ideal: 480 } },
+      });
+      const video = document.getElementById("cam-video");
+      if (video) {
+        video.srcObject = _camStream;
+        await video.play();
+      }
+      document.getElementById("cam-overlay")?.classList.add("is-open");
+      // Initialise MediaPipe (charge les modèles si nécessaire)
+      if (typeof mpInit === "function") {
+        await mpInit();
+        mpStart();
+      }
+      return true;
+    } catch (err) {
+      console.error("[Camera] Erreur :", err);
+      return false;
+    }
+  }
+
+  function stopCamera() {
+    if (typeof mpStop === "function") mpStop();
+    if (_camStream) {
+      _camStream.getTracks().forEach(t => t.stop());
+      _camStream = null;
+    }
+    const video = document.getElementById("cam-video");
+    if (video) video.srcObject = null;
+    document.getElementById("cam-overlay")?.classList.remove("is-open");
+  }
+
+
+  // ── Widget Musique ─────────────────────────────────────────────────
+  let _musicPollTimer = null;
+  let _musicPlaying   = false;
+
+  function startMusicPoll() {
+    fetchMusicStatus();
+    _musicPollTimer = setInterval(fetchMusicStatus, 5000);
+  }
+
+  function stopMusicPoll() {
+    clearInterval(_musicPollTimer);
+    _musicPollTimer = null;
+  }
+
+  async function fetchMusicStatus() {
+    try {
+      const s = await J.api.get("/api/music/status");
+      updateMusicWidget(s);
+    } catch (_) {}
+  }
+
+  function updateMusicWidget(s) {
+    const trackEl  = document.getElementById("hcw-music-track");
+    const artistEl = document.getElementById("hcw-music-artist");
+    const srcEl    = document.getElementById("hcw-music-source");
+    const artEl    = document.getElementById("hcw-album-art");
+    const fillEl   = document.getElementById("hcw-progress-fill");
+    const playIcon = document.getElementById("hcw-play-icon");
+
+    if (!s || !s.connected) {
+      if (trackEl)  trackEl.textContent  = "Non connecté";
+      if (artistEl) artistEl.textContent = s?.provider ? "Configurer dans les paramètres" : "Aucun service configuré";
+      if (srcEl)    srcEl.textContent    = s?.provider || "—";
+      return;
+    }
+
+    _musicPlaying = s.is_playing || false;
+
+    const providerLabel = (s.provider || "").toUpperCase();
+    if (srcEl) srcEl.textContent = providerLabel || "—";
+
+    if (!s.track) {
+      if (trackEl)  trackEl.textContent  = "Aucune lecture";
+      if (artistEl) artistEl.textContent = providerLabel ? providerLabel + " CONNECTÉ" : "—";
+    } else {
+      if (trackEl)  trackEl.textContent  = s.track;
+      if (artistEl) artistEl.textContent = s.last_played
+        ? (s.artist || "") + (s.artist ? " — DERNIER JOUÉ" : "DERNIER JOUÉ")
+        : (s.artist || "");
+    }
+
+    // Album art
+    if (artEl) {
+      if (s.album_art) {
+        artEl.src = s.album_art;
+        artEl.classList.add("loaded");
+      } else {
+        artEl.classList.remove("loaded");
+      }
+    }
+
+    // Barre de progression
+    if (fillEl && s.duration_ms > 0) {
+      const pct = Math.min(100, (s.progress_ms / s.duration_ms) * 100);
+      fillEl.style.width = pct + "%";
+    }
+
+    // Icône play/pause
+    if (playIcon) {
+      playIcon.innerHTML = _musicPlaying
+        ? '<line x1="5" y1="2" x2="5" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="10" y1="2" x2="10" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>'
+        : '<path fill="currentColor" d="M3 2l10 4.5L3 11V2z"/>';
+    }
+  }
+
+  // ── Spotify Web Playback SDK ───────────────────────────────────────
+  let _spotifyPlayer   = null;
+  let _spotifyDeviceId = null;
+  let _sdkProgressTimer = null;
+  let _currentTrackId  = null;
+
+  async function fetchTrackBeat(trackId) {
+    // Fallback immédiat — l'API audio-features est dépréciée pour les nouvelles apps
+    const applyBeat = (tempo, energy) => { if (_orb) _orb.setMusicBeat(tempo, energy); };
+    try {
+      const { token } = await (await fetch("/api/spotify/token", { headers: J.authHeaders ? J.authHeaders() : {} })).json();
+      if (!token) return applyBeat(120, 0.6);
+      const resp = await fetch(
+        `https://api.spotify.com/v1/audio-features/${trackId}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!resp.ok) return applyBeat(120, 0.6);
+      const f = await resp.json();
+      applyBeat(f.tempo || 120, f.energy ?? 0.6);
+    } catch (_) {
+      applyBeat(120, 0.6);
+    }
+  }
+
+  function _tickSDKProgress() {
+    if (!_spotifyPlayer || !_musicPlaying) return;
+    _spotifyPlayer.getCurrentState().then(state => {
+      if (!state) return;
+      const fillEl = document.getElementById("hcw-progress-fill");
+      if (fillEl && state.duration) {
+        fillEl.style.width = Math.min(100, (state.position / state.duration) * 100) + "%";
+      }
+    }).catch(() => {});
+  }
+
+  async function initSpotifySDK() {
+    if (_spotifyPlayer || window._sdkInitStarted) return;
+    window._sdkInitStarted = true;
+
+    try {
+      const status = await J.api.get("/api/music/provider-status");
+      if (status.provider !== "spotify") return;
+    } catch (_) { return; }
+
+    window.onSpotifyWebPlaybackSDKReady = () => {
+      _spotifyPlayer = new Spotify.Player({
+        name: "JARVIS",
+        getOAuthToken: async (cb) => {
+          try {
+            const res = await fetch("/api/spotify/token", { headers: J.authHeaders ? J.authHeaders() : {} });
+            const data = await res.json();
+            cb(data.token || "");
+          } catch (_) { cb(""); }
+        },
+        volume: 0.7,
+      });
+
+      _spotifyPlayer.addListener("ready", ({ device_id }) => {
+        _spotifyDeviceId = device_id;
+        // Enregistre le device sans transférer la lecture
+        fetch("/api/spotify/transfer", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...(J.authHeaders ? J.authHeaders() : {}) },
+          body: JSON.stringify({ device_id }),
+        }).catch(() => {});
+        // Charge l'état initial (dernier joué)
+        if (_ctrlState.music) fetchMusicStatus();
+      });
+
+      _spotifyPlayer.addListener("not_ready", () => {
+        _spotifyDeviceId = null;
+      });
+
+      _spotifyPlayer.addListener("player_state_changed", (state) => {
+        if (!state) return;
+        const track = state.track_window?.current_track;
+        if (!track) return;
+        _musicPlaying = !state.paused;
+
+        // Beat sync
+        const tid = track.id;
+        const wasPlaying = _musicPlaying;
+        if (tid && (tid !== _currentTrackId || (!wasPlaying && !state.paused))) {
+          _currentTrackId = tid;
+          if (!state.paused) fetchTrackBeat(tid);
+        }
+        if (state.paused && _orb) _orb.setMusicBeat(0, 0);
+
+        updateMusicWidget({
+          connected: true,
+          is_playing: !state.paused,
+          track: track.name,
+          artist: track.artists?.map(a => a.name).join(", ") || "",
+          album: track.album?.name || "",
+          album_art: track.album?.images?.[0]?.url || null,
+          progress_ms: state.position,
+          duration_ms: track.duration_ms,
+          provider: "spotify",
+        });
+      });
+
+      _spotifyPlayer.connect();
+      _sdkProgressTimer = setInterval(_tickSDKProgress, 1000);
+    };
+
+    const script = document.createElement("script");
+    script.src = "https://sdk.scdn.co/spotify-player.js";
+    document.head.appendChild(script);
+  }
+
+  // Démarrage SDK au chargement de la page
+  initSpotifySDK();
+
+  // Boutons du widget musique — SDK en priorité, API en fallback
+  document.getElementById("hcw-prev")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.previousTrack().catch(() => {}); return; }
+    J.api.post("/api/music/prev").then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-play")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.togglePlay().catch(() => {}); return; }
+    J.api.post(_musicPlaying ? "/api/music/pause" : "/api/music/play")
+      .then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-next")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.nextTrack().catch(() => {}); return; }
+    J.api.post("/api/music/next").then(fetchMusicStatus).catch(() => {});
+  });
+
+
+  // ── Widget Chat ────────────────────────────────────────────────────
+  async function loadChatWidget() {
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (!msgsEl) return;
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucune session</div>';
+        return;
+      }
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=30");
+      if (countEl) countEl.textContent = msgs.length + " msg";
+      msgsEl.innerHTML = "";
+      const recent = msgs.slice(-14);
+      if (!recent.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucun message</div>';
+        return;
+      }
+      recent.forEach(m => {
+        const text = m.content || m.text || "";
+        if (!text) return;
+        const wrap = document.createElement("div");
+        wrap.className = "hcw-msg";
+        const role = document.createElement("span");
+        role.className = "hcw-msg-role " + (m.role === "assistant" ? "assistant" : "");
+        role.textContent = m.role === "assistant" ? "JARVIS" : "VOUS";
+        const body = document.createElement("span");
+        body.className = "hcw-msg-text";
+        body.textContent = text.length > 220 ? text.slice(0, 217) + "…" : text;
+        wrap.appendChild(role);
+        wrap.appendChild(body);
+        msgsEl.appendChild(wrap);
+      });
+      msgsEl.scrollTop = msgsEl.scrollHeight;
+    } catch (_) {
+      msgsEl.innerHTML = '<div class="hcw-empty">Erreur de chargement</div>';
+    }
+  }
+
+  // ── Widget Chat : envoi de message texte ──────────────────────────
+  let _chatSending = false;
+
+  function appendChatMsg(role, text, streaming) {
+    const msgsEl = document.getElementById("hcw-chat-msgs");
+    if (!msgsEl) return null;
+    const empty = msgsEl.querySelector(".hcw-empty");
+    if (empty) empty.remove();
+
+    const wrap = document.createElement("div");
+    wrap.className = "hcw-msg";
+    const roleEl = document.createElement("span");
+    roleEl.className = "hcw-msg-role" + (role === "assistant" ? " assistant" : "");
+    roleEl.textContent = role === "assistant" ? "JARVIS" : "VOUS";
+    const bodyEl = document.createElement("span");
+    bodyEl.className = "hcw-msg-text";
+    bodyEl.textContent = text;
+    wrap.appendChild(roleEl);
+    wrap.appendChild(bodyEl);
+    msgsEl.appendChild(wrap);
+    msgsEl.scrollTop = msgsEl.scrollHeight;
+    if (streaming) return bodyEl;
+    return null;
+  }
+
+  async function sendChatMessage() {
+    if (_chatSending) return;
+    const input = document.getElementById("hcw-input");
+    const sendBtn = document.getElementById("hcw-send");
+    const text = (input?.value || "").trim();
+    if (!text) return;
+
+    _chatSending = true;
+    if (sendBtn) sendBtn.disabled = true;
+    input.value = "";
+
+    appendChatMsg("user", text, false);
+
+    const streamTarget = appendChatMsg("assistant", "", true);
+    setOrbState("thinking");
+
+    try {
+      const sessionId = localStorage.getItem("jarvis_voice_session") || null;
+      const resp = await fetch("/api/voice/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...(J.authHeaders ? J.authHeaders() : {}) },
+        body: JSON.stringify({ message: text, session_id: sessionId }),
+      });
+      const returnedSid = resp.headers.get("x-session-id");
+      if (returnedSid) localStorage.setItem("jarvis_voice_session", returnedSid);
+
+      if (!resp.ok || !resp.body) throw new Error("Erreur réseau");
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let full = "";
+      setOrbState("speaking");
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        full += decoder.decode(value, { stream: true });
+        if (streamTarget) {
+          streamTarget.textContent = full;
+          document.getElementById("hcw-chat-msgs").scrollTop = 9999;
+        }
+      }
+
+      const countEl = document.getElementById("hcw-chat-count");
+      if (countEl) {
+        const cur = parseInt(countEl.textContent) || 0;
+        countEl.textContent = (cur + 2) + " msg";
+      }
+    } catch (err) {
+      if (streamTarget) streamTarget.textContent = "Erreur de communication.";
+    } finally {
+      _chatSending = false;
+      if (sendBtn) sendBtn.disabled = false;
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  }
+
+  document.getElementById("hcw-new-session")?.addEventListener("click", () => {
+    localStorage.removeItem("jarvis_voice_session");
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (msgsEl)  msgsEl.innerHTML = '<div class="hcw-empty">Nouvelle conversation</div>';
+    if (countEl) countEl.textContent = "—";
+    document.getElementById("hcw-input")?.focus();
+  });
+
+  document.getElementById("hcw-send")?.addEventListener("click", sendChatMessage);
+
+  document.getElementById("hcw-input")?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendChatMessage();
+    }
+  });
+
+
+  // ── WebSocket — sync état orbe + canal passif ──────────────────────
+  function connectWS() {
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    try {
+      _ws = new WebSocket(proto + "//" + location.host + "/ws");
+    } catch (_) { return; }
+
+    _ws.onmessage = (ev) => {
+      let data;
+      try { data = JSON.parse(ev.data); } catch (_) { return; }
+
+      if (data.type === "voice_state") setOrbState(data.state || "idle");
+      if (data.type === "audio_level" && _orb) _orb.setAudioLevel(data.level || 0);
+      if (data.type === "wake_up") window.dispatchEvent(new CustomEvent("jarvis-wake", { detail: data }));
+
+      if (data.type === "message" && data.role === "assistant" && data.text) {
+        showChannel(data.text);
+        if (_ctrlState.chat) loadChatWidget();
+      }
+
+      // ── View routing ──────────────────────────────────────────────
+      if (data.type === "reload_views") {
+        const _prevActive = J.views._active;
+        if (_prevActive) J.views.deactivate(_prevActive);
+        // Supprime aussi les scripts sans data-view-skill (chargés avant le fix)
+        document.querySelectorAll('script[src*="/skills/"]').forEach(el => el.remove());
+        document.querySelectorAll('link[href*="/skills/"]').forEach(el => el.remove());
+        window.loadViewSkills?.().then?.(() => {
+          if (_prevActive) J.views.activate(_prevActive);
+        });
+      }
+      if (data.type === "show_home")  { const a = J.views._active; if (a) J.views.deactivate(a); }
+      if (data.type === "show_view")    J.views.activate(data.view_id, data.params);
+      if (data.type === "hide_view")    J.views.deactivate(data.view_id);
+      if (data.type === "view_command") J.views.dispatch(data.view_id, data.command, data.params);
+
+      // Backward compat (map_control legacy events)
+      if (data.type === "map_fly_to")    { J.views.activate("globe"); J.views.dispatch("globe", "fly_to", data); }
+      if (data.type === "map_zoom_out")  J.views.dispatch("globe", "zoom_out", {});
+      if (data.type === "map_zoom_in")   J.views.dispatch("globe", "zoom_in", {});
+      if (data.type === "map_globe_view"){ J.views.activate("globe"); J.views.dispatch("globe", "globe_view", {}); }
+      if (data.type === "toggle_panels") J.views.dispatch("globe", "toggle_panels", {});
+    };
+
+    _ws.onclose = () => setTimeout(connectWS, 3000);
+  }
+  connectWS();
+
+  // ── Canal passif (bas-droite) ──────────────────────────────────────
+  let _channelTs    = null;
+  let _channelTimer = null;
+
+  function relativeTime(ts) {
+    const mins = Math.round((Date.now() - ts) / 60000);
+    if (mins < 1)  return "À L'INSTANT";
+    if (mins === 1) return "IL Y A 1 MIN";
+    if (mins < 60) return "IL Y A " + mins + " MIN";
+    return "IL Y A " + Math.floor(mins / 60) + " H";
+  }
+
+  function updateChannelTime() {
+    if (!_channelTs) return;
+    const el = document.getElementById("channel-time");
+    if (el) el.textContent = relativeTime(_channelTs);
+  }
+
+  function showChannel(text) {
+    const el  = document.getElementById("home-channel");
+    const msg = document.getElementById("channel-msg");
+    if (!el || !msg) return;
+    msg.textContent = text.length > 160 ? text.slice(0, 157) + "…" : text;
+    _channelTs = Date.now();
+    updateChannelTime();
+    el.style.display = "";
+    if (_channelTimer) clearInterval(_channelTimer);
+    _channelTimer = setInterval(updateChannelTime, 30000);
+  }
+
+  (async function loadLastMessage() {
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) return;
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=10");
+      const last = [...msgs].reverse().find(m => m.role === "assistant");
+      if (last && (last.content || last.text)) showChannel(last.content || last.text);
+    } catch (_) {}
+  })();
+
+  // ── Navigation iframe — shell persistant ─────────────────────────
+  const _frame = document.getElementById("page-frame");
+  let _frameActive = false;
+
+  Jarvis.navigateFrame = function (url) {
+    if (!url || url === "/" || url === window.location.origin + "/") {
+      // Retour home — cacher l'iframe
+      if (_frame) {
+        _frame.classList.remove("is-active");
+        _frame.src = "about:blank";
+      }
+      _frameActive = false;
+      history.replaceState(null, "", "/");
+    } else {
+      // Fermer toute vue active (globe, etc.) avant de naviguer
+      Jarvis.views.deactivate();
+      if (_frame) {
+        _frame.src = url;
+        _frame.classList.add("is-active");
+      }
+      _frameActive = true;
+      history.pushState({ frame: url }, "", url);
+    }
+  };
+
+  // Bouton retour navigateur
+  window.addEventListener("popstate", (e) => {
+    if (e.state?.frame) {
+      if (_frame) { _frame.src = e.state.frame; _frame.classList.add("is-active"); }
+      _frameActive = true;
+    } else {
+      if (_frame) { _frame.classList.remove("is-active"); _frame.src = "about:blank"; }
+      _frameActive = false;
+    }
+  });
+
+  // ── Touche espace → dashboard (ou ferme l'iframe si déjà ouvert) ──
+  document.addEventListener("keydown", (e) => {
+    if (e.key === " " && !e.metaKey && !e.ctrlKey) {
+      const active = document.activeElement;
+      if (active && (active.tagName === "INPUT" || active.tagName === "TEXTAREA")) return;
+      e.preventDefault();
+      if (_frameActive) {
+        Jarvis.navigateFrame("/");
+      } else {
+        Jarvis.navigateFrame("/dashboard");
+      }
+    }
+  });
+
+  // ── Helper drag-and-drop pour widgets / overlay ────────────────────
+  function makeDraggable(el, handle) {
+    if (!el) return;
+    const grip = handle || el;
+
+    grip.addEventListener("mousedown", (e) => {
+      if (e.target.closest("button, input, textarea, .hcw-resize-handle")) return;
+      e.preventDefault();
+      let ex = e.clientX, ey = e.clientY;
+      el.classList.add("dragging");
+
+      function onMove(e) {
+        const dx = e.clientX - ex;
+        const dy = e.clientY - ey;
+        ex = e.clientX; ey = e.clientY;
+        const rect = el.getBoundingClientRect();
+        el.style.left   = (rect.left + dx) + "px";
+        el.style.top    = (rect.top  + dy) + "px";
+        el.style.right  = "auto";
+        el.style.bottom = "auto";
+      }
+
+      function onUp() {
+        el.classList.remove("dragging");
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // ── Helper redimensionnement pour widgets ──────────────────────────
+  function makeResizable(el, handleEl, minW, minH) {
+    if (!el || !handleEl) return;
+    minW = minW || 180;
+    minH = minH || 80;
+
+    handleEl.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Ancrer en top/left au moment du resize
+      const rect = el.getBoundingClientRect();
+      el.style.left   = rect.left   + "px";
+      el.style.top    = rect.top    + "px";
+      el.style.right  = "auto";
+      el.style.bottom = "auto";
+      el.style.width  = rect.width  + "px";
+      el.style.height = rect.height + "px";
+
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startW = rect.width;
+      const startH = rect.height;
+
+      function onMove(e) {
+        const w = Math.max(minW, startW + (e.clientX - startX));
+        const h = Math.max(minH, startH + (e.clientY - startY));
+        el.style.width  = w + "px";
+        el.style.height = h + "px";
+        // Enleve max-height sur le corps messages si present
+        const msgs = el.querySelector(".hcw-messages");
+        if (msgs) msgs.style.maxHeight = "none";
+      }
+
+      function onUp() {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // Attacher drag + resize aux widgets
+  makeDraggable(document.getElementById("cam-overlay"), document.getElementById("cam-drag-handle"));
+  makeResizable(document.getElementById("cam-overlay"), document.getElementById("cam-resize-handle"), 180, 120);
+
+  makeDraggable(document.getElementById("hc-widget-music"));
+  makeResizable(document.getElementById("hc-widget-music"), document.getElementById("music-resize-handle"), 180, 100);
+
+  makeDraggable(document.getElementById("hc-widget-chat"));
+  makeResizable(document.getElementById("hc-widget-chat"), document.getElementById("chat-resize-handle"), 220, 160);
+})();

--- a/src/jarvis/interfaces/ui/static/home.js.bak-20260620-124254
+++ b/src/jarvis/interfaces/ui/static/home.js.bak-20260620-124254
@@ -1,0 +1,888 @@
+/* home.js — page Home runtime */
+(function () {
+  "use strict";
+
+  const J = window.Jarvis;
+
+  // ── Atmosphere + Mission Control ──────────────────────────────────
+  J.mountAtmosphere();
+  J.mountRooms({ mode: "home", pages: [], activePage: null, onNav: () => {} });
+
+  // ── Stubs pour voice.js (tourne aussi dans cette page) ───────────
+  // voice.js cherche addMsg / checkForMindmap en global
+  window.addMsg = function (role, text = "", streaming = false) {
+    if (streaming) {
+      // Retourne une div temporaire que le VoiceClient remplit de chunks
+      const div = document.createElement("div");
+      div.className = "hcw-msg";
+      div.dataset.streaming = "1";
+      const roleEl = document.createElement("span");
+      roleEl.className = "hcw-msg-role " + (role === "jarvis" ? "assistant" : "");
+      roleEl.textContent = role === "jarvis" ? "JARVIS" : "VOUS";
+      const textEl = document.createElement("span");
+      textEl.className = "hcw-msg-text";
+      div.appendChild(roleEl);
+      div.appendChild(textEl);
+      // Si le widget chat est ouvert, on append
+      const msgsEl = document.getElementById("hcw-chat-msgs");
+      if (msgsEl && _ctrlState.chat) {
+        msgsEl.appendChild(div);
+        msgsEl.scrollTop = msgsEl.scrollHeight;
+      }
+      return textEl; // voice.js écrit dans .textContent de ce noeud
+    }
+    // Non-streaming : on recharge le widget si ouvert
+    if (_ctrlState.chat) setTimeout(loadChatWidget, 800);
+    return null;
+  };
+  window.checkForMindmap = function () {};
+
+  // ── WebSocket session ID / send (pour mediapipe_vision.js) ───────
+  let _ws = null;
+  window._jarvisSessionId = () => null;
+  window._jarvisWsSend = (data) => {
+    if (_ws && _ws.readyState === WebSocket.OPEN) {
+      _ws.send(JSON.stringify(data));
+    }
+  };
+
+  // ── Clock + date ──────────────────────────────────────────────────
+  const JOURS = ["DIMANCHE","LUNDI","MARDI","MERCREDI","JEUDI","VENDREDI","SAMEDI"];
+  const MOIS  = ["JANVIER","FÉVRIER","MARS","AVRIL","MAI","JUIN","JUILLET","AOÛT","SEPTEMBRE","OCTOBRE","NOVEMBRE","DÉCEMBRE"];
+
+  function updateClock() {
+    const t   = new Date();
+    const pad = n => String(n).padStart(2, "0");
+    const cl  = document.getElementById("home-clock");
+    const dt  = document.getElementById("home-date");
+    if (cl) cl.textContent = pad(t.getHours()) + ":" + pad(t.getMinutes());
+    if (dt) dt.textContent = JOURS[t.getDay()] + ", " + t.getDate() + " " + MOIS[t.getMonth()] + " " + t.getFullYear();
+  }
+  updateClock();
+  setInterval(updateClock, 1000);
+
+  // ── État orbe ─────────────────────────────────────────────────────
+  const STATE_DOTS = {
+    idle:      { cls: "blue",   label: "AU REPOS" },
+    listening: { cls: "blue",   label: "EN ÉCOUTE" },
+    thinking:  { cls: "purple", label: "RÉFLEXION" },
+    speaking:  { cls: "purple", label: "PARLE" },
+    success:   { cls: "green",  label: "SUCCÈS" },
+    offline:   { cls: "gray",   label: "HORS LIGNE" },
+  };
+
+  let _orb = null;
+  let _currentState = "idle";
+
+  function setOrbState(state) {
+    _currentState = state;
+    const meta = STATE_DOTS[state] || STATE_DOTS.idle;
+    const dot = document.getElementById("status-dot");
+    const lbl = document.getElementById("status-label");
+    if (dot) dot.className = "status-dot " + meta.cls;
+    if (lbl) lbl.textContent = meta.label;
+    if (_orb) _orb.setState(state);
+  }
+
+  function initOrb() {
+    if (typeof THREE === "undefined" || typeof JarvisOrb === "undefined") {
+      setTimeout(initOrb, 100);
+      return;
+    }
+    const canvas = document.getElementById("orb-canvas");
+    if (!canvas) return;
+    _orb = new JarvisOrb(canvas);
+    setOrbState("idle");
+  }
+  initOrb();
+
+  // ── body.view-active : source de vérité unique pour toutes les vues ─
+  const _origViewActivate   = J.views.activate.bind(J.views);
+  const _origViewDeactivate = J.views.deactivate.bind(J.views);
+  J.views.activate = function (id, params) {
+    _origViewActivate(id, params);
+    document.body.classList.add("view-active");
+  };
+  J.views.deactivate = function (id) {
+    _origViewDeactivate(id);
+    // Différé : si activate() enchaîne, _active est déjà re-setté quand le check tourne
+    Promise.resolve().then(() => {
+      if (!J.views._active) document.body.classList.remove("view-active");
+    });
+  };
+
+  // ── Sync état orbe depuis les events voice.js ─────────────────────
+  const VOICE_ORB_MAP = {
+    vad_start:   "listening",
+    stt_done:    "thinking",
+    llm_start:   "thinking",
+    tts_start:   "speaking",
+    tts_done:    "idle",
+    interrupted: "listening",
+  };
+  window.addEventListener("jarvis:ws", (e) => {
+    const msg = e.detail;
+    if (VOICE_ORB_MAP[msg.type]) setOrbState(VOICE_ORB_MAP[msg.type]);
+    if (msg.type === "tts_done" || msg.type === "done") {
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  });
+
+  // ── Controls (pictos haut-gauche) ─────────────────────────────────
+  const CTRL_DEFS = [
+    { key: "mic",    id: "hc-mic" },
+    { key: "screen", id: "hc-screen" },
+    { key: "cam",    id: "hc-cam" },
+    { key: "files",  id: "hc-files" },
+    { key: "music",  id: "hc-music",  widget: "hc-widget-music" },
+    { key: "chat",   id: "hc-chat",   widget: "hc-widget-chat" },
+  ];
+
+  const _ctrlState = {};
+  CTRL_DEFS.forEach(c => { _ctrlState[c.key] = false; });
+
+  function setCtrl(key, val) {
+    _ctrlState[key] = val;
+    const def = CTRL_DEFS.find(c => c.key === key);
+    if (!def) return;
+    const btn = document.getElementById(def.id);
+    if (btn) btn.classList.toggle("active", val);
+    if (def.widget) {
+      const w = document.getElementById(def.widget);
+      if (w) w.classList.toggle("is-open", val);
+    }
+  }
+
+  async function toggleCtrl(key) {
+    const next = !_ctrlState[key];
+
+    if (key === "mic") {
+      _ctrlState.mic = next;
+      const vc = window._voiceClient;
+      if (!vc) return;
+      if (next) {
+        await playGreeting();
+        try {
+          await vc._start();
+        } catch (err) {
+          console.error("[Mic] Erreur demarrage :", err);
+          _ctrlState.mic = false;
+          setOrbState("offline");
+          setTimeout(() => setOrbState("idle"), 2000);
+        }
+      } else {
+        vc._stop();
+        setOrbState("idle");
+      }
+      return;
+    }
+
+    if (key === "cam") {
+      if (next) {
+        setCtrl("cam", true);  // marque actif immédiatement pour que le 2e clic puisse désactiver
+        const ok = await startCamera();
+        if (!ok) {
+          setCtrl("cam", false);
+          return;
+        }
+        J.api.patch("/api/permissions/camera", { enabled: true }).catch(() => {});
+      } else {
+        stopCamera();
+        setCtrl("cam", false);
+        J.api.patch("/api/permissions/camera", { enabled: false }).catch(() => {});
+      }
+      return;
+    }
+
+    if (key === "screen") {
+      setCtrl("screen", next);
+      J.api.patch("/api/permissions/screen", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "files") {
+      setCtrl("files", next);
+      J.api.patch("/api/permissions/files", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "music") {
+      setCtrl("music", next);
+      if (next) startMusicPoll();
+      else stopMusicPoll();
+      return;
+    }
+
+    if (key === "chat") {
+      setCtrl("chat", next);
+      if (next) loadChatWidget();
+      return;
+    }
+  }
+
+  // Charge l'etat initial des permissions depuis le serveur
+  (async function loadPermissions() {
+    try {
+      const perms = await J.api.get("/api/permissions");
+      if (perms.screen   != null) setCtrl("screen", perms.screen);
+      if (perms.camera   != null) setCtrl("cam",    perms.camera);
+      if (perms.files    != null) setCtrl("files",  perms.files);
+    } catch (_) {}
+  })();
+
+  CTRL_DEFS.forEach(c => {
+    const btn = document.getElementById(c.id);
+    if (btn) btn.addEventListener("click", () => toggleCtrl(c.key));
+  });
+
+  // Lier le bouton mic au VoiceClient après DOMContentLoaded
+  document.addEventListener("DOMContentLoaded", () => {
+    const vc = window._voiceClient;
+    if (vc) {
+      vc._btn = document.getElementById("hc-mic");
+    }
+  }, { once: true });
+
+  // ── Greeting vocal (comme l'ancien repo) ──────────────────────────
+  async function playGreeting() {
+    try {
+      const resp = await fetch("/api/voice/speak", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "Systèmes en ligne. Bonjour Barth." }),
+      });
+      const data = await resp.json();
+      if (!data.audio_b64) return;
+
+      // Décoder le base64 → ArrayBuffer → AudioContext
+      const binary = atob(data.audio_b64);
+      const bytes  = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+      const audioCtx = new AudioContext();
+      const buffer   = await audioCtx.decodeAudioData(bytes.buffer);
+      const source   = audioCtx.createBufferSource();
+      source.buffer  = buffer;
+      source.connect(audioCtx.destination);
+
+      setOrbState("speaking");
+
+      await new Promise((resolve) => {
+        source.onended = resolve;
+        source.start();
+      });
+      audioCtx.close();
+    } catch (err) {
+      console.warn("[Greeting] Erreur :", err);
+    } finally {
+      setOrbState("listening");
+    }
+  }
+
+  // ── Caméra (MediaPipe) ─────────────────────────────────────────────
+  let _camStream = null;
+
+  async function startCamera() {
+    try {
+      _camStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "user", width: { ideal: 640 }, height: { ideal: 480 } },
+      });
+      const video = document.getElementById("cam-video");
+      if (video) {
+        video.srcObject = _camStream;
+        await video.play();
+      }
+      document.getElementById("cam-overlay")?.classList.add("is-open");
+      // Initialise MediaPipe (charge les modèles si nécessaire)
+      if (typeof mpInit === "function") {
+        await mpInit();
+        mpStart();
+      }
+      return true;
+    } catch (err) {
+      console.error("[Camera] Erreur :", err);
+      return false;
+    }
+  }
+
+  function stopCamera() {
+    if (typeof mpStop === "function") mpStop();
+    if (_camStream) {
+      _camStream.getTracks().forEach(t => t.stop());
+      _camStream = null;
+    }
+    const video = document.getElementById("cam-video");
+    if (video) video.srcObject = null;
+    document.getElementById("cam-overlay")?.classList.remove("is-open");
+  }
+
+
+  // ── Widget Musique ─────────────────────────────────────────────────
+  let _musicPollTimer = null;
+  let _musicPlaying   = false;
+
+  function startMusicPoll() {
+    fetchMusicStatus();
+    _musicPollTimer = setInterval(fetchMusicStatus, 5000);
+  }
+
+  function stopMusicPoll() {
+    clearInterval(_musicPollTimer);
+    _musicPollTimer = null;
+  }
+
+  async function fetchMusicStatus() {
+    try {
+      const s = await J.api.get("/api/music/status");
+      updateMusicWidget(s);
+    } catch (_) {}
+  }
+
+  function updateMusicWidget(s) {
+    const trackEl  = document.getElementById("hcw-music-track");
+    const artistEl = document.getElementById("hcw-music-artist");
+    const srcEl    = document.getElementById("hcw-music-source");
+    const artEl    = document.getElementById("hcw-album-art");
+    const fillEl   = document.getElementById("hcw-progress-fill");
+    const playIcon = document.getElementById("hcw-play-icon");
+
+    if (!s || !s.connected) {
+      if (trackEl)  trackEl.textContent  = "Non connecté";
+      if (artistEl) artistEl.textContent = s?.provider ? "Configurer dans les paramètres" : "Aucun service configuré";
+      if (srcEl)    srcEl.textContent    = s?.provider || "—";
+      return;
+    }
+
+    _musicPlaying = s.is_playing || false;
+
+    const providerLabel = (s.provider || "").toUpperCase();
+    if (srcEl) srcEl.textContent = providerLabel || "—";
+
+    if (!s.track) {
+      if (trackEl)  trackEl.textContent  = "Aucune lecture";
+      if (artistEl) artistEl.textContent = providerLabel ? providerLabel + " CONNECTÉ" : "—";
+    } else {
+      if (trackEl)  trackEl.textContent  = s.track;
+      if (artistEl) artistEl.textContent = s.last_played
+        ? (s.artist || "") + (s.artist ? " — DERNIER JOUÉ" : "DERNIER JOUÉ")
+        : (s.artist || "");
+    }
+
+    // Album art
+    if (artEl) {
+      if (s.album_art) {
+        artEl.src = s.album_art;
+        artEl.classList.add("loaded");
+      } else {
+        artEl.classList.remove("loaded");
+      }
+    }
+
+    // Barre de progression
+    if (fillEl && s.duration_ms > 0) {
+      const pct = Math.min(100, (s.progress_ms / s.duration_ms) * 100);
+      fillEl.style.width = pct + "%";
+    }
+
+    // Icône play/pause
+    if (playIcon) {
+      playIcon.innerHTML = _musicPlaying
+        ? '<line x1="5" y1="2" x2="5" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="10" y1="2" x2="10" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>'
+        : '<path fill="currentColor" d="M3 2l10 4.5L3 11V2z"/>';
+    }
+  }
+
+  // ── Spotify Web Playback SDK ───────────────────────────────────────
+  let _spotifyPlayer   = null;
+  let _spotifyDeviceId = null;
+  let _sdkProgressTimer = null;
+  let _currentTrackId  = null;
+
+  async function fetchTrackBeat(trackId) {
+    // Fallback immédiat — l'API audio-features est dépréciée pour les nouvelles apps
+    const applyBeat = (tempo, energy) => { if (_orb) _orb.setMusicBeat(tempo, energy); };
+    try {
+      const { token } = await (await fetch("/api/spotify/token")).json();
+      if (!token) return applyBeat(120, 0.6);
+      const resp = await fetch(
+        `https://api.spotify.com/v1/audio-features/${trackId}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!resp.ok) return applyBeat(120, 0.6);
+      const f = await resp.json();
+      applyBeat(f.tempo || 120, f.energy ?? 0.6);
+    } catch (_) {
+      applyBeat(120, 0.6);
+    }
+  }
+
+  function _tickSDKProgress() {
+    if (!_spotifyPlayer || !_musicPlaying) return;
+    _spotifyPlayer.getCurrentState().then(state => {
+      if (!state) return;
+      const fillEl = document.getElementById("hcw-progress-fill");
+      if (fillEl && state.duration) {
+        fillEl.style.width = Math.min(100, (state.position / state.duration) * 100) + "%";
+      }
+    }).catch(() => {});
+  }
+
+  async function initSpotifySDK() {
+    if (_spotifyPlayer || window._sdkInitStarted) return;
+    window._sdkInitStarted = true;
+
+    try {
+      const status = await J.api.get("/api/music/provider-status");
+      if (status.provider !== "spotify") return;
+    } catch (_) { return; }
+
+    window.onSpotifyWebPlaybackSDKReady = () => {
+      _spotifyPlayer = new Spotify.Player({
+        name: "JARVIS",
+        getOAuthToken: async (cb) => {
+          try {
+            const res = await fetch("/api/spotify/token");
+            const data = await res.json();
+            cb(data.token || "");
+          } catch (_) { cb(""); }
+        },
+        volume: 0.7,
+      });
+
+      _spotifyPlayer.addListener("ready", ({ device_id }) => {
+        _spotifyDeviceId = device_id;
+        // Enregistre le device sans transférer la lecture
+        fetch("/api/spotify/transfer", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ device_id }),
+        }).catch(() => {});
+        // Charge l'état initial (dernier joué)
+        if (_ctrlState.music) fetchMusicStatus();
+      });
+
+      _spotifyPlayer.addListener("not_ready", () => {
+        _spotifyDeviceId = null;
+      });
+
+      _spotifyPlayer.addListener("player_state_changed", (state) => {
+        if (!state) return;
+        const track = state.track_window?.current_track;
+        if (!track) return;
+        _musicPlaying = !state.paused;
+
+        // Beat sync
+        const tid = track.id;
+        const wasPlaying = _musicPlaying;
+        if (tid && (tid !== _currentTrackId || (!wasPlaying && !state.paused))) {
+          _currentTrackId = tid;
+          if (!state.paused) fetchTrackBeat(tid);
+        }
+        if (state.paused && _orb) _orb.setMusicBeat(0, 0);
+
+        updateMusicWidget({
+          connected: true,
+          is_playing: !state.paused,
+          track: track.name,
+          artist: track.artists?.map(a => a.name).join(", ") || "",
+          album: track.album?.name || "",
+          album_art: track.album?.images?.[0]?.url || null,
+          progress_ms: state.position,
+          duration_ms: track.duration_ms,
+          provider: "spotify",
+        });
+      });
+
+      _spotifyPlayer.connect();
+      _sdkProgressTimer = setInterval(_tickSDKProgress, 1000);
+    };
+
+    const script = document.createElement("script");
+    script.src = "https://sdk.scdn.co/spotify-player.js";
+    document.head.appendChild(script);
+  }
+
+  // Démarrage SDK au chargement de la page
+  initSpotifySDK();
+
+  // Boutons du widget musique — SDK en priorité, API en fallback
+  document.getElementById("hcw-prev")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.previousTrack().catch(() => {}); return; }
+    J.api.post("/api/music/prev").then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-play")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.togglePlay().catch(() => {}); return; }
+    J.api.post(_musicPlaying ? "/api/music/pause" : "/api/music/play")
+      .then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-next")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.nextTrack().catch(() => {}); return; }
+    J.api.post("/api/music/next").then(fetchMusicStatus).catch(() => {});
+  });
+
+
+  // ── Widget Chat ────────────────────────────────────────────────────
+  async function loadChatWidget() {
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (!msgsEl) return;
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucune session</div>';
+        return;
+      }
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=30");
+      if (countEl) countEl.textContent = msgs.length + " msg";
+      msgsEl.innerHTML = "";
+      const recent = msgs.slice(-14);
+      if (!recent.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucun message</div>';
+        return;
+      }
+      recent.forEach(m => {
+        const text = m.content || m.text || "";
+        if (!text) return;
+        const wrap = document.createElement("div");
+        wrap.className = "hcw-msg";
+        const role = document.createElement("span");
+        role.className = "hcw-msg-role " + (m.role === "assistant" ? "assistant" : "");
+        role.textContent = m.role === "assistant" ? "JARVIS" : "VOUS";
+        const body = document.createElement("span");
+        body.className = "hcw-msg-text";
+        body.textContent = text.length > 220 ? text.slice(0, 217) + "…" : text;
+        wrap.appendChild(role);
+        wrap.appendChild(body);
+        msgsEl.appendChild(wrap);
+      });
+      msgsEl.scrollTop = msgsEl.scrollHeight;
+    } catch (_) {
+      msgsEl.innerHTML = '<div class="hcw-empty">Erreur de chargement</div>';
+    }
+  }
+
+  // ── Widget Chat : envoi de message texte ──────────────────────────
+  let _chatSending = false;
+
+  function appendChatMsg(role, text, streaming) {
+    const msgsEl = document.getElementById("hcw-chat-msgs");
+    if (!msgsEl) return null;
+    const empty = msgsEl.querySelector(".hcw-empty");
+    if (empty) empty.remove();
+
+    const wrap = document.createElement("div");
+    wrap.className = "hcw-msg";
+    const roleEl = document.createElement("span");
+    roleEl.className = "hcw-msg-role" + (role === "assistant" ? " assistant" : "");
+    roleEl.textContent = role === "assistant" ? "JARVIS" : "VOUS";
+    const bodyEl = document.createElement("span");
+    bodyEl.className = "hcw-msg-text";
+    bodyEl.textContent = text;
+    wrap.appendChild(roleEl);
+    wrap.appendChild(bodyEl);
+    msgsEl.appendChild(wrap);
+    msgsEl.scrollTop = msgsEl.scrollHeight;
+    if (streaming) return bodyEl;
+    return null;
+  }
+
+  async function sendChatMessage() {
+    if (_chatSending) return;
+    const input = document.getElementById("hcw-input");
+    const sendBtn = document.getElementById("hcw-send");
+    const text = (input?.value || "").trim();
+    if (!text) return;
+
+    _chatSending = true;
+    if (sendBtn) sendBtn.disabled = true;
+    input.value = "";
+
+    appendChatMsg("user", text, false);
+
+    const streamTarget = appendChatMsg("assistant", "", true);
+    setOrbState("thinking");
+
+    try {
+      const sessionId = localStorage.getItem("jarvis_voice_session") || null;
+      const resp = await fetch("/api/voice/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: text, session_id: sessionId }),
+      });
+      const returnedSid = resp.headers.get("x-session-id");
+      if (returnedSid) localStorage.setItem("jarvis_voice_session", returnedSid);
+
+      if (!resp.ok || !resp.body) throw new Error("Erreur réseau");
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let full = "";
+      setOrbState("speaking");
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        full += decoder.decode(value, { stream: true });
+        if (streamTarget) {
+          streamTarget.textContent = full;
+          document.getElementById("hcw-chat-msgs").scrollTop = 9999;
+        }
+      }
+
+      const countEl = document.getElementById("hcw-chat-count");
+      if (countEl) {
+        const cur = parseInt(countEl.textContent) || 0;
+        countEl.textContent = (cur + 2) + " msg";
+      }
+    } catch (err) {
+      if (streamTarget) streamTarget.textContent = "Erreur de communication.";
+    } finally {
+      _chatSending = false;
+      if (sendBtn) sendBtn.disabled = false;
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  }
+
+  document.getElementById("hcw-new-session")?.addEventListener("click", () => {
+    localStorage.removeItem("jarvis_voice_session");
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (msgsEl)  msgsEl.innerHTML = '<div class="hcw-empty">Nouvelle conversation</div>';
+    if (countEl) countEl.textContent = "—";
+    document.getElementById("hcw-input")?.focus();
+  });
+
+  document.getElementById("hcw-send")?.addEventListener("click", sendChatMessage);
+
+  document.getElementById("hcw-input")?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendChatMessage();
+    }
+  });
+
+
+  // ── WebSocket — sync état orbe + canal passif ──────────────────────
+  function connectWS() {
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    try {
+      _ws = new WebSocket(proto + "//" + location.host + "/ws");
+    } catch (_) { return; }
+
+    _ws.onmessage = (ev) => {
+      let data;
+      try { data = JSON.parse(ev.data); } catch (_) { return; }
+
+      if (data.type === "voice_state") setOrbState(data.state || "idle");
+      if (data.type === "audio_level" && _orb) _orb.setAudioLevel(data.level || 0);
+
+      if (data.type === "message" && data.role === "assistant" && data.text) {
+        showChannel(data.text);
+        if (_ctrlState.chat) loadChatWidget();
+      }
+
+      // ── View routing ──────────────────────────────────────────────
+      if (data.type === "reload_views") {
+        const _prevActive = J.views._active;
+        if (_prevActive) J.views.deactivate(_prevActive);
+        // Supprime aussi les scripts sans data-view-skill (chargés avant le fix)
+        document.querySelectorAll('script[src*="/skills/"]').forEach(el => el.remove());
+        document.querySelectorAll('link[href*="/skills/"]').forEach(el => el.remove());
+        window.loadViewSkills?.().then?.(() => {
+          if (_prevActive) J.views.activate(_prevActive);
+        });
+      }
+      if (data.type === "show_home")  { const a = J.views._active; if (a) J.views.deactivate(a); }
+      if (data.type === "show_view")    J.views.activate(data.view_id, data.params);
+      if (data.type === "hide_view")    J.views.deactivate(data.view_id);
+      if (data.type === "view_command") J.views.dispatch(data.view_id, data.command, data.params);
+
+      // Backward compat (map_control legacy events)
+      if (data.type === "map_fly_to")    { J.views.activate("globe"); J.views.dispatch("globe", "fly_to", data); }
+      if (data.type === "map_zoom_out")  J.views.dispatch("globe", "zoom_out", {});
+      if (data.type === "map_zoom_in")   J.views.dispatch("globe", "zoom_in", {});
+      if (data.type === "map_globe_view"){ J.views.activate("globe"); J.views.dispatch("globe", "globe_view", {}); }
+      if (data.type === "toggle_panels") J.views.dispatch("globe", "toggle_panels", {});
+    };
+
+    _ws.onclose = () => setTimeout(connectWS, 3000);
+  }
+  connectWS();
+
+  // ── Canal passif (bas-droite) ──────────────────────────────────────
+  let _channelTs    = null;
+  let _channelTimer = null;
+
+  function relativeTime(ts) {
+    const mins = Math.round((Date.now() - ts) / 60000);
+    if (mins < 1)  return "À L'INSTANT";
+    if (mins === 1) return "IL Y A 1 MIN";
+    if (mins < 60) return "IL Y A " + mins + " MIN";
+    return "IL Y A " + Math.floor(mins / 60) + " H";
+  }
+
+  function updateChannelTime() {
+    if (!_channelTs) return;
+    const el = document.getElementById("channel-time");
+    if (el) el.textContent = relativeTime(_channelTs);
+  }
+
+  function showChannel(text) {
+    const el  = document.getElementById("home-channel");
+    const msg = document.getElementById("channel-msg");
+    if (!el || !msg) return;
+    msg.textContent = text.length > 160 ? text.slice(0, 157) + "…" : text;
+    _channelTs = Date.now();
+    updateChannelTime();
+    el.style.display = "";
+    if (_channelTimer) clearInterval(_channelTimer);
+    _channelTimer = setInterval(updateChannelTime, 30000);
+  }
+
+  (async function loadLastMessage() {
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) return;
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=10");
+      const last = [...msgs].reverse().find(m => m.role === "assistant");
+      if (last && (last.content || last.text)) showChannel(last.content || last.text);
+    } catch (_) {}
+  })();
+
+  // ── Navigation iframe — shell persistant ─────────────────────────
+  const _frame = document.getElementById("page-frame");
+  let _frameActive = false;
+
+  Jarvis.navigateFrame = function (url) {
+    if (!url || url === "/" || url === window.location.origin + "/") {
+      // Retour home — cacher l'iframe
+      if (_frame) {
+        _frame.classList.remove("is-active");
+        _frame.src = "about:blank";
+      }
+      _frameActive = false;
+      history.replaceState(null, "", "/");
+    } else {
+      // Fermer toute vue active (globe, etc.) avant de naviguer
+      Jarvis.views.deactivate();
+      if (_frame) {
+        _frame.src = url;
+        _frame.classList.add("is-active");
+      }
+      _frameActive = true;
+      history.pushState({ frame: url }, "", url);
+    }
+  };
+
+  // Bouton retour navigateur
+  window.addEventListener("popstate", (e) => {
+    if (e.state?.frame) {
+      if (_frame) { _frame.src = e.state.frame; _frame.classList.add("is-active"); }
+      _frameActive = true;
+    } else {
+      if (_frame) { _frame.classList.remove("is-active"); _frame.src = "about:blank"; }
+      _frameActive = false;
+    }
+  });
+
+  // ── Touche espace → dashboard (ou ferme l'iframe si déjà ouvert) ──
+  document.addEventListener("keydown", (e) => {
+    if (e.key === " " && !e.metaKey && !e.ctrlKey) {
+      const active = document.activeElement;
+      if (active && (active.tagName === "INPUT" || active.tagName === "TEXTAREA")) return;
+      e.preventDefault();
+      if (_frameActive) {
+        Jarvis.navigateFrame("/");
+      } else {
+        Jarvis.navigateFrame("/dashboard");
+      }
+    }
+  });
+
+  // ── Helper drag-and-drop pour widgets / overlay ────────────────────
+  function makeDraggable(el, handle) {
+    if (!el) return;
+    const grip = handle || el;
+
+    grip.addEventListener("mousedown", (e) => {
+      if (e.target.closest("button, input, textarea, .hcw-resize-handle")) return;
+      e.preventDefault();
+      let ex = e.clientX, ey = e.clientY;
+      el.classList.add("dragging");
+
+      function onMove(e) {
+        const dx = e.clientX - ex;
+        const dy = e.clientY - ey;
+        ex = e.clientX; ey = e.clientY;
+        const rect = el.getBoundingClientRect();
+        el.style.left   = (rect.left + dx) + "px";
+        el.style.top    = (rect.top  + dy) + "px";
+        el.style.right  = "auto";
+        el.style.bottom = "auto";
+      }
+
+      function onUp() {
+        el.classList.remove("dragging");
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // ── Helper redimensionnement pour widgets ──────────────────────────
+  function makeResizable(el, handleEl, minW, minH) {
+    if (!el || !handleEl) return;
+    minW = minW || 180;
+    minH = minH || 80;
+
+    handleEl.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Ancrer en top/left au moment du resize
+      const rect = el.getBoundingClientRect();
+      el.style.left   = rect.left   + "px";
+      el.style.top    = rect.top    + "px";
+      el.style.right  = "auto";
+      el.style.bottom = "auto";
+      el.style.width  = rect.width  + "px";
+      el.style.height = rect.height + "px";
+
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startW = rect.width;
+      const startH = rect.height;
+
+      function onMove(e) {
+        const w = Math.max(minW, startW + (e.clientX - startX));
+        const h = Math.max(minH, startH + (e.clientY - startY));
+        el.style.width  = w + "px";
+        el.style.height = h + "px";
+        // Enleve max-height sur le corps messages si present
+        const msgs = el.querySelector(".hcw-messages");
+        if (msgs) msgs.style.maxHeight = "none";
+      }
+
+      function onUp() {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // Attacher drag + resize aux widgets
+  makeDraggable(document.getElementById("cam-overlay"), document.getElementById("cam-drag-handle"));
+  makeResizable(document.getElementById("cam-overlay"), document.getElementById("cam-resize-handle"), 180, 120);
+
+  makeDraggable(document.getElementById("hc-widget-music"));
+  makeResizable(document.getElementById("hc-widget-music"), document.getElementById("music-resize-handle"), 180, 100);
+
+  makeDraggable(document.getElementById("hc-widget-chat"));
+  makeResizable(document.getElementById("hc-widget-chat"), document.getElementById("chat-resize-handle"), 220, 160);
+})();

--- a/src/jarvis/interfaces/ui/static/home.js.bak-20260620-124545
+++ b/src/jarvis/interfaces/ui/static/home.js.bak-20260620-124545
@@ -1,0 +1,888 @@
+/* home.js — page Home runtime */
+(function () {
+  "use strict";
+
+  const J = window.Jarvis;
+
+  // ── Atmosphere + Mission Control ──────────────────────────────────
+  J.mountAtmosphere();
+  J.mountRooms({ mode: "home", pages: [], activePage: null, onNav: () => {} });
+
+  // ── Stubs pour voice.js (tourne aussi dans cette page) ───────────
+  // voice.js cherche addMsg / checkForMindmap en global
+  window.addMsg = function (role, text = "", streaming = false) {
+    if (streaming) {
+      // Retourne une div temporaire que le VoiceClient remplit de chunks
+      const div = document.createElement("div");
+      div.className = "hcw-msg";
+      div.dataset.streaming = "1";
+      const roleEl = document.createElement("span");
+      roleEl.className = "hcw-msg-role " + (role === "jarvis" ? "assistant" : "");
+      roleEl.textContent = role === "jarvis" ? "JARVIS" : "VOUS";
+      const textEl = document.createElement("span");
+      textEl.className = "hcw-msg-text";
+      div.appendChild(roleEl);
+      div.appendChild(textEl);
+      // Si le widget chat est ouvert, on append
+      const msgsEl = document.getElementById("hcw-chat-msgs");
+      if (msgsEl && _ctrlState.chat) {
+        msgsEl.appendChild(div);
+        msgsEl.scrollTop = msgsEl.scrollHeight;
+      }
+      return textEl; // voice.js écrit dans .textContent de ce noeud
+    }
+    // Non-streaming : on recharge le widget si ouvert
+    if (_ctrlState.chat) setTimeout(loadChatWidget, 800);
+    return null;
+  };
+  window.checkForMindmap = function () {};
+
+  // ── WebSocket session ID / send (pour mediapipe_vision.js) ───────
+  let _ws = null;
+  window._jarvisSessionId = () => null;
+  window._jarvisWsSend = (data) => {
+    if (_ws && _ws.readyState === WebSocket.OPEN) {
+      _ws.send(JSON.stringify(data));
+    }
+  };
+
+  // ── Clock + date ──────────────────────────────────────────────────
+  const JOURS = ["DIMANCHE","LUNDI","MARDI","MERCREDI","JEUDI","VENDREDI","SAMEDI"];
+  const MOIS  = ["JANVIER","FÉVRIER","MARS","AVRIL","MAI","JUIN","JUILLET","AOÛT","SEPTEMBRE","OCTOBRE","NOVEMBRE","DÉCEMBRE"];
+
+  function updateClock() {
+    const t   = new Date();
+    const pad = n => String(n).padStart(2, "0");
+    const cl  = document.getElementById("home-clock");
+    const dt  = document.getElementById("home-date");
+    if (cl) cl.textContent = pad(t.getHours()) + ":" + pad(t.getMinutes());
+    if (dt) dt.textContent = JOURS[t.getDay()] + ", " + t.getDate() + " " + MOIS[t.getMonth()] + " " + t.getFullYear();
+  }
+  updateClock();
+  setInterval(updateClock, 1000);
+
+  // ── État orbe ─────────────────────────────────────────────────────
+  const STATE_DOTS = {
+    idle:      { cls: "blue",   label: "AU REPOS" },
+    listening: { cls: "blue",   label: "EN ÉCOUTE" },
+    thinking:  { cls: "purple", label: "RÉFLEXION" },
+    speaking:  { cls: "purple", label: "PARLE" },
+    success:   { cls: "green",  label: "SUCCÈS" },
+    offline:   { cls: "gray",   label: "HORS LIGNE" },
+  };
+
+  let _orb = null;
+  let _currentState = "idle";
+
+  function setOrbState(state) {
+    _currentState = state;
+    const meta = STATE_DOTS[state] || STATE_DOTS.idle;
+    const dot = document.getElementById("status-dot");
+    const lbl = document.getElementById("status-label");
+    if (dot) dot.className = "status-dot " + meta.cls;
+    if (lbl) lbl.textContent = meta.label;
+    if (_orb) _orb.setState(state);
+  }
+
+  function initOrb() {
+    if (typeof THREE === "undefined" || typeof JarvisOrb === "undefined") {
+      setTimeout(initOrb, 100);
+      return;
+    }
+    const canvas = document.getElementById("orb-canvas");
+    if (!canvas) return;
+    _orb = new JarvisOrb(canvas);
+    setOrbState("idle");
+  }
+  initOrb();
+
+  // ── body.view-active : source de vérité unique pour toutes les vues ─
+  const _origViewActivate   = J.views.activate.bind(J.views);
+  const _origViewDeactivate = J.views.deactivate.bind(J.views);
+  J.views.activate = function (id, params) {
+    _origViewActivate(id, params);
+    document.body.classList.add("view-active");
+  };
+  J.views.deactivate = function (id) {
+    _origViewDeactivate(id);
+    // Différé : si activate() enchaîne, _active est déjà re-setté quand le check tourne
+    Promise.resolve().then(() => {
+      if (!J.views._active) document.body.classList.remove("view-active");
+    });
+  };
+
+  // ── Sync état orbe depuis les events voice.js ─────────────────────
+  const VOICE_ORB_MAP = {
+    vad_start:   "listening",
+    stt_done:    "thinking",
+    llm_start:   "thinking",
+    tts_start:   "speaking",
+    tts_done:    "idle",
+    interrupted: "listening",
+  };
+  window.addEventListener("jarvis:ws", (e) => {
+    const msg = e.detail;
+    if (VOICE_ORB_MAP[msg.type]) setOrbState(VOICE_ORB_MAP[msg.type]);
+    if (msg.type === "tts_done" || msg.type === "done") {
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  });
+
+  // ── Controls (pictos haut-gauche) ─────────────────────────────────
+  const CTRL_DEFS = [
+    { key: "mic",    id: "hc-mic" },
+    { key: "screen", id: "hc-screen" },
+    { key: "cam",    id: "hc-cam" },
+    { key: "files",  id: "hc-files" },
+    { key: "music",  id: "hc-music",  widget: "hc-widget-music" },
+    { key: "chat",   id: "hc-chat",   widget: "hc-widget-chat" },
+  ];
+
+  const _ctrlState = {};
+  CTRL_DEFS.forEach(c => { _ctrlState[c.key] = false; });
+
+  function setCtrl(key, val) {
+    _ctrlState[key] = val;
+    const def = CTRL_DEFS.find(c => c.key === key);
+    if (!def) return;
+    const btn = document.getElementById(def.id);
+    if (btn) btn.classList.toggle("active", val);
+    if (def.widget) {
+      const w = document.getElementById(def.widget);
+      if (w) w.classList.toggle("is-open", val);
+    }
+  }
+
+  async function toggleCtrl(key) {
+    const next = !_ctrlState[key];
+
+    if (key === "mic") {
+      _ctrlState.mic = next;
+      const vc = window._voiceClient;
+      if (!vc) return;
+      if (next) {
+        await playGreeting();
+        try {
+          await vc._start();
+        } catch (err) {
+          console.error("[Mic] Erreur demarrage :", err);
+          _ctrlState.mic = false;
+          setOrbState("offline");
+          setTimeout(() => setOrbState("idle"), 2000);
+        }
+      } else {
+        vc._stop();
+        setOrbState("idle");
+      }
+      return;
+    }
+
+    if (key === "cam") {
+      if (next) {
+        setCtrl("cam", true);  // marque actif immédiatement pour que le 2e clic puisse désactiver
+        const ok = await startCamera();
+        if (!ok) {
+          setCtrl("cam", false);
+          return;
+        }
+        J.api.patch("/api/permissions/camera", { enabled: true }).catch(() => {});
+      } else {
+        stopCamera();
+        setCtrl("cam", false);
+        J.api.patch("/api/permissions/camera", { enabled: false }).catch(() => {});
+      }
+      return;
+    }
+
+    if (key === "screen") {
+      setCtrl("screen", next);
+      J.api.patch("/api/permissions/screen", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "files") {
+      setCtrl("files", next);
+      J.api.patch("/api/permissions/files", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "music") {
+      setCtrl("music", next);
+      if (next) startMusicPoll();
+      else stopMusicPoll();
+      return;
+    }
+
+    if (key === "chat") {
+      setCtrl("chat", next);
+      if (next) loadChatWidget();
+      return;
+    }
+  }
+
+  // Charge l'etat initial des permissions depuis le serveur
+  (async function loadPermissions() {
+    try {
+      const perms = await J.api.get("/api/permissions");
+      if (perms.screen   != null) setCtrl("screen", perms.screen);
+      if (perms.camera   != null) setCtrl("cam",    perms.camera);
+      if (perms.files    != null) setCtrl("files",  perms.files);
+    } catch (_) {}
+  })();
+
+  CTRL_DEFS.forEach(c => {
+    const btn = document.getElementById(c.id);
+    if (btn) btn.addEventListener("click", () => toggleCtrl(c.key));
+  });
+
+  // Lier le bouton mic au VoiceClient après DOMContentLoaded
+  document.addEventListener("DOMContentLoaded", () => {
+    const vc = window._voiceClient;
+    if (vc) {
+      vc._btn = document.getElementById("hc-mic");
+    }
+  }, { once: true });
+
+  // ── Greeting vocal (comme l'ancien repo) ──────────────────────────
+  async function playGreeting() {
+    try {
+      const resp = await fetch("/api/voice/speak", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "Systèmes en ligne. Bonjour Barth." }),
+      });
+      const data = await resp.json();
+      if (!data.audio_b64) return;
+
+      // Décoder le base64 → ArrayBuffer → AudioContext
+      const binary = atob(data.audio_b64);
+      const bytes  = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+      const audioCtx = new AudioContext();
+      const buffer   = await audioCtx.decodeAudioData(bytes.buffer);
+      const source   = audioCtx.createBufferSource();
+      source.buffer  = buffer;
+      source.connect(audioCtx.destination);
+
+      setOrbState("speaking");
+
+      await new Promise((resolve) => {
+        source.onended = resolve;
+        source.start();
+      });
+      audioCtx.close();
+    } catch (err) {
+      console.warn("[Greeting] Erreur :", err);
+    } finally {
+      setOrbState("listening");
+    }
+  }
+
+  // ── Caméra (MediaPipe) ─────────────────────────────────────────────
+  let _camStream = null;
+
+  async function startCamera() {
+    try {
+      _camStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "user", width: { ideal: 640 }, height: { ideal: 480 } },
+      });
+      const video = document.getElementById("cam-video");
+      if (video) {
+        video.srcObject = _camStream;
+        await video.play();
+      }
+      document.getElementById("cam-overlay")?.classList.add("is-open");
+      // Initialise MediaPipe (charge les modèles si nécessaire)
+      if (typeof mpInit === "function") {
+        await mpInit();
+        mpStart();
+      }
+      return true;
+    } catch (err) {
+      console.error("[Camera] Erreur :", err);
+      return false;
+    }
+  }
+
+  function stopCamera() {
+    if (typeof mpStop === "function") mpStop();
+    if (_camStream) {
+      _camStream.getTracks().forEach(t => t.stop());
+      _camStream = null;
+    }
+    const video = document.getElementById("cam-video");
+    if (video) video.srcObject = null;
+    document.getElementById("cam-overlay")?.classList.remove("is-open");
+  }
+
+
+  // ── Widget Musique ─────────────────────────────────────────────────
+  let _musicPollTimer = null;
+  let _musicPlaying   = false;
+
+  function startMusicPoll() {
+    fetchMusicStatus();
+    _musicPollTimer = setInterval(fetchMusicStatus, 5000);
+  }
+
+  function stopMusicPoll() {
+    clearInterval(_musicPollTimer);
+    _musicPollTimer = null;
+  }
+
+  async function fetchMusicStatus() {
+    try {
+      const s = await J.api.get("/api/music/status");
+      updateMusicWidget(s);
+    } catch (_) {}
+  }
+
+  function updateMusicWidget(s) {
+    const trackEl  = document.getElementById("hcw-music-track");
+    const artistEl = document.getElementById("hcw-music-artist");
+    const srcEl    = document.getElementById("hcw-music-source");
+    const artEl    = document.getElementById("hcw-album-art");
+    const fillEl   = document.getElementById("hcw-progress-fill");
+    const playIcon = document.getElementById("hcw-play-icon");
+
+    if (!s || !s.connected) {
+      if (trackEl)  trackEl.textContent  = "Non connecté";
+      if (artistEl) artistEl.textContent = s?.provider ? "Configurer dans les paramètres" : "Aucun service configuré";
+      if (srcEl)    srcEl.textContent    = s?.provider || "—";
+      return;
+    }
+
+    _musicPlaying = s.is_playing || false;
+
+    const providerLabel = (s.provider || "").toUpperCase();
+    if (srcEl) srcEl.textContent = providerLabel || "—";
+
+    if (!s.track) {
+      if (trackEl)  trackEl.textContent  = "Aucune lecture";
+      if (artistEl) artistEl.textContent = providerLabel ? providerLabel + " CONNECTÉ" : "—";
+    } else {
+      if (trackEl)  trackEl.textContent  = s.track;
+      if (artistEl) artistEl.textContent = s.last_played
+        ? (s.artist || "") + (s.artist ? " — DERNIER JOUÉ" : "DERNIER JOUÉ")
+        : (s.artist || "");
+    }
+
+    // Album art
+    if (artEl) {
+      if (s.album_art) {
+        artEl.src = s.album_art;
+        artEl.classList.add("loaded");
+      } else {
+        artEl.classList.remove("loaded");
+      }
+    }
+
+    // Barre de progression
+    if (fillEl && s.duration_ms > 0) {
+      const pct = Math.min(100, (s.progress_ms / s.duration_ms) * 100);
+      fillEl.style.width = pct + "%";
+    }
+
+    // Icône play/pause
+    if (playIcon) {
+      playIcon.innerHTML = _musicPlaying
+        ? '<line x1="5" y1="2" x2="5" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="10" y1="2" x2="10" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>'
+        : '<path fill="currentColor" d="M3 2l10 4.5L3 11V2z"/>';
+    }
+  }
+
+  // ── Spotify Web Playback SDK ───────────────────────────────────────
+  let _spotifyPlayer   = null;
+  let _spotifyDeviceId = null;
+  let _sdkProgressTimer = null;
+  let _currentTrackId  = null;
+
+  async function fetchTrackBeat(trackId) {
+    // Fallback immédiat — l'API audio-features est dépréciée pour les nouvelles apps
+    const applyBeat = (tempo, energy) => { if (_orb) _orb.setMusicBeat(tempo, energy); };
+    try {
+      const { token } = await (await fetch("/api/spotify/token")).json();
+      if (!token) return applyBeat(120, 0.6);
+      const resp = await fetch(
+        `https://api.spotify.com/v1/audio-features/${trackId}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!resp.ok) return applyBeat(120, 0.6);
+      const f = await resp.json();
+      applyBeat(f.tempo || 120, f.energy ?? 0.6);
+    } catch (_) {
+      applyBeat(120, 0.6);
+    }
+  }
+
+  function _tickSDKProgress() {
+    if (!_spotifyPlayer || !_musicPlaying) return;
+    _spotifyPlayer.getCurrentState().then(state => {
+      if (!state) return;
+      const fillEl = document.getElementById("hcw-progress-fill");
+      if (fillEl && state.duration) {
+        fillEl.style.width = Math.min(100, (state.position / state.duration) * 100) + "%";
+      }
+    }).catch(() => {});
+  }
+
+  async function initSpotifySDK() {
+    if (_spotifyPlayer || window._sdkInitStarted) return;
+    window._sdkInitStarted = true;
+
+    try {
+      const status = await J.api.get("/api/music/provider-status");
+      if (status.provider !== "spotify") return;
+    } catch (_) { return; }
+
+    window.onSpotifyWebPlaybackSDKReady = () => {
+      _spotifyPlayer = new Spotify.Player({
+        name: "JARVIS",
+        getOAuthToken: async (cb) => {
+          try {
+            const res = await fetch("/api/spotify/token", { headers: J.authHeaders ? J.authHeaders() : {} });
+            const data = await res.json();
+            cb(data.token || "");
+          } catch (_) { cb(""); }
+        },
+        volume: 0.7,
+      });
+
+      _spotifyPlayer.addListener("ready", ({ device_id }) => {
+        _spotifyDeviceId = device_id;
+        // Enregistre le device sans transférer la lecture
+        fetch("/api/spotify/transfer", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ device_id }),
+        }).catch(() => {});
+        // Charge l'état initial (dernier joué)
+        if (_ctrlState.music) fetchMusicStatus();
+      });
+
+      _spotifyPlayer.addListener("not_ready", () => {
+        _spotifyDeviceId = null;
+      });
+
+      _spotifyPlayer.addListener("player_state_changed", (state) => {
+        if (!state) return;
+        const track = state.track_window?.current_track;
+        if (!track) return;
+        _musicPlaying = !state.paused;
+
+        // Beat sync
+        const tid = track.id;
+        const wasPlaying = _musicPlaying;
+        if (tid && (tid !== _currentTrackId || (!wasPlaying && !state.paused))) {
+          _currentTrackId = tid;
+          if (!state.paused) fetchTrackBeat(tid);
+        }
+        if (state.paused && _orb) _orb.setMusicBeat(0, 0);
+
+        updateMusicWidget({
+          connected: true,
+          is_playing: !state.paused,
+          track: track.name,
+          artist: track.artists?.map(a => a.name).join(", ") || "",
+          album: track.album?.name || "",
+          album_art: track.album?.images?.[0]?.url || null,
+          progress_ms: state.position,
+          duration_ms: track.duration_ms,
+          provider: "spotify",
+        });
+      });
+
+      _spotifyPlayer.connect();
+      _sdkProgressTimer = setInterval(_tickSDKProgress, 1000);
+    };
+
+    const script = document.createElement("script");
+    script.src = "https://sdk.scdn.co/spotify-player.js";
+    document.head.appendChild(script);
+  }
+
+  // Démarrage SDK au chargement de la page
+  initSpotifySDK();
+
+  // Boutons du widget musique — SDK en priorité, API en fallback
+  document.getElementById("hcw-prev")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.previousTrack().catch(() => {}); return; }
+    J.api.post("/api/music/prev").then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-play")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.togglePlay().catch(() => {}); return; }
+    J.api.post(_musicPlaying ? "/api/music/pause" : "/api/music/play")
+      .then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-next")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.nextTrack().catch(() => {}); return; }
+    J.api.post("/api/music/next").then(fetchMusicStatus).catch(() => {});
+  });
+
+
+  // ── Widget Chat ────────────────────────────────────────────────────
+  async function loadChatWidget() {
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (!msgsEl) return;
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucune session</div>';
+        return;
+      }
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=30");
+      if (countEl) countEl.textContent = msgs.length + " msg";
+      msgsEl.innerHTML = "";
+      const recent = msgs.slice(-14);
+      if (!recent.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucun message</div>';
+        return;
+      }
+      recent.forEach(m => {
+        const text = m.content || m.text || "";
+        if (!text) return;
+        const wrap = document.createElement("div");
+        wrap.className = "hcw-msg";
+        const role = document.createElement("span");
+        role.className = "hcw-msg-role " + (m.role === "assistant" ? "assistant" : "");
+        role.textContent = m.role === "assistant" ? "JARVIS" : "VOUS";
+        const body = document.createElement("span");
+        body.className = "hcw-msg-text";
+        body.textContent = text.length > 220 ? text.slice(0, 217) + "…" : text;
+        wrap.appendChild(role);
+        wrap.appendChild(body);
+        msgsEl.appendChild(wrap);
+      });
+      msgsEl.scrollTop = msgsEl.scrollHeight;
+    } catch (_) {
+      msgsEl.innerHTML = '<div class="hcw-empty">Erreur de chargement</div>';
+    }
+  }
+
+  // ── Widget Chat : envoi de message texte ──────────────────────────
+  let _chatSending = false;
+
+  function appendChatMsg(role, text, streaming) {
+    const msgsEl = document.getElementById("hcw-chat-msgs");
+    if (!msgsEl) return null;
+    const empty = msgsEl.querySelector(".hcw-empty");
+    if (empty) empty.remove();
+
+    const wrap = document.createElement("div");
+    wrap.className = "hcw-msg";
+    const roleEl = document.createElement("span");
+    roleEl.className = "hcw-msg-role" + (role === "assistant" ? " assistant" : "");
+    roleEl.textContent = role === "assistant" ? "JARVIS" : "VOUS";
+    const bodyEl = document.createElement("span");
+    bodyEl.className = "hcw-msg-text";
+    bodyEl.textContent = text;
+    wrap.appendChild(roleEl);
+    wrap.appendChild(bodyEl);
+    msgsEl.appendChild(wrap);
+    msgsEl.scrollTop = msgsEl.scrollHeight;
+    if (streaming) return bodyEl;
+    return null;
+  }
+
+  async function sendChatMessage() {
+    if (_chatSending) return;
+    const input = document.getElementById("hcw-input");
+    const sendBtn = document.getElementById("hcw-send");
+    const text = (input?.value || "").trim();
+    if (!text) return;
+
+    _chatSending = true;
+    if (sendBtn) sendBtn.disabled = true;
+    input.value = "";
+
+    appendChatMsg("user", text, false);
+
+    const streamTarget = appendChatMsg("assistant", "", true);
+    setOrbState("thinking");
+
+    try {
+      const sessionId = localStorage.getItem("jarvis_voice_session") || null;
+      const resp = await fetch("/api/voice/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: text, session_id: sessionId }),
+      });
+      const returnedSid = resp.headers.get("x-session-id");
+      if (returnedSid) localStorage.setItem("jarvis_voice_session", returnedSid);
+
+      if (!resp.ok || !resp.body) throw new Error("Erreur réseau");
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let full = "";
+      setOrbState("speaking");
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        full += decoder.decode(value, { stream: true });
+        if (streamTarget) {
+          streamTarget.textContent = full;
+          document.getElementById("hcw-chat-msgs").scrollTop = 9999;
+        }
+      }
+
+      const countEl = document.getElementById("hcw-chat-count");
+      if (countEl) {
+        const cur = parseInt(countEl.textContent) || 0;
+        countEl.textContent = (cur + 2) + " msg";
+      }
+    } catch (err) {
+      if (streamTarget) streamTarget.textContent = "Erreur de communication.";
+    } finally {
+      _chatSending = false;
+      if (sendBtn) sendBtn.disabled = false;
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  }
+
+  document.getElementById("hcw-new-session")?.addEventListener("click", () => {
+    localStorage.removeItem("jarvis_voice_session");
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (msgsEl)  msgsEl.innerHTML = '<div class="hcw-empty">Nouvelle conversation</div>';
+    if (countEl) countEl.textContent = "—";
+    document.getElementById("hcw-input")?.focus();
+  });
+
+  document.getElementById("hcw-send")?.addEventListener("click", sendChatMessage);
+
+  document.getElementById("hcw-input")?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendChatMessage();
+    }
+  });
+
+
+  // ── WebSocket — sync état orbe + canal passif ──────────────────────
+  function connectWS() {
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    try {
+      _ws = new WebSocket(proto + "//" + location.host + "/ws");
+    } catch (_) { return; }
+
+    _ws.onmessage = (ev) => {
+      let data;
+      try { data = JSON.parse(ev.data); } catch (_) { return; }
+
+      if (data.type === "voice_state") setOrbState(data.state || "idle");
+      if (data.type === "audio_level" && _orb) _orb.setAudioLevel(data.level || 0);
+
+      if (data.type === "message" && data.role === "assistant" && data.text) {
+        showChannel(data.text);
+        if (_ctrlState.chat) loadChatWidget();
+      }
+
+      // ── View routing ──────────────────────────────────────────────
+      if (data.type === "reload_views") {
+        const _prevActive = J.views._active;
+        if (_prevActive) J.views.deactivate(_prevActive);
+        // Supprime aussi les scripts sans data-view-skill (chargés avant le fix)
+        document.querySelectorAll('script[src*="/skills/"]').forEach(el => el.remove());
+        document.querySelectorAll('link[href*="/skills/"]').forEach(el => el.remove());
+        window.loadViewSkills?.().then?.(() => {
+          if (_prevActive) J.views.activate(_prevActive);
+        });
+      }
+      if (data.type === "show_home")  { const a = J.views._active; if (a) J.views.deactivate(a); }
+      if (data.type === "show_view")    J.views.activate(data.view_id, data.params);
+      if (data.type === "hide_view")    J.views.deactivate(data.view_id);
+      if (data.type === "view_command") J.views.dispatch(data.view_id, data.command, data.params);
+
+      // Backward compat (map_control legacy events)
+      if (data.type === "map_fly_to")    { J.views.activate("globe"); J.views.dispatch("globe", "fly_to", data); }
+      if (data.type === "map_zoom_out")  J.views.dispatch("globe", "zoom_out", {});
+      if (data.type === "map_zoom_in")   J.views.dispatch("globe", "zoom_in", {});
+      if (data.type === "map_globe_view"){ J.views.activate("globe"); J.views.dispatch("globe", "globe_view", {}); }
+      if (data.type === "toggle_panels") J.views.dispatch("globe", "toggle_panels", {});
+    };
+
+    _ws.onclose = () => setTimeout(connectWS, 3000);
+  }
+  connectWS();
+
+  // ── Canal passif (bas-droite) ──────────────────────────────────────
+  let _channelTs    = null;
+  let _channelTimer = null;
+
+  function relativeTime(ts) {
+    const mins = Math.round((Date.now() - ts) / 60000);
+    if (mins < 1)  return "À L'INSTANT";
+    if (mins === 1) return "IL Y A 1 MIN";
+    if (mins < 60) return "IL Y A " + mins + " MIN";
+    return "IL Y A " + Math.floor(mins / 60) + " H";
+  }
+
+  function updateChannelTime() {
+    if (!_channelTs) return;
+    const el = document.getElementById("channel-time");
+    if (el) el.textContent = relativeTime(_channelTs);
+  }
+
+  function showChannel(text) {
+    const el  = document.getElementById("home-channel");
+    const msg = document.getElementById("channel-msg");
+    if (!el || !msg) return;
+    msg.textContent = text.length > 160 ? text.slice(0, 157) + "…" : text;
+    _channelTs = Date.now();
+    updateChannelTime();
+    el.style.display = "";
+    if (_channelTimer) clearInterval(_channelTimer);
+    _channelTimer = setInterval(updateChannelTime, 30000);
+  }
+
+  (async function loadLastMessage() {
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) return;
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=10");
+      const last = [...msgs].reverse().find(m => m.role === "assistant");
+      if (last && (last.content || last.text)) showChannel(last.content || last.text);
+    } catch (_) {}
+  })();
+
+  // ── Navigation iframe — shell persistant ─────────────────────────
+  const _frame = document.getElementById("page-frame");
+  let _frameActive = false;
+
+  Jarvis.navigateFrame = function (url) {
+    if (!url || url === "/" || url === window.location.origin + "/") {
+      // Retour home — cacher l'iframe
+      if (_frame) {
+        _frame.classList.remove("is-active");
+        _frame.src = "about:blank";
+      }
+      _frameActive = false;
+      history.replaceState(null, "", "/");
+    } else {
+      // Fermer toute vue active (globe, etc.) avant de naviguer
+      Jarvis.views.deactivate();
+      if (_frame) {
+        _frame.src = url;
+        _frame.classList.add("is-active");
+      }
+      _frameActive = true;
+      history.pushState({ frame: url }, "", url);
+    }
+  };
+
+  // Bouton retour navigateur
+  window.addEventListener("popstate", (e) => {
+    if (e.state?.frame) {
+      if (_frame) { _frame.src = e.state.frame; _frame.classList.add("is-active"); }
+      _frameActive = true;
+    } else {
+      if (_frame) { _frame.classList.remove("is-active"); _frame.src = "about:blank"; }
+      _frameActive = false;
+    }
+  });
+
+  // ── Touche espace → dashboard (ou ferme l'iframe si déjà ouvert) ──
+  document.addEventListener("keydown", (e) => {
+    if (e.key === " " && !e.metaKey && !e.ctrlKey) {
+      const active = document.activeElement;
+      if (active && (active.tagName === "INPUT" || active.tagName === "TEXTAREA")) return;
+      e.preventDefault();
+      if (_frameActive) {
+        Jarvis.navigateFrame("/");
+      } else {
+        Jarvis.navigateFrame("/dashboard");
+      }
+    }
+  });
+
+  // ── Helper drag-and-drop pour widgets / overlay ────────────────────
+  function makeDraggable(el, handle) {
+    if (!el) return;
+    const grip = handle || el;
+
+    grip.addEventListener("mousedown", (e) => {
+      if (e.target.closest("button, input, textarea, .hcw-resize-handle")) return;
+      e.preventDefault();
+      let ex = e.clientX, ey = e.clientY;
+      el.classList.add("dragging");
+
+      function onMove(e) {
+        const dx = e.clientX - ex;
+        const dy = e.clientY - ey;
+        ex = e.clientX; ey = e.clientY;
+        const rect = el.getBoundingClientRect();
+        el.style.left   = (rect.left + dx) + "px";
+        el.style.top    = (rect.top  + dy) + "px";
+        el.style.right  = "auto";
+        el.style.bottom = "auto";
+      }
+
+      function onUp() {
+        el.classList.remove("dragging");
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // ── Helper redimensionnement pour widgets ──────────────────────────
+  function makeResizable(el, handleEl, minW, minH) {
+    if (!el || !handleEl) return;
+    minW = minW || 180;
+    minH = minH || 80;
+
+    handleEl.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Ancrer en top/left au moment du resize
+      const rect = el.getBoundingClientRect();
+      el.style.left   = rect.left   + "px";
+      el.style.top    = rect.top    + "px";
+      el.style.right  = "auto";
+      el.style.bottom = "auto";
+      el.style.width  = rect.width  + "px";
+      el.style.height = rect.height + "px";
+
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startW = rect.width;
+      const startH = rect.height;
+
+      function onMove(e) {
+        const w = Math.max(minW, startW + (e.clientX - startX));
+        const h = Math.max(minH, startH + (e.clientY - startY));
+        el.style.width  = w + "px";
+        el.style.height = h + "px";
+        // Enleve max-height sur le corps messages si present
+        const msgs = el.querySelector(".hcw-messages");
+        if (msgs) msgs.style.maxHeight = "none";
+      }
+
+      function onUp() {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // Attacher drag + resize aux widgets
+  makeDraggable(document.getElementById("cam-overlay"), document.getElementById("cam-drag-handle"));
+  makeResizable(document.getElementById("cam-overlay"), document.getElementById("cam-resize-handle"), 180, 120);
+
+  makeDraggable(document.getElementById("hc-widget-music"));
+  makeResizable(document.getElementById("hc-widget-music"), document.getElementById("music-resize-handle"), 180, 100);
+
+  makeDraggable(document.getElementById("hc-widget-chat"));
+  makeResizable(document.getElementById("hc-widget-chat"), document.getElementById("chat-resize-handle"), 220, 160);
+})();

--- a/src/jarvis/interfaces/ui/static/home.js.bak-20260621-011004
+++ b/src/jarvis/interfaces/ui/static/home.js.bak-20260621-011004
@@ -1,0 +1,906 @@
+/* home.js — page Home runtime */
+(function () {
+  "use strict";
+
+  const J = window.Jarvis;
+
+  // ── Atmosphere + Mission Control ──────────────────────────────────
+  J.mountAtmosphere();
+  J.mountRooms({ mode: "home", pages: [], activePage: null, onNav: () => {} });
+
+  // ── Stubs pour voice.js (tourne aussi dans cette page) ───────────
+  // voice.js cherche addMsg / checkForMindmap en global
+  window.addMsg = function (role, text = "", streaming = false) {
+    if (streaming) {
+      // Retourne une div temporaire que le VoiceClient remplit de chunks
+      const div = document.createElement("div");
+      div.className = "hcw-msg";
+      div.dataset.streaming = "1";
+      const roleEl = document.createElement("span");
+      roleEl.className = "hcw-msg-role " + (role === "jarvis" ? "assistant" : "");
+      roleEl.textContent = role === "jarvis" ? "JARVIS" : "VOUS";
+      const textEl = document.createElement("span");
+      textEl.className = "hcw-msg-text";
+      div.appendChild(roleEl);
+      div.appendChild(textEl);
+      // Si le widget chat est ouvert, on append
+      const msgsEl = document.getElementById("hcw-chat-msgs");
+      if (msgsEl && _ctrlState.chat) {
+        msgsEl.appendChild(div);
+        msgsEl.scrollTop = msgsEl.scrollHeight;
+      }
+      return textEl; // voice.js écrit dans .textContent de ce noeud
+    }
+    // Non-streaming : on recharge le widget si ouvert
+    if (_ctrlState.chat) setTimeout(loadChatWidget, 800);
+    return null;
+  };
+  window.checkForMindmap = function () {};
+
+  // ── WebSocket session ID / send (pour mediapipe_vision.js) ───────
+  let _ws = null;
+  window._jarvisSessionId = () => null;
+  window._jarvisWsSend = (data) => {
+    if (_ws && _ws.readyState === WebSocket.OPEN) {
+      _ws.send(JSON.stringify(data));
+    }
+  };
+
+  // ── Clock + date ──────────────────────────────────────────────────
+  const JOURS = ["DIMANCHE","LUNDI","MARDI","MERCREDI","JEUDI","VENDREDI","SAMEDI"];
+  const MOIS  = ["JANVIER","FÉVRIER","MARS","AVRIL","MAI","JUIN","JUILLET","AOÛT","SEPTEMBRE","OCTOBRE","NOVEMBRE","DÉCEMBRE"];
+
+  function updateClock() {
+    const t   = new Date();
+    const pad = n => String(n).padStart(2, "0");
+    const cl  = document.getElementById("home-clock");
+    const dt  = document.getElementById("home-date");
+    if (cl) cl.textContent = pad(t.getHours()) + ":" + pad(t.getMinutes());
+    if (dt) dt.textContent = JOURS[t.getDay()] + ", " + t.getDate() + " " + MOIS[t.getMonth()] + " " + t.getFullYear();
+  }
+  updateClock();
+  setInterval(updateClock, 1000);
+
+  // ── État orbe ─────────────────────────────────────────────────────
+  const STATE_DOTS = {
+    idle:      { cls: "blue",   label: "AU REPOS" },
+    listening: { cls: "blue",   label: "EN ÉCOUTE" },
+    thinking:  { cls: "purple", label: "RÉFLEXION" },
+    speaking:  { cls: "purple", label: "PARLE" },
+    success:   { cls: "green",  label: "SUCCÈS" },
+    offline:   { cls: "gray",   label: "HORS LIGNE" },
+  };
+
+  let _orb = null;
+  let _currentState = "idle";
+
+  function setOrbState(state) {
+    _currentState = state;
+    const meta = STATE_DOTS[state] || STATE_DOTS.idle;
+    const dot = document.getElementById("status-dot");
+    const lbl = document.getElementById("status-label");
+    if (dot) dot.className = "status-dot " + meta.cls;
+    if (lbl) lbl.textContent = meta.label;
+    if (_orb) _orb.setState(state);
+  }
+
+  function initOrb() {
+    if (typeof THREE === "undefined" || typeof JarvisOrb === "undefined") {
+      setTimeout(initOrb, 100);
+      return;
+    }
+    // Cold boot wake : la séquence va mounter l'orbe sur #orb-canvas en
+    // frozen, puis nous le rendra via injectWakeOrb() à l'entrée ONLINE.
+    if (window.__jarvisWakeActive) return;
+    const canvas = document.getElementById("orb-canvas");
+    if (!canvas) return;
+    _orb = new JarvisOrb(canvas);
+    setOrbState("idle");
+  }
+  initOrb();
+
+  // ── Bascule depuis la séquence de réveil ────────────────────────────
+  // wake_sequence.js appelle ça à l'entrée ONLINE : l'orbe partagé est
+  // remis à home.js, qui prend la main pour les states voice/audio/music.
+  window.__jarvisInjectOrb = function (orb) {
+    _orb = orb;
+    setOrbState("idle");
+  };
+
+  // ── body.view-active : source de vérité unique pour toutes les vues ─
+  const _origViewActivate   = J.views.activate.bind(J.views);
+  const _origViewDeactivate = J.views.deactivate.bind(J.views);
+  J.views.activate = function (id, params) {
+    _origViewActivate(id, params);
+    document.body.classList.add("view-active");
+  };
+  J.views.deactivate = function (id) {
+    _origViewDeactivate(id);
+    // Différé : si activate() enchaîne, _active est déjà re-setté quand le check tourne
+    Promise.resolve().then(() => {
+      if (!J.views._active) document.body.classList.remove("view-active");
+    });
+  };
+
+  // ── Sync état orbe depuis les events voice.js ─────────────────────
+  const VOICE_ORB_MAP = {
+    vad_start:   "listening",
+    stt_done:    "thinking",
+    llm_start:   "thinking",
+    tts_start:   "speaking",
+    tts_done:    "idle",
+    interrupted: "listening",
+  };
+  window.addEventListener("jarvis:ws", (e) => {
+    const msg = e.detail;
+    if (VOICE_ORB_MAP[msg.type]) setOrbState(VOICE_ORB_MAP[msg.type]);
+    if (msg.type === "tts_done" || msg.type === "done") {
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  });
+
+  // ── Controls (pictos haut-gauche) ─────────────────────────────────
+  const CTRL_DEFS = [
+    { key: "mic",    id: "hc-mic" },
+    { key: "screen", id: "hc-screen" },
+    { key: "cam",    id: "hc-cam" },
+    { key: "files",  id: "hc-files" },
+    { key: "music",  id: "hc-music",  widget: "hc-widget-music" },
+    { key: "chat",   id: "hc-chat",   widget: "hc-widget-chat" },
+  ];
+
+  const _ctrlState = {};
+  CTRL_DEFS.forEach(c => { _ctrlState[c.key] = false; });
+
+  function setCtrl(key, val) {
+    _ctrlState[key] = val;
+    const def = CTRL_DEFS.find(c => c.key === key);
+    if (!def) return;
+    const btn = document.getElementById(def.id);
+    if (btn) btn.classList.toggle("active", val);
+    if (def.widget) {
+      const w = document.getElementById(def.widget);
+      if (w) w.classList.toggle("is-open", val);
+    }
+  }
+
+  async function toggleCtrl(key) {
+    const next = !_ctrlState[key];
+
+    if (key === "mic") {
+      _ctrlState.mic = next;
+      const vc = window._voiceClient;
+      if (!vc) return;
+      if (next) {
+        await playGreeting();
+        try {
+          await vc._start();
+        } catch (err) {
+          console.error("[Mic] Erreur demarrage :", err);
+          _ctrlState.mic = false;
+          setOrbState("offline");
+          setTimeout(() => setOrbState("idle"), 2000);
+        }
+      } else {
+        vc._stop();
+        setOrbState("idle");
+      }
+      return;
+    }
+
+    if (key === "cam") {
+      if (next) {
+        setCtrl("cam", true);  // marque actif immédiatement pour que le 2e clic puisse désactiver
+        const ok = await startCamera();
+        if (!ok) {
+          setCtrl("cam", false);
+          return;
+        }
+        J.api.patch("/api/permissions/camera", { enabled: true }).catch(() => {});
+      } else {
+        stopCamera();
+        setCtrl("cam", false);
+        J.api.patch("/api/permissions/camera", { enabled: false }).catch(() => {});
+      }
+      return;
+    }
+
+    if (key === "screen") {
+      setCtrl("screen", next);
+      J.api.patch("/api/permissions/screen", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "files") {
+      setCtrl("files", next);
+      J.api.patch("/api/permissions/files", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "music") {
+      setCtrl("music", next);
+      if (next) startMusicPoll();
+      else stopMusicPoll();
+      return;
+    }
+
+    if (key === "chat") {
+      setCtrl("chat", next);
+      if (next) loadChatWidget();
+      return;
+    }
+  }
+
+  // Charge l'etat initial des permissions depuis le serveur
+  (async function loadPermissions() {
+    try {
+      const perms = await J.api.get("/api/permissions");
+      if (perms.screen   != null) setCtrl("screen", perms.screen);
+      if (perms.camera   != null) setCtrl("cam",    perms.camera);
+      if (perms.files    != null) setCtrl("files",  perms.files);
+    } catch (_) {}
+  })();
+
+  CTRL_DEFS.forEach(c => {
+    const btn = document.getElementById(c.id);
+    if (btn) btn.addEventListener("click", () => toggleCtrl(c.key));
+  });
+
+  // Lier le bouton mic au VoiceClient après DOMContentLoaded
+  document.addEventListener("DOMContentLoaded", () => {
+    const vc = window._voiceClient;
+    if (vc) {
+      vc._btn = document.getElementById("hc-mic");
+    }
+  }, { once: true });
+
+  // ── Greeting vocal (comme l'ancien repo) ──────────────────────────
+  async function playGreeting() {
+    try {
+      let fn = "";
+      try {
+        const s = await fetch("/api/wakeup/status").then((r) => r.json());
+        fn = (s && s.user_firstname) || "";
+      } catch { /* repli sans prénom */ }
+      const greeting = fn ? `Systèmes en ligne. Bonjour ${fn}.` : "Systèmes en ligne.";
+      const resp = await fetch("/api/voice/speak", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: greeting }),
+      });
+      const data = await resp.json();
+      if (!data.audio_b64) return;
+
+      // Décoder le base64 → ArrayBuffer → AudioContext
+      const binary = atob(data.audio_b64);
+      const bytes  = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+      const audioCtx = new AudioContext();
+      const buffer   = await audioCtx.decodeAudioData(bytes.buffer);
+      const source   = audioCtx.createBufferSource();
+      source.buffer  = buffer;
+      source.connect(audioCtx.destination);
+
+      setOrbState("speaking");
+
+      await new Promise((resolve) => {
+        source.onended = resolve;
+        source.start();
+      });
+      audioCtx.close();
+    } catch (err) {
+      console.warn("[Greeting] Erreur :", err);
+    } finally {
+      setOrbState("listening");
+    }
+  }
+
+  // ── Caméra (MediaPipe) ─────────────────────────────────────────────
+  let _camStream = null;
+
+  async function startCamera() {
+    try {
+      _camStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "user", width: { ideal: 640 }, height: { ideal: 480 } },
+      });
+      const video = document.getElementById("cam-video");
+      if (video) {
+        video.srcObject = _camStream;
+        await video.play();
+      }
+      document.getElementById("cam-overlay")?.classList.add("is-open");
+      // Initialise MediaPipe (charge les modèles si nécessaire)
+      if (typeof mpInit === "function") {
+        await mpInit();
+        mpStart();
+      }
+      return true;
+    } catch (err) {
+      console.error("[Camera] Erreur :", err);
+      return false;
+    }
+  }
+
+  function stopCamera() {
+    if (typeof mpStop === "function") mpStop();
+    if (_camStream) {
+      _camStream.getTracks().forEach(t => t.stop());
+      _camStream = null;
+    }
+    const video = document.getElementById("cam-video");
+    if (video) video.srcObject = null;
+    document.getElementById("cam-overlay")?.classList.remove("is-open");
+  }
+
+
+  // ── Widget Musique ─────────────────────────────────────────────────
+  let _musicPollTimer = null;
+  let _musicPlaying   = false;
+
+  function startMusicPoll() {
+    fetchMusicStatus();
+    _musicPollTimer = setInterval(fetchMusicStatus, 5000);
+  }
+
+  function stopMusicPoll() {
+    clearInterval(_musicPollTimer);
+    _musicPollTimer = null;
+  }
+
+  async function fetchMusicStatus() {
+    try {
+      const s = await J.api.get("/api/music/status");
+      updateMusicWidget(s);
+    } catch (_) {}
+  }
+
+  function updateMusicWidget(s) {
+    const trackEl  = document.getElementById("hcw-music-track");
+    const artistEl = document.getElementById("hcw-music-artist");
+    const srcEl    = document.getElementById("hcw-music-source");
+    const artEl    = document.getElementById("hcw-album-art");
+    const fillEl   = document.getElementById("hcw-progress-fill");
+    const playIcon = document.getElementById("hcw-play-icon");
+
+    if (!s || !s.connected) {
+      if (trackEl)  trackEl.textContent  = "Non connecté";
+      if (artistEl) artistEl.textContent = s?.provider ? "Configurer dans les paramètres" : "Aucun service configuré";
+      if (srcEl)    srcEl.textContent    = s?.provider || "—";
+      return;
+    }
+
+    _musicPlaying = s.is_playing || false;
+
+    const providerLabel = (s.provider || "").toUpperCase();
+    if (srcEl) srcEl.textContent = providerLabel || "—";
+
+    if (!s.track) {
+      if (trackEl)  trackEl.textContent  = "Aucune lecture";
+      if (artistEl) artistEl.textContent = providerLabel ? providerLabel + " CONNECTÉ" : "—";
+    } else {
+      if (trackEl)  trackEl.textContent  = s.track;
+      if (artistEl) artistEl.textContent = s.last_played
+        ? (s.artist || "") + (s.artist ? " — DERNIER JOUÉ" : "DERNIER JOUÉ")
+        : (s.artist || "");
+    }
+
+    // Album art
+    if (artEl) {
+      if (s.album_art) {
+        artEl.src = s.album_art;
+        artEl.classList.add("loaded");
+      } else {
+        artEl.classList.remove("loaded");
+      }
+    }
+
+    // Barre de progression
+    if (fillEl && s.duration_ms > 0) {
+      const pct = Math.min(100, (s.progress_ms / s.duration_ms) * 100);
+      fillEl.style.width = pct + "%";
+    }
+
+    // Icône play/pause
+    if (playIcon) {
+      playIcon.innerHTML = _musicPlaying
+        ? '<line x1="5" y1="2" x2="5" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="10" y1="2" x2="10" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>'
+        : '<path fill="currentColor" d="M3 2l10 4.5L3 11V2z"/>';
+    }
+  }
+
+  // ── Spotify Web Playback SDK ───────────────────────────────────────
+  let _spotifyPlayer   = null;
+  let _spotifyDeviceId = null;
+  let _sdkProgressTimer = null;
+  let _currentTrackId  = null;
+
+  async function fetchTrackBeat(trackId) {
+    // Fallback immédiat — l'API audio-features est dépréciée pour les nouvelles apps
+    const applyBeat = (tempo, energy) => { if (_orb) _orb.setMusicBeat(tempo, energy); };
+    try {
+      const { token } = await (await fetch("/api/spotify/token", { headers: J.authHeaders ? J.authHeaders() : {} })).json();
+      if (!token) return applyBeat(120, 0.6);
+      const resp = await fetch(
+        `https://api.spotify.com/v1/audio-features/${trackId}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!resp.ok) return applyBeat(120, 0.6);
+      const f = await resp.json();
+      applyBeat(f.tempo || 120, f.energy ?? 0.6);
+    } catch (_) {
+      applyBeat(120, 0.6);
+    }
+  }
+
+  function _tickSDKProgress() {
+    if (!_spotifyPlayer || !_musicPlaying) return;
+    _spotifyPlayer.getCurrentState().then(state => {
+      if (!state) return;
+      const fillEl = document.getElementById("hcw-progress-fill");
+      if (fillEl && state.duration) {
+        fillEl.style.width = Math.min(100, (state.position / state.duration) * 100) + "%";
+      }
+    }).catch(() => {});
+  }
+
+  async function initSpotifySDK() {
+    if (_spotifyPlayer || window._sdkInitStarted) return;
+    window._sdkInitStarted = true;
+
+    try {
+      const status = await J.api.get("/api/music/provider-status");
+      if (status.provider !== "spotify") return;
+    } catch (_) { return; }
+
+    window.onSpotifyWebPlaybackSDKReady = () => {
+      _spotifyPlayer = new Spotify.Player({
+        name: "JARVIS",
+        getOAuthToken: async (cb) => {
+          try {
+            const res = await fetch("/api/spotify/token", { headers: J.authHeaders ? J.authHeaders() : {} });
+            const data = await res.json();
+            cb(data.token || "");
+          } catch (_) { cb(""); }
+        },
+        volume: 0.7,
+      });
+
+      _spotifyPlayer.addListener("ready", ({ device_id }) => {
+        _spotifyDeviceId = device_id;
+        // Enregistre le device sans transférer la lecture
+        fetch("/api/spotify/transfer", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...(J.authHeaders ? J.authHeaders() : {}) },
+          body: JSON.stringify({ device_id }),
+        }).catch(() => {});
+        // Charge l'état initial (dernier joué)
+        if (_ctrlState.music) fetchMusicStatus();
+      });
+
+      _spotifyPlayer.addListener("not_ready", () => {
+        _spotifyDeviceId = null;
+      });
+
+      _spotifyPlayer.addListener("player_state_changed", (state) => {
+        if (!state) return;
+        const track = state.track_window?.current_track;
+        if (!track) return;
+        _musicPlaying = !state.paused;
+
+        // Beat sync
+        const tid = track.id;
+        const wasPlaying = _musicPlaying;
+        if (tid && (tid !== _currentTrackId || (!wasPlaying && !state.paused))) {
+          _currentTrackId = tid;
+          if (!state.paused) fetchTrackBeat(tid);
+        }
+        if (state.paused && _orb) _orb.setMusicBeat(0, 0);
+
+        updateMusicWidget({
+          connected: true,
+          is_playing: !state.paused,
+          track: track.name,
+          artist: track.artists?.map(a => a.name).join(", ") || "",
+          album: track.album?.name || "",
+          album_art: track.album?.images?.[0]?.url || null,
+          progress_ms: state.position,
+          duration_ms: track.duration_ms,
+          provider: "spotify",
+        });
+      });
+
+      _spotifyPlayer.connect();
+      _sdkProgressTimer = setInterval(_tickSDKProgress, 1000);
+    };
+
+    const script = document.createElement("script");
+    script.src = "https://sdk.scdn.co/spotify-player.js";
+    document.head.appendChild(script);
+  }
+
+  // Démarrage SDK au chargement de la page
+  initSpotifySDK();
+
+  // Boutons du widget musique — SDK en priorité, API en fallback
+  document.getElementById("hcw-prev")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.previousTrack().catch(() => {}); return; }
+    J.api.post("/api/music/prev").then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-play")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.togglePlay().catch(() => {}); return; }
+    J.api.post(_musicPlaying ? "/api/music/pause" : "/api/music/play")
+      .then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-next")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.nextTrack().catch(() => {}); return; }
+    J.api.post("/api/music/next").then(fetchMusicStatus).catch(() => {});
+  });
+
+
+  // ── Widget Chat ────────────────────────────────────────────────────
+  async function loadChatWidget() {
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (!msgsEl) return;
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucune session</div>';
+        return;
+      }
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=30");
+      if (countEl) countEl.textContent = msgs.length + " msg";
+      msgsEl.innerHTML = "";
+      const recent = msgs.slice(-14);
+      if (!recent.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucun message</div>';
+        return;
+      }
+      recent.forEach(m => {
+        const text = m.content || m.text || "";
+        if (!text) return;
+        const wrap = document.createElement("div");
+        wrap.className = "hcw-msg";
+        const role = document.createElement("span");
+        role.className = "hcw-msg-role " + (m.role === "assistant" ? "assistant" : "");
+        role.textContent = m.role === "assistant" ? "JARVIS" : "VOUS";
+        const body = document.createElement("span");
+        body.className = "hcw-msg-text";
+        body.textContent = text.length > 220 ? text.slice(0, 217) + "…" : text;
+        wrap.appendChild(role);
+        wrap.appendChild(body);
+        msgsEl.appendChild(wrap);
+      });
+      msgsEl.scrollTop = msgsEl.scrollHeight;
+    } catch (_) {
+      msgsEl.innerHTML = '<div class="hcw-empty">Erreur de chargement</div>';
+    }
+  }
+
+  // ── Widget Chat : envoi de message texte ──────────────────────────
+  let _chatSending = false;
+
+  function appendChatMsg(role, text, streaming) {
+    const msgsEl = document.getElementById("hcw-chat-msgs");
+    if (!msgsEl) return null;
+    const empty = msgsEl.querySelector(".hcw-empty");
+    if (empty) empty.remove();
+
+    const wrap = document.createElement("div");
+    wrap.className = "hcw-msg";
+    const roleEl = document.createElement("span");
+    roleEl.className = "hcw-msg-role" + (role === "assistant" ? " assistant" : "");
+    roleEl.textContent = role === "assistant" ? "JARVIS" : "VOUS";
+    const bodyEl = document.createElement("span");
+    bodyEl.className = "hcw-msg-text";
+    bodyEl.textContent = text;
+    wrap.appendChild(roleEl);
+    wrap.appendChild(bodyEl);
+    msgsEl.appendChild(wrap);
+    msgsEl.scrollTop = msgsEl.scrollHeight;
+    if (streaming) return bodyEl;
+    return null;
+  }
+
+  async function sendChatMessage() {
+    if (_chatSending) return;
+    const input = document.getElementById("hcw-input");
+    const sendBtn = document.getElementById("hcw-send");
+    const text = (input?.value || "").trim();
+    if (!text) return;
+
+    _chatSending = true;
+    if (sendBtn) sendBtn.disabled = true;
+    input.value = "";
+
+    appendChatMsg("user", text, false);
+
+    const streamTarget = appendChatMsg("assistant", "", true);
+    setOrbState("thinking");
+
+    try {
+      const sessionId = localStorage.getItem("jarvis_voice_session") || null;
+      const resp = await fetch("/api/voice/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...(J.authHeaders ? J.authHeaders() : {}) },
+        body: JSON.stringify({ message: text, session_id: sessionId }),
+      });
+      const returnedSid = resp.headers.get("x-session-id");
+      if (returnedSid) localStorage.setItem("jarvis_voice_session", returnedSid);
+
+      if (!resp.ok || !resp.body) throw new Error("Erreur réseau");
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let full = "";
+      setOrbState("speaking");
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        full += decoder.decode(value, { stream: true });
+        if (streamTarget) {
+          streamTarget.textContent = full;
+          document.getElementById("hcw-chat-msgs").scrollTop = 9999;
+        }
+      }
+
+      const countEl = document.getElementById("hcw-chat-count");
+      if (countEl) {
+        const cur = parseInt(countEl.textContent) || 0;
+        countEl.textContent = (cur + 2) + " msg";
+      }
+    } catch (err) {
+      if (streamTarget) streamTarget.textContent = "Erreur de communication.";
+    } finally {
+      _chatSending = false;
+      if (sendBtn) sendBtn.disabled = false;
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  }
+
+  document.getElementById("hcw-new-session")?.addEventListener("click", () => {
+    localStorage.removeItem("jarvis_voice_session");
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (msgsEl)  msgsEl.innerHTML = '<div class="hcw-empty">Nouvelle conversation</div>';
+    if (countEl) countEl.textContent = "—";
+    document.getElementById("hcw-input")?.focus();
+  });
+
+  document.getElementById("hcw-send")?.addEventListener("click", sendChatMessage);
+
+  document.getElementById("hcw-input")?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendChatMessage();
+    }
+  });
+
+
+  // ── WebSocket — sync état orbe + canal passif ──────────────────────
+  function connectWS() {
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    try {
+      _ws = new WebSocket(proto + "//" + location.host + "/ws");
+    } catch (_) { return; }
+
+    _ws.onmessage = (ev) => {
+      let data;
+      try { data = JSON.parse(ev.data); } catch (_) { return; }
+
+      if (data.type === "voice_state") setOrbState(data.state || "idle");
+      if (data.type === "audio_level" && _orb) _orb.setAudioLevel(data.level || 0);
+      if (data.type === "wake_up") window.dispatchEvent(new CustomEvent("jarvis-wake", { detail: data }));
+
+      if (data.type === "message" && data.role === "assistant" && data.text) {
+        showChannel(data.text);
+        if (_ctrlState.chat) loadChatWidget();
+      }
+
+      // ── View routing ──────────────────────────────────────────────
+      if (data.type === "reload_views") {
+        const _prevActive = J.views._active;
+        if (_prevActive) J.views.deactivate(_prevActive);
+        // Supprime aussi les scripts sans data-view-skill (chargés avant le fix)
+        document.querySelectorAll('script[src*="/skills/"]').forEach(el => el.remove());
+        document.querySelectorAll('link[href*="/skills/"]').forEach(el => el.remove());
+        window.loadViewSkills?.().then?.(() => {
+          if (_prevActive) J.views.activate(_prevActive);
+        });
+      }
+      if (data.type === "show_home")  { const a = J.views._active; if (a) J.views.deactivate(a); }
+      if (data.type === "show_view")    J.views.activate(data.view_id, data.params);
+      if (data.type === "hide_view")    J.views.deactivate(data.view_id);
+      if (data.type === "view_command") J.views.dispatch(data.view_id, data.command, data.params);
+
+      // Backward compat (map_control legacy events)
+      if (data.type === "map_fly_to")    { J.views.activate("globe"); J.views.dispatch("globe", "fly_to", data); }
+      if (data.type === "map_zoom_out")  J.views.dispatch("globe", "zoom_out", {});
+      if (data.type === "map_zoom_in")   J.views.dispatch("globe", "zoom_in", {});
+      if (data.type === "map_globe_view"){ J.views.activate("globe"); J.views.dispatch("globe", "globe_view", {}); }
+      if (data.type === "toggle_panels") J.views.dispatch("globe", "toggle_panels", {});
+    };
+
+    _ws.onclose = () => setTimeout(connectWS, 3000);
+  }
+  connectWS();
+
+  // ── Canal passif (bas-droite) ──────────────────────────────────────
+  let _channelTs    = null;
+  let _channelTimer = null;
+
+  function relativeTime(ts) {
+    const mins = Math.round((Date.now() - ts) / 60000);
+    if (mins < 1)  return "À L'INSTANT";
+    if (mins === 1) return "IL Y A 1 MIN";
+    if (mins < 60) return "IL Y A " + mins + " MIN";
+    return "IL Y A " + Math.floor(mins / 60) + " H";
+  }
+
+  function updateChannelTime() {
+    if (!_channelTs) return;
+    const el = document.getElementById("channel-time");
+    if (el) el.textContent = relativeTime(_channelTs);
+  }
+
+  function showChannel(text) {
+    const el  = document.getElementById("home-channel");
+    const msg = document.getElementById("channel-msg");
+    if (!el || !msg) return;
+    msg.textContent = text.length > 160 ? text.slice(0, 157) + "…" : text;
+    _channelTs = Date.now();
+    updateChannelTime();
+    el.style.display = "";
+    if (_channelTimer) clearInterval(_channelTimer);
+    _channelTimer = setInterval(updateChannelTime, 30000);
+  }
+
+  (async function loadLastMessage() {
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) return;
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=10");
+      const last = [...msgs].reverse().find(m => m.role === "assistant");
+      if (last && (last.content || last.text)) showChannel(last.content || last.text);
+    } catch (_) {}
+  })();
+
+  // ── Navigation iframe — shell persistant ─────────────────────────
+  const _frame = document.getElementById("page-frame");
+  let _frameActive = false;
+
+  Jarvis.navigateFrame = function (url) {
+    if (!url || url === "/" || url === window.location.origin + "/") {
+      // Retour home — cacher l'iframe
+      if (_frame) {
+        _frame.classList.remove("is-active");
+        _frame.src = "about:blank";
+      }
+      _frameActive = false;
+      history.replaceState(null, "", "/");
+    } else {
+      // Fermer toute vue active (globe, etc.) avant de naviguer
+      Jarvis.views.deactivate();
+      if (_frame) {
+        _frame.src = url;
+        _frame.classList.add("is-active");
+      }
+      _frameActive = true;
+      history.pushState({ frame: url }, "", url);
+    }
+  };
+
+  // Bouton retour navigateur
+  window.addEventListener("popstate", (e) => {
+    if (e.state?.frame) {
+      if (_frame) { _frame.src = e.state.frame; _frame.classList.add("is-active"); }
+      _frameActive = true;
+    } else {
+      if (_frame) { _frame.classList.remove("is-active"); _frame.src = "about:blank"; }
+      _frameActive = false;
+    }
+  });
+
+  // ── Touche espace → dashboard (ou ferme l'iframe si déjà ouvert) ──
+  document.addEventListener("keydown", (e) => {
+    if (e.key === " " && !e.metaKey && !e.ctrlKey) {
+      const active = document.activeElement;
+      if (active && (active.tagName === "INPUT" || active.tagName === "TEXTAREA")) return;
+      e.preventDefault();
+      if (_frameActive) {
+        Jarvis.navigateFrame("/");
+      } else {
+        Jarvis.navigateFrame("/dashboard");
+      }
+    }
+  });
+
+  // ── Helper drag-and-drop pour widgets / overlay ────────────────────
+  function makeDraggable(el, handle) {
+    if (!el) return;
+    const grip = handle || el;
+
+    grip.addEventListener("mousedown", (e) => {
+      if (e.target.closest("button, input, textarea, .hcw-resize-handle")) return;
+      e.preventDefault();
+      let ex = e.clientX, ey = e.clientY;
+      el.classList.add("dragging");
+
+      function onMove(e) {
+        const dx = e.clientX - ex;
+        const dy = e.clientY - ey;
+        ex = e.clientX; ey = e.clientY;
+        const rect = el.getBoundingClientRect();
+        el.style.left   = (rect.left + dx) + "px";
+        el.style.top    = (rect.top  + dy) + "px";
+        el.style.right  = "auto";
+        el.style.bottom = "auto";
+      }
+
+      function onUp() {
+        el.classList.remove("dragging");
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // ── Helper redimensionnement pour widgets ──────────────────────────
+  function makeResizable(el, handleEl, minW, minH) {
+    if (!el || !handleEl) return;
+    minW = minW || 180;
+    minH = minH || 80;
+
+    handleEl.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Ancrer en top/left au moment du resize
+      const rect = el.getBoundingClientRect();
+      el.style.left   = rect.left   + "px";
+      el.style.top    = rect.top    + "px";
+      el.style.right  = "auto";
+      el.style.bottom = "auto";
+      el.style.width  = rect.width  + "px";
+      el.style.height = rect.height + "px";
+
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startW = rect.width;
+      const startH = rect.height;
+
+      function onMove(e) {
+        const w = Math.max(minW, startW + (e.clientX - startX));
+        const h = Math.max(minH, startH + (e.clientY - startY));
+        el.style.width  = w + "px";
+        el.style.height = h + "px";
+        // Enleve max-height sur le corps messages si present
+        const msgs = el.querySelector(".hcw-messages");
+        if (msgs) msgs.style.maxHeight = "none";
+      }
+
+      function onUp() {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // Attacher drag + resize aux widgets
+  makeDraggable(document.getElementById("cam-overlay"), document.getElementById("cam-drag-handle"));
+  makeResizable(document.getElementById("cam-overlay"), document.getElementById("cam-resize-handle"), 180, 120);
+
+  makeDraggable(document.getElementById("hc-widget-music"));
+  makeResizable(document.getElementById("hc-widget-music"), document.getElementById("music-resize-handle"), 180, 100);
+
+  makeDraggable(document.getElementById("hc-widget-chat"));
+  makeResizable(document.getElementById("hc-widget-chat"), document.getElementById("chat-resize-handle"), 220, 160);
+})();

--- a/src/jarvis/interfaces/ui/static/home.js.bak-20260621-011107
+++ b/src/jarvis/interfaces/ui/static/home.js.bak-20260621-011107
@@ -1,0 +1,906 @@
+/* home.js — page Home runtime */
+(function () {
+  "use strict";
+
+  const J = window.Jarvis;
+
+  // ── Atmosphere + Mission Control ──────────────────────────────────
+  J.mountAtmosphere();
+  J.mountRooms({ mode: "home", pages: [], activePage: null, onNav: () => {} });
+
+  // ── Stubs pour voice.js (tourne aussi dans cette page) ───────────
+  // voice.js cherche addMsg / checkForMindmap en global
+  window.addMsg = function (role, text = "", streaming = false) {
+    if (streaming) {
+      // Retourne une div temporaire que le VoiceClient remplit de chunks
+      const div = document.createElement("div");
+      div.className = "hcw-msg";
+      div.dataset.streaming = "1";
+      const roleEl = document.createElement("span");
+      roleEl.className = "hcw-msg-role " + (role === "jarvis" ? "assistant" : "");
+      roleEl.textContent = role === "jarvis" ? "JARVIS" : "VOUS";
+      const textEl = document.createElement("span");
+      textEl.className = "hcw-msg-text";
+      div.appendChild(roleEl);
+      div.appendChild(textEl);
+      // Si le widget chat est ouvert, on append
+      const msgsEl = document.getElementById("hcw-chat-msgs");
+      if (msgsEl && _ctrlState.chat) {
+        msgsEl.appendChild(div);
+        msgsEl.scrollTop = msgsEl.scrollHeight;
+      }
+      return textEl; // voice.js écrit dans .textContent de ce noeud
+    }
+    // Non-streaming : on recharge le widget si ouvert
+    if (_ctrlState.chat) setTimeout(loadChatWidget, 800);
+    return null;
+  };
+  window.checkForMindmap = function () {};
+
+  // ── WebSocket session ID / send (pour mediapipe_vision.js) ───────
+  let _ws = null;
+  window._jarvisSessionId = () => null;
+  window._jarvisWsSend = (data) => {
+    if (_ws && _ws.readyState === WebSocket.OPEN) {
+      _ws.send(JSON.stringify(data));
+    }
+  };
+
+  // ── Clock + date ──────────────────────────────────────────────────
+  const JOURS = ["DIMANCHE","LUNDI","MARDI","MERCREDI","JEUDI","VENDREDI","SAMEDI"];
+  const MOIS  = ["JANVIER","FÉVRIER","MARS","AVRIL","MAI","JUIN","JUILLET","AOÛT","SEPTEMBRE","OCTOBRE","NOVEMBRE","DÉCEMBRE"];
+
+  function updateClock() {
+    const t   = new Date();
+    const pad = n => String(n).padStart(2, "0");
+    const cl  = document.getElementById("home-clock");
+    const dt  = document.getElementById("home-date");
+    if (cl) cl.textContent = pad(t.getHours()) + ":" + pad(t.getMinutes());
+    if (dt) dt.textContent = JOURS[t.getDay()] + ", " + t.getDate() + " " + MOIS[t.getMonth()] + " " + t.getFullYear();
+  }
+  updateClock();
+  setInterval(updateClock, 1000);
+
+  // ── État orbe ─────────────────────────────────────────────────────
+  const STATE_DOTS = {
+    idle:      { cls: "blue",   label: "AU REPOS" },
+    listening: { cls: "blue",   label: "EN ÉCOUTE" },
+    thinking:  { cls: "purple", label: "RÉFLEXION" },
+    speaking:  { cls: "purple", label: "PARLE" },
+    success:   { cls: "green",  label: "SUCCÈS" },
+    offline:   { cls: "gray",   label: "HORS LIGNE" },
+  };
+
+  let _orb = null;
+  let _currentState = "idle";
+
+  function setOrbState(state) {
+    _currentState = state;
+    const meta = STATE_DOTS[state] || STATE_DOTS.idle;
+    const dot = document.getElementById("status-dot");
+    const lbl = document.getElementById("status-label");
+    if (dot) dot.className = "status-dot " + meta.cls;
+    if (lbl) lbl.textContent = meta.label;
+    if (_orb) _orb.setState(state);
+  }
+
+  function initOrb() {
+    if (typeof THREE === "undefined" || typeof JarvisOrb === "undefined") {
+      setTimeout(initOrb, 100);
+      return;
+    }
+    // Cold boot wake : la séquence va mounter l'orbe sur #orb-canvas en
+    // frozen, puis nous le rendra via injectWakeOrb() à l'entrée ONLINE.
+    if (window.__jarvisWakeActive) return;
+    const canvas = document.getElementById("orb-canvas");
+    if (!canvas) return;
+    _orb = new JarvisOrb(canvas);
+    setOrbState("idle");
+  }
+  initOrb();
+
+  // ── Bascule depuis la séquence de réveil ────────────────────────────
+  // wake_sequence.js appelle ça à l'entrée ONLINE : l'orbe partagé est
+  // remis à home.js, qui prend la main pour les states voice/audio/music.
+  window.__jarvisInjectOrb = function (orb) {
+    _orb = orb;
+    setOrbState("idle");
+  };
+
+  // ── body.view-active : source de vérité unique pour toutes les vues ─
+  const _origViewActivate   = J.views.activate.bind(J.views);
+  const _origViewDeactivate = J.views.deactivate.bind(J.views);
+  J.views.activate = function (id, params) {
+    _origViewActivate(id, params);
+    document.body.classList.add("view-active");
+  };
+  J.views.deactivate = function (id) {
+    _origViewDeactivate(id);
+    // Différé : si activate() enchaîne, _active est déjà re-setté quand le check tourne
+    Promise.resolve().then(() => {
+      if (!J.views._active) document.body.classList.remove("view-active");
+    });
+  };
+
+  // ── Sync état orbe depuis les events voice.js ─────────────────────
+  const VOICE_ORB_MAP = {
+    vad_start:   "listening",
+    stt_done:    "thinking",
+    llm_start:   "thinking",
+    tts_start:   "speaking",
+    tts_done:    "idle",
+    interrupted: "listening",
+  };
+  window.addEventListener("jarvis:ws", (e) => {
+    const msg = e.detail;
+    if (VOICE_ORB_MAP[msg.type]) setOrbState(VOICE_ORB_MAP[msg.type]);
+    if (msg.type === "tts_done" || msg.type === "done") {
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  });
+
+  // ── Controls (pictos haut-gauche) ─────────────────────────────────
+  const CTRL_DEFS = [
+    { key: "mic",    id: "hc-mic" },
+    { key: "screen", id: "hc-screen" },
+    { key: "cam",    id: "hc-cam" },
+    { key: "files",  id: "hc-files" },
+    { key: "music",  id: "hc-music",  widget: "hc-widget-music" },
+    { key: "chat",   id: "hc-chat",   widget: "hc-widget-chat" },
+  ];
+
+  const _ctrlState = {};
+  CTRL_DEFS.forEach(c => { _ctrlState[c.key] = false; });
+
+  function setCtrl(key, val) {
+    _ctrlState[key] = val;
+    const def = CTRL_DEFS.find(c => c.key === key);
+    if (!def) return;
+    const btn = document.getElementById(def.id);
+    if (btn) btn.classList.toggle("active", val);
+    if (def.widget) {
+      const w = document.getElementById(def.widget);
+      if (w) w.classList.toggle("is-open", val);
+    }
+  }
+
+  async function toggleCtrl(key) {
+    const next = !_ctrlState[key];
+
+    if (key === "mic") {
+      _ctrlState.mic = next;
+      const vc = window._voiceClient;
+      if (!vc) return;
+      if (next) {
+        await playGreeting();
+        try {
+          await vc._start();
+        } catch (err) {
+          console.error("[Mic] Erreur demarrage :", err);
+          _ctrlState.mic = false;
+          setOrbState("offline");
+          setTimeout(() => setOrbState("idle"), 2000);
+        }
+      } else {
+        vc._stop();
+        setOrbState("idle");
+      }
+      return;
+    }
+
+    if (key === "cam") {
+      if (next) {
+        setCtrl("cam", true);  // marque actif immédiatement pour que le 2e clic puisse désactiver
+        const ok = await startCamera();
+        if (!ok) {
+          setCtrl("cam", false);
+          return;
+        }
+        J.api.patch("/api/permissions/camera", { enabled: true }).catch(() => {});
+      } else {
+        stopCamera();
+        setCtrl("cam", false);
+        J.api.patch("/api/permissions/camera", { enabled: false }).catch(() => {});
+      }
+      return;
+    }
+
+    if (key === "screen") {
+      setCtrl("screen", next);
+      J.api.patch("/api/permissions/screen", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "files") {
+      setCtrl("files", next);
+      J.api.patch("/api/permissions/files", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "music") {
+      setCtrl("music", next);
+      if (next) startMusicPoll();
+      else stopMusicPoll();
+      return;
+    }
+
+    if (key === "chat") {
+      setCtrl("chat", next);
+      if (next) loadChatWidget();
+      return;
+    }
+  }
+
+  // Charge l'etat initial des permissions depuis le serveur
+  (async function loadPermissions() {
+    try {
+      const perms = await J.api.get("/api/permissions");
+      if (perms.screen   != null) setCtrl("screen", perms.screen);
+      if (perms.camera   != null) setCtrl("cam",    perms.camera);
+      if (perms.files    != null) setCtrl("files",  perms.files);
+    } catch (_) {}
+  })();
+
+  CTRL_DEFS.forEach(c => {
+    const btn = document.getElementById(c.id);
+    if (btn) btn.addEventListener("click", () => toggleCtrl(c.key));
+  });
+
+  // Lier le bouton mic au VoiceClient après DOMContentLoaded
+  document.addEventListener("DOMContentLoaded", () => {
+    const vc = window._voiceClient;
+    if (vc) {
+      vc._btn = document.getElementById("hc-mic");
+    }
+  }, { once: true });
+
+  // ── Greeting vocal (comme l'ancien repo) ──────────────────────────
+  async function playGreeting() {
+    try {
+      let fn = "";
+      try {
+        const s = await fetch("/api/wakeup/status", { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} }).then((r) => r.json());
+        fn = (s && s.user_firstname) || "";
+      } catch { /* repli sans prénom */ }
+      const greeting = fn ? `Systèmes en ligne. Bonjour ${fn}.` : "Systèmes en ligne.";
+      const resp = await fetch("/api/voice/speak", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...(window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {}) },
+        body: JSON.stringify({ text: greeting }),
+      });
+      const data = await resp.json();
+      if (!data.audio_b64) return;
+
+      // Décoder le base64 → ArrayBuffer → AudioContext
+      const binary = atob(data.audio_b64);
+      const bytes  = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+      const audioCtx = new AudioContext();
+      const buffer   = await audioCtx.decodeAudioData(bytes.buffer);
+      const source   = audioCtx.createBufferSource();
+      source.buffer  = buffer;
+      source.connect(audioCtx.destination);
+
+      setOrbState("speaking");
+
+      await new Promise((resolve) => {
+        source.onended = resolve;
+        source.start();
+      });
+      audioCtx.close();
+    } catch (err) {
+      console.warn("[Greeting] Erreur :", err);
+    } finally {
+      setOrbState("listening");
+    }
+  }
+
+  // ── Caméra (MediaPipe) ─────────────────────────────────────────────
+  let _camStream = null;
+
+  async function startCamera() {
+    try {
+      _camStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "user", width: { ideal: 640 }, height: { ideal: 480 } },
+      });
+      const video = document.getElementById("cam-video");
+      if (video) {
+        video.srcObject = _camStream;
+        await video.play();
+      }
+      document.getElementById("cam-overlay")?.classList.add("is-open");
+      // Initialise MediaPipe (charge les modèles si nécessaire)
+      if (typeof mpInit === "function") {
+        await mpInit();
+        mpStart();
+      }
+      return true;
+    } catch (err) {
+      console.error("[Camera] Erreur :", err);
+      return false;
+    }
+  }
+
+  function stopCamera() {
+    if (typeof mpStop === "function") mpStop();
+    if (_camStream) {
+      _camStream.getTracks().forEach(t => t.stop());
+      _camStream = null;
+    }
+    const video = document.getElementById("cam-video");
+    if (video) video.srcObject = null;
+    document.getElementById("cam-overlay")?.classList.remove("is-open");
+  }
+
+
+  // ── Widget Musique ─────────────────────────────────────────────────
+  let _musicPollTimer = null;
+  let _musicPlaying   = false;
+
+  function startMusicPoll() {
+    fetchMusicStatus();
+    _musicPollTimer = setInterval(fetchMusicStatus, 5000);
+  }
+
+  function stopMusicPoll() {
+    clearInterval(_musicPollTimer);
+    _musicPollTimer = null;
+  }
+
+  async function fetchMusicStatus() {
+    try {
+      const s = await J.api.get("/api/music/status");
+      updateMusicWidget(s);
+    } catch (_) {}
+  }
+
+  function updateMusicWidget(s) {
+    const trackEl  = document.getElementById("hcw-music-track");
+    const artistEl = document.getElementById("hcw-music-artist");
+    const srcEl    = document.getElementById("hcw-music-source");
+    const artEl    = document.getElementById("hcw-album-art");
+    const fillEl   = document.getElementById("hcw-progress-fill");
+    const playIcon = document.getElementById("hcw-play-icon");
+
+    if (!s || !s.connected) {
+      if (trackEl)  trackEl.textContent  = "Non connecté";
+      if (artistEl) artistEl.textContent = s?.provider ? "Configurer dans les paramètres" : "Aucun service configuré";
+      if (srcEl)    srcEl.textContent    = s?.provider || "—";
+      return;
+    }
+
+    _musicPlaying = s.is_playing || false;
+
+    const providerLabel = (s.provider || "").toUpperCase();
+    if (srcEl) srcEl.textContent = providerLabel || "—";
+
+    if (!s.track) {
+      if (trackEl)  trackEl.textContent  = "Aucune lecture";
+      if (artistEl) artistEl.textContent = providerLabel ? providerLabel + " CONNECTÉ" : "—";
+    } else {
+      if (trackEl)  trackEl.textContent  = s.track;
+      if (artistEl) artistEl.textContent = s.last_played
+        ? (s.artist || "") + (s.artist ? " — DERNIER JOUÉ" : "DERNIER JOUÉ")
+        : (s.artist || "");
+    }
+
+    // Album art
+    if (artEl) {
+      if (s.album_art) {
+        artEl.src = s.album_art;
+        artEl.classList.add("loaded");
+      } else {
+        artEl.classList.remove("loaded");
+      }
+    }
+
+    // Barre de progression
+    if (fillEl && s.duration_ms > 0) {
+      const pct = Math.min(100, (s.progress_ms / s.duration_ms) * 100);
+      fillEl.style.width = pct + "%";
+    }
+
+    // Icône play/pause
+    if (playIcon) {
+      playIcon.innerHTML = _musicPlaying
+        ? '<line x1="5" y1="2" x2="5" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="10" y1="2" x2="10" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>'
+        : '<path fill="currentColor" d="M3 2l10 4.5L3 11V2z"/>';
+    }
+  }
+
+  // ── Spotify Web Playback SDK ───────────────────────────────────────
+  let _spotifyPlayer   = null;
+  let _spotifyDeviceId = null;
+  let _sdkProgressTimer = null;
+  let _currentTrackId  = null;
+
+  async function fetchTrackBeat(trackId) {
+    // Fallback immédiat — l'API audio-features est dépréciée pour les nouvelles apps
+    const applyBeat = (tempo, energy) => { if (_orb) _orb.setMusicBeat(tempo, energy); };
+    try {
+      const { token } = await (await fetch("/api/spotify/token", { headers: J.authHeaders ? J.authHeaders() : {} })).json();
+      if (!token) return applyBeat(120, 0.6);
+      const resp = await fetch(
+        `https://api.spotify.com/v1/audio-features/${trackId}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!resp.ok) return applyBeat(120, 0.6);
+      const f = await resp.json();
+      applyBeat(f.tempo || 120, f.energy ?? 0.6);
+    } catch (_) {
+      applyBeat(120, 0.6);
+    }
+  }
+
+  function _tickSDKProgress() {
+    if (!_spotifyPlayer || !_musicPlaying) return;
+    _spotifyPlayer.getCurrentState().then(state => {
+      if (!state) return;
+      const fillEl = document.getElementById("hcw-progress-fill");
+      if (fillEl && state.duration) {
+        fillEl.style.width = Math.min(100, (state.position / state.duration) * 100) + "%";
+      }
+    }).catch(() => {});
+  }
+
+  async function initSpotifySDK() {
+    if (_spotifyPlayer || window._sdkInitStarted) return;
+    window._sdkInitStarted = true;
+
+    try {
+      const status = await J.api.get("/api/music/provider-status");
+      if (status.provider !== "spotify") return;
+    } catch (_) { return; }
+
+    window.onSpotifyWebPlaybackSDKReady = () => {
+      _spotifyPlayer = new Spotify.Player({
+        name: "JARVIS",
+        getOAuthToken: async (cb) => {
+          try {
+            const res = await fetch("/api/spotify/token", { headers: J.authHeaders ? J.authHeaders() : {} });
+            const data = await res.json();
+            cb(data.token || "");
+          } catch (_) { cb(""); }
+        },
+        volume: 0.7,
+      });
+
+      _spotifyPlayer.addListener("ready", ({ device_id }) => {
+        _spotifyDeviceId = device_id;
+        // Enregistre le device sans transférer la lecture
+        fetch("/api/spotify/transfer", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...(J.authHeaders ? J.authHeaders() : {}) },
+          body: JSON.stringify({ device_id }),
+        }).catch(() => {});
+        // Charge l'état initial (dernier joué)
+        if (_ctrlState.music) fetchMusicStatus();
+      });
+
+      _spotifyPlayer.addListener("not_ready", () => {
+        _spotifyDeviceId = null;
+      });
+
+      _spotifyPlayer.addListener("player_state_changed", (state) => {
+        if (!state) return;
+        const track = state.track_window?.current_track;
+        if (!track) return;
+        _musicPlaying = !state.paused;
+
+        // Beat sync
+        const tid = track.id;
+        const wasPlaying = _musicPlaying;
+        if (tid && (tid !== _currentTrackId || (!wasPlaying && !state.paused))) {
+          _currentTrackId = tid;
+          if (!state.paused) fetchTrackBeat(tid);
+        }
+        if (state.paused && _orb) _orb.setMusicBeat(0, 0);
+
+        updateMusicWidget({
+          connected: true,
+          is_playing: !state.paused,
+          track: track.name,
+          artist: track.artists?.map(a => a.name).join(", ") || "",
+          album: track.album?.name || "",
+          album_art: track.album?.images?.[0]?.url || null,
+          progress_ms: state.position,
+          duration_ms: track.duration_ms,
+          provider: "spotify",
+        });
+      });
+
+      _spotifyPlayer.connect();
+      _sdkProgressTimer = setInterval(_tickSDKProgress, 1000);
+    };
+
+    const script = document.createElement("script");
+    script.src = "https://sdk.scdn.co/spotify-player.js";
+    document.head.appendChild(script);
+  }
+
+  // Démarrage SDK au chargement de la page
+  initSpotifySDK();
+
+  // Boutons du widget musique — SDK en priorité, API en fallback
+  document.getElementById("hcw-prev")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.previousTrack().catch(() => {}); return; }
+    J.api.post("/api/music/prev").then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-play")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.togglePlay().catch(() => {}); return; }
+    J.api.post(_musicPlaying ? "/api/music/pause" : "/api/music/play")
+      .then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-next")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.nextTrack().catch(() => {}); return; }
+    J.api.post("/api/music/next").then(fetchMusicStatus).catch(() => {});
+  });
+
+
+  // ── Widget Chat ────────────────────────────────────────────────────
+  async function loadChatWidget() {
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (!msgsEl) return;
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucune session</div>';
+        return;
+      }
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=30");
+      if (countEl) countEl.textContent = msgs.length + " msg";
+      msgsEl.innerHTML = "";
+      const recent = msgs.slice(-14);
+      if (!recent.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucun message</div>';
+        return;
+      }
+      recent.forEach(m => {
+        const text = m.content || m.text || "";
+        if (!text) return;
+        const wrap = document.createElement("div");
+        wrap.className = "hcw-msg";
+        const role = document.createElement("span");
+        role.className = "hcw-msg-role " + (m.role === "assistant" ? "assistant" : "");
+        role.textContent = m.role === "assistant" ? "JARVIS" : "VOUS";
+        const body = document.createElement("span");
+        body.className = "hcw-msg-text";
+        body.textContent = text.length > 220 ? text.slice(0, 217) + "…" : text;
+        wrap.appendChild(role);
+        wrap.appendChild(body);
+        msgsEl.appendChild(wrap);
+      });
+      msgsEl.scrollTop = msgsEl.scrollHeight;
+    } catch (_) {
+      msgsEl.innerHTML = '<div class="hcw-empty">Erreur de chargement</div>';
+    }
+  }
+
+  // ── Widget Chat : envoi de message texte ──────────────────────────
+  let _chatSending = false;
+
+  function appendChatMsg(role, text, streaming) {
+    const msgsEl = document.getElementById("hcw-chat-msgs");
+    if (!msgsEl) return null;
+    const empty = msgsEl.querySelector(".hcw-empty");
+    if (empty) empty.remove();
+
+    const wrap = document.createElement("div");
+    wrap.className = "hcw-msg";
+    const roleEl = document.createElement("span");
+    roleEl.className = "hcw-msg-role" + (role === "assistant" ? " assistant" : "");
+    roleEl.textContent = role === "assistant" ? "JARVIS" : "VOUS";
+    const bodyEl = document.createElement("span");
+    bodyEl.className = "hcw-msg-text";
+    bodyEl.textContent = text;
+    wrap.appendChild(roleEl);
+    wrap.appendChild(bodyEl);
+    msgsEl.appendChild(wrap);
+    msgsEl.scrollTop = msgsEl.scrollHeight;
+    if (streaming) return bodyEl;
+    return null;
+  }
+
+  async function sendChatMessage() {
+    if (_chatSending) return;
+    const input = document.getElementById("hcw-input");
+    const sendBtn = document.getElementById("hcw-send");
+    const text = (input?.value || "").trim();
+    if (!text) return;
+
+    _chatSending = true;
+    if (sendBtn) sendBtn.disabled = true;
+    input.value = "";
+
+    appendChatMsg("user", text, false);
+
+    const streamTarget = appendChatMsg("assistant", "", true);
+    setOrbState("thinking");
+
+    try {
+      const sessionId = localStorage.getItem("jarvis_voice_session") || null;
+      const resp = await fetch("/api/voice/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...(J.authHeaders ? J.authHeaders() : {}) },
+        body: JSON.stringify({ message: text, session_id: sessionId }),
+      });
+      const returnedSid = resp.headers.get("x-session-id");
+      if (returnedSid) localStorage.setItem("jarvis_voice_session", returnedSid);
+
+      if (!resp.ok || !resp.body) throw new Error("Erreur réseau");
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let full = "";
+      setOrbState("speaking");
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        full += decoder.decode(value, { stream: true });
+        if (streamTarget) {
+          streamTarget.textContent = full;
+          document.getElementById("hcw-chat-msgs").scrollTop = 9999;
+        }
+      }
+
+      const countEl = document.getElementById("hcw-chat-count");
+      if (countEl) {
+        const cur = parseInt(countEl.textContent) || 0;
+        countEl.textContent = (cur + 2) + " msg";
+      }
+    } catch (err) {
+      if (streamTarget) streamTarget.textContent = "Erreur de communication.";
+    } finally {
+      _chatSending = false;
+      if (sendBtn) sendBtn.disabled = false;
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  }
+
+  document.getElementById("hcw-new-session")?.addEventListener("click", () => {
+    localStorage.removeItem("jarvis_voice_session");
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (msgsEl)  msgsEl.innerHTML = '<div class="hcw-empty">Nouvelle conversation</div>';
+    if (countEl) countEl.textContent = "—";
+    document.getElementById("hcw-input")?.focus();
+  });
+
+  document.getElementById("hcw-send")?.addEventListener("click", sendChatMessage);
+
+  document.getElementById("hcw-input")?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendChatMessage();
+    }
+  });
+
+
+  // ── WebSocket — sync état orbe + canal passif ──────────────────────
+  function connectWS() {
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    try {
+      _ws = new WebSocket(proto + "//" + location.host + "/ws");
+    } catch (_) { return; }
+
+    _ws.onmessage = (ev) => {
+      let data;
+      try { data = JSON.parse(ev.data); } catch (_) { return; }
+
+      if (data.type === "voice_state") setOrbState(data.state || "idle");
+      if (data.type === "audio_level" && _orb) _orb.setAudioLevel(data.level || 0);
+      if (data.type === "wake_up") window.dispatchEvent(new CustomEvent("jarvis-wake", { detail: data }));
+
+      if (data.type === "message" && data.role === "assistant" && data.text) {
+        showChannel(data.text);
+        if (_ctrlState.chat) loadChatWidget();
+      }
+
+      // ── View routing ──────────────────────────────────────────────
+      if (data.type === "reload_views") {
+        const _prevActive = J.views._active;
+        if (_prevActive) J.views.deactivate(_prevActive);
+        // Supprime aussi les scripts sans data-view-skill (chargés avant le fix)
+        document.querySelectorAll('script[src*="/skills/"]').forEach(el => el.remove());
+        document.querySelectorAll('link[href*="/skills/"]').forEach(el => el.remove());
+        window.loadViewSkills?.().then?.(() => {
+          if (_prevActive) J.views.activate(_prevActive);
+        });
+      }
+      if (data.type === "show_home")  { const a = J.views._active; if (a) J.views.deactivate(a); }
+      if (data.type === "show_view")    J.views.activate(data.view_id, data.params);
+      if (data.type === "hide_view")    J.views.deactivate(data.view_id);
+      if (data.type === "view_command") J.views.dispatch(data.view_id, data.command, data.params);
+
+      // Backward compat (map_control legacy events)
+      if (data.type === "map_fly_to")    { J.views.activate("globe"); J.views.dispatch("globe", "fly_to", data); }
+      if (data.type === "map_zoom_out")  J.views.dispatch("globe", "zoom_out", {});
+      if (data.type === "map_zoom_in")   J.views.dispatch("globe", "zoom_in", {});
+      if (data.type === "map_globe_view"){ J.views.activate("globe"); J.views.dispatch("globe", "globe_view", {}); }
+      if (data.type === "toggle_panels") J.views.dispatch("globe", "toggle_panels", {});
+    };
+
+    _ws.onclose = () => setTimeout(connectWS, 3000);
+  }
+  connectWS();
+
+  // ── Canal passif (bas-droite) ──────────────────────────────────────
+  let _channelTs    = null;
+  let _channelTimer = null;
+
+  function relativeTime(ts) {
+    const mins = Math.round((Date.now() - ts) / 60000);
+    if (mins < 1)  return "À L'INSTANT";
+    if (mins === 1) return "IL Y A 1 MIN";
+    if (mins < 60) return "IL Y A " + mins + " MIN";
+    return "IL Y A " + Math.floor(mins / 60) + " H";
+  }
+
+  function updateChannelTime() {
+    if (!_channelTs) return;
+    const el = document.getElementById("channel-time");
+    if (el) el.textContent = relativeTime(_channelTs);
+  }
+
+  function showChannel(text) {
+    const el  = document.getElementById("home-channel");
+    const msg = document.getElementById("channel-msg");
+    if (!el || !msg) return;
+    msg.textContent = text.length > 160 ? text.slice(0, 157) + "…" : text;
+    _channelTs = Date.now();
+    updateChannelTime();
+    el.style.display = "";
+    if (_channelTimer) clearInterval(_channelTimer);
+    _channelTimer = setInterval(updateChannelTime, 30000);
+  }
+
+  (async function loadLastMessage() {
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) return;
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=10");
+      const last = [...msgs].reverse().find(m => m.role === "assistant");
+      if (last && (last.content || last.text)) showChannel(last.content || last.text);
+    } catch (_) {}
+  })();
+
+  // ── Navigation iframe — shell persistant ─────────────────────────
+  const _frame = document.getElementById("page-frame");
+  let _frameActive = false;
+
+  Jarvis.navigateFrame = function (url) {
+    if (!url || url === "/" || url === window.location.origin + "/") {
+      // Retour home — cacher l'iframe
+      if (_frame) {
+        _frame.classList.remove("is-active");
+        _frame.src = "about:blank";
+      }
+      _frameActive = false;
+      history.replaceState(null, "", "/");
+    } else {
+      // Fermer toute vue active (globe, etc.) avant de naviguer
+      Jarvis.views.deactivate();
+      if (_frame) {
+        _frame.src = url;
+        _frame.classList.add("is-active");
+      }
+      _frameActive = true;
+      history.pushState({ frame: url }, "", url);
+    }
+  };
+
+  // Bouton retour navigateur
+  window.addEventListener("popstate", (e) => {
+    if (e.state?.frame) {
+      if (_frame) { _frame.src = e.state.frame; _frame.classList.add("is-active"); }
+      _frameActive = true;
+    } else {
+      if (_frame) { _frame.classList.remove("is-active"); _frame.src = "about:blank"; }
+      _frameActive = false;
+    }
+  });
+
+  // ── Touche espace → dashboard (ou ferme l'iframe si déjà ouvert) ──
+  document.addEventListener("keydown", (e) => {
+    if (e.key === " " && !e.metaKey && !e.ctrlKey) {
+      const active = document.activeElement;
+      if (active && (active.tagName === "INPUT" || active.tagName === "TEXTAREA")) return;
+      e.preventDefault();
+      if (_frameActive) {
+        Jarvis.navigateFrame("/");
+      } else {
+        Jarvis.navigateFrame("/dashboard");
+      }
+    }
+  });
+
+  // ── Helper drag-and-drop pour widgets / overlay ────────────────────
+  function makeDraggable(el, handle) {
+    if (!el) return;
+    const grip = handle || el;
+
+    grip.addEventListener("mousedown", (e) => {
+      if (e.target.closest("button, input, textarea, .hcw-resize-handle")) return;
+      e.preventDefault();
+      let ex = e.clientX, ey = e.clientY;
+      el.classList.add("dragging");
+
+      function onMove(e) {
+        const dx = e.clientX - ex;
+        const dy = e.clientY - ey;
+        ex = e.clientX; ey = e.clientY;
+        const rect = el.getBoundingClientRect();
+        el.style.left   = (rect.left + dx) + "px";
+        el.style.top    = (rect.top  + dy) + "px";
+        el.style.right  = "auto";
+        el.style.bottom = "auto";
+      }
+
+      function onUp() {
+        el.classList.remove("dragging");
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // ── Helper redimensionnement pour widgets ──────────────────────────
+  function makeResizable(el, handleEl, minW, minH) {
+    if (!el || !handleEl) return;
+    minW = minW || 180;
+    minH = minH || 80;
+
+    handleEl.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Ancrer en top/left au moment du resize
+      const rect = el.getBoundingClientRect();
+      el.style.left   = rect.left   + "px";
+      el.style.top    = rect.top    + "px";
+      el.style.right  = "auto";
+      el.style.bottom = "auto";
+      el.style.width  = rect.width  + "px";
+      el.style.height = rect.height + "px";
+
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startW = rect.width;
+      const startH = rect.height;
+
+      function onMove(e) {
+        const w = Math.max(minW, startW + (e.clientX - startX));
+        const h = Math.max(minH, startH + (e.clientY - startY));
+        el.style.width  = w + "px";
+        el.style.height = h + "px";
+        // Enleve max-height sur le corps messages si present
+        const msgs = el.querySelector(".hcw-messages");
+        if (msgs) msgs.style.maxHeight = "none";
+      }
+
+      function onUp() {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // Attacher drag + resize aux widgets
+  makeDraggable(document.getElementById("cam-overlay"), document.getElementById("cam-drag-handle"));
+  makeResizable(document.getElementById("cam-overlay"), document.getElementById("cam-resize-handle"), 180, 120);
+
+  makeDraggable(document.getElementById("hc-widget-music"));
+  makeResizable(document.getElementById("hc-widget-music"), document.getElementById("music-resize-handle"), 180, 100);
+
+  makeDraggable(document.getElementById("hc-widget-chat"));
+  makeResizable(document.getElementById("hc-widget-chat"), document.getElementById("chat-resize-handle"), 220, 160);
+})();

--- a/src/jarvis/interfaces/ui/static/home.js.bak-20260621-011148
+++ b/src/jarvis/interfaces/ui/static/home.js.bak-20260621-011148
@@ -1,0 +1,906 @@
+/* home.js — page Home runtime */
+(function () {
+  "use strict";
+
+  const J = window.Jarvis;
+
+  // ── Atmosphere + Mission Control ──────────────────────────────────
+  J.mountAtmosphere();
+  J.mountRooms({ mode: "home", pages: [], activePage: null, onNav: () => {} });
+
+  // ── Stubs pour voice.js (tourne aussi dans cette page) ───────────
+  // voice.js cherche addMsg / checkForMindmap en global
+  window.addMsg = function (role, text = "", streaming = false) {
+    if (streaming) {
+      // Retourne une div temporaire que le VoiceClient remplit de chunks
+      const div = document.createElement("div");
+      div.className = "hcw-msg";
+      div.dataset.streaming = "1";
+      const roleEl = document.createElement("span");
+      roleEl.className = "hcw-msg-role " + (role === "jarvis" ? "assistant" : "");
+      roleEl.textContent = role === "jarvis" ? "JARVIS" : "VOUS";
+      const textEl = document.createElement("span");
+      textEl.className = "hcw-msg-text";
+      div.appendChild(roleEl);
+      div.appendChild(textEl);
+      // Si le widget chat est ouvert, on append
+      const msgsEl = document.getElementById("hcw-chat-msgs");
+      if (msgsEl && _ctrlState.chat) {
+        msgsEl.appendChild(div);
+        msgsEl.scrollTop = msgsEl.scrollHeight;
+      }
+      return textEl; // voice.js écrit dans .textContent de ce noeud
+    }
+    // Non-streaming : on recharge le widget si ouvert
+    if (_ctrlState.chat) setTimeout(loadChatWidget, 800);
+    return null;
+  };
+  window.checkForMindmap = function () {};
+
+  // ── WebSocket session ID / send (pour mediapipe_vision.js) ───────
+  let _ws = null;
+  window._jarvisSessionId = () => null;
+  window._jarvisWsSend = (data) => {
+    if (_ws && _ws.readyState === WebSocket.OPEN) {
+      _ws.send(JSON.stringify(data));
+    }
+  };
+
+  // ── Clock + date ──────────────────────────────────────────────────
+  const JOURS = ["DIMANCHE","LUNDI","MARDI","MERCREDI","JEUDI","VENDREDI","SAMEDI"];
+  const MOIS  = ["JANVIER","FÉVRIER","MARS","AVRIL","MAI","JUIN","JUILLET","AOÛT","SEPTEMBRE","OCTOBRE","NOVEMBRE","DÉCEMBRE"];
+
+  function updateClock() {
+    const t   = new Date();
+    const pad = n => String(n).padStart(2, "0");
+    const cl  = document.getElementById("home-clock");
+    const dt  = document.getElementById("home-date");
+    if (cl) cl.textContent = pad(t.getHours()) + ":" + pad(t.getMinutes());
+    if (dt) dt.textContent = JOURS[t.getDay()] + ", " + t.getDate() + " " + MOIS[t.getMonth()] + " " + t.getFullYear();
+  }
+  updateClock();
+  setInterval(updateClock, 1000);
+
+  // ── État orbe ─────────────────────────────────────────────────────
+  const STATE_DOTS = {
+    idle:      { cls: "blue",   label: "AU REPOS" },
+    listening: { cls: "blue",   label: "EN ÉCOUTE" },
+    thinking:  { cls: "purple", label: "RÉFLEXION" },
+    speaking:  { cls: "purple", label: "PARLE" },
+    success:   { cls: "green",  label: "SUCCÈS" },
+    offline:   { cls: "gray",   label: "HORS LIGNE" },
+  };
+
+  let _orb = null;
+  let _currentState = "idle";
+
+  function setOrbState(state) {
+    _currentState = state;
+    const meta = STATE_DOTS[state] || STATE_DOTS.idle;
+    const dot = document.getElementById("status-dot");
+    const lbl = document.getElementById("status-label");
+    if (dot) dot.className = "status-dot " + meta.cls;
+    if (lbl) lbl.textContent = meta.label;
+    if (_orb) _orb.setState(state);
+  }
+
+  function initOrb() {
+    if (typeof THREE === "undefined" || typeof JarvisOrb === "undefined") {
+      setTimeout(initOrb, 100);
+      return;
+    }
+    // Cold boot wake : la séquence va mounter l'orbe sur #orb-canvas en
+    // frozen, puis nous le rendra via injectWakeOrb() à l'entrée ONLINE.
+    if (window.__jarvisWakeActive) return;
+    const canvas = document.getElementById("orb-canvas");
+    if (!canvas) return;
+    _orb = new JarvisOrb(canvas);
+    setOrbState("idle");
+  }
+  initOrb();
+
+  // ── Bascule depuis la séquence de réveil ────────────────────────────
+  // wake_sequence.js appelle ça à l'entrée ONLINE : l'orbe partagé est
+  // remis à home.js, qui prend la main pour les states voice/audio/music.
+  window.__jarvisInjectOrb = function (orb) {
+    _orb = orb;
+    setOrbState("idle");
+  };
+
+  // ── body.view-active : source de vérité unique pour toutes les vues ─
+  const _origViewActivate   = J.views.activate.bind(J.views);
+  const _origViewDeactivate = J.views.deactivate.bind(J.views);
+  J.views.activate = function (id, params) {
+    _origViewActivate(id, params);
+    document.body.classList.add("view-active");
+  };
+  J.views.deactivate = function (id) {
+    _origViewDeactivate(id);
+    // Différé : si activate() enchaîne, _active est déjà re-setté quand le check tourne
+    Promise.resolve().then(() => {
+      if (!J.views._active) document.body.classList.remove("view-active");
+    });
+  };
+
+  // ── Sync état orbe depuis les events voice.js ─────────────────────
+  const VOICE_ORB_MAP = {
+    vad_start:   "listening",
+    stt_done:    "thinking",
+    llm_start:   "thinking",
+    tts_start:   "speaking",
+    tts_done:    "idle",
+    interrupted: "listening",
+  };
+  window.addEventListener("jarvis:ws", (e) => {
+    const msg = e.detail;
+    if (VOICE_ORB_MAP[msg.type]) setOrbState(VOICE_ORB_MAP[msg.type]);
+    if (msg.type === "tts_done" || msg.type === "done") {
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  });
+
+  // ── Controls (pictos haut-gauche) ─────────────────────────────────
+  const CTRL_DEFS = [
+    { key: "mic",    id: "hc-mic" },
+    { key: "screen", id: "hc-screen" },
+    { key: "cam",    id: "hc-cam" },
+    { key: "files",  id: "hc-files" },
+    { key: "music",  id: "hc-music",  widget: "hc-widget-music" },
+    { key: "chat",   id: "hc-chat",   widget: "hc-widget-chat" },
+  ];
+
+  const _ctrlState = {};
+  CTRL_DEFS.forEach(c => { _ctrlState[c.key] = false; });
+
+  function setCtrl(key, val) {
+    _ctrlState[key] = val;
+    const def = CTRL_DEFS.find(c => c.key === key);
+    if (!def) return;
+    const btn = document.getElementById(def.id);
+    if (btn) btn.classList.toggle("active", val);
+    if (def.widget) {
+      const w = document.getElementById(def.widget);
+      if (w) w.classList.toggle("is-open", val);
+    }
+  }
+
+  async function toggleCtrl(key) {
+    const next = !_ctrlState[key];
+
+    if (key === "mic") {
+      _ctrlState.mic = next;
+      const vc = window._voiceClient;
+      if (!vc) return;
+      if (next) {
+        await playGreeting();
+        try {
+          await vc._start();
+        } catch (err) {
+          console.error("[Mic] Erreur demarrage :", err);
+          _ctrlState.mic = false;
+          setOrbState("offline");
+          setTimeout(() => setOrbState("idle"), 2000);
+        }
+      } else {
+        vc._stop();
+        setOrbState("idle");
+      }
+      return;
+    }
+
+    if (key === "cam") {
+      if (next) {
+        setCtrl("cam", true);  // marque actif immédiatement pour que le 2e clic puisse désactiver
+        const ok = await startCamera();
+        if (!ok) {
+          setCtrl("cam", false);
+          return;
+        }
+        J.api.patch("/api/permissions/camera", { enabled: true }).catch(() => {});
+      } else {
+        stopCamera();
+        setCtrl("cam", false);
+        J.api.patch("/api/permissions/camera", { enabled: false }).catch(() => {});
+      }
+      return;
+    }
+
+    if (key === "screen") {
+      setCtrl("screen", next);
+      J.api.patch("/api/permissions/screen", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "files") {
+      setCtrl("files", next);
+      J.api.patch("/api/permissions/files", { enabled: next }).catch(() => {});
+      return;
+    }
+
+    if (key === "music") {
+      setCtrl("music", next);
+      if (next) startMusicPoll();
+      else stopMusicPoll();
+      return;
+    }
+
+    if (key === "chat") {
+      setCtrl("chat", next);
+      if (next) loadChatWidget();
+      return;
+    }
+  }
+
+  // Charge l'etat initial des permissions depuis le serveur
+  (async function loadPermissions() {
+    try {
+      const perms = await J.api.get("/api/permissions");
+      if (perms.screen   != null) setCtrl("screen", perms.screen);
+      if (perms.camera   != null) setCtrl("cam",    perms.camera);
+      if (perms.files    != null) setCtrl("files",  perms.files);
+    } catch (_) {}
+  })();
+
+  CTRL_DEFS.forEach(c => {
+    const btn = document.getElementById(c.id);
+    if (btn) btn.addEventListener("click", () => toggleCtrl(c.key));
+  });
+
+  // Lier le bouton mic au VoiceClient après DOMContentLoaded
+  document.addEventListener("DOMContentLoaded", () => {
+    const vc = window._voiceClient;
+    if (vc) {
+      vc._btn = document.getElementById("hc-mic");
+    }
+  }, { once: true });
+
+  // ── Greeting vocal (comme l'ancien repo) ──────────────────────────
+  async function playGreeting() {
+    try {
+      let fn = "";
+      try {
+        const s = await fetch("/api/wakeup/status", { headers: window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {} }).then((r) => r.json());
+        fn = (s && s.user_firstname) || "";
+      } catch { /* repli sans prénom */ }
+      const greeting = fn ? `Systèmes en ligne. Bonjour ${fn}.` : "Systèmes en ligne.";
+      const resp = await fetch("/api/voice/speak", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...(window.Jarvis && Jarvis.authHeaders ? Jarvis.authHeaders() : {}) },
+        body: JSON.stringify({ text: greeting }),
+      });
+      const data = await resp.json();
+      if (!data.audio_b64) return;
+
+      // Décoder le base64 → ArrayBuffer → AudioContext
+      const binary = atob(data.audio_b64);
+      const bytes  = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+
+      const audioCtx = new AudioContext();
+      const buffer   = await audioCtx.decodeAudioData(bytes.buffer);
+      const source   = audioCtx.createBufferSource();
+      source.buffer  = buffer;
+      source.connect(audioCtx.destination);
+
+      setOrbState("speaking");
+
+      await new Promise((resolve) => {
+        source.onended = resolve;
+        source.start();
+      });
+      audioCtx.close();
+    } catch (err) {
+      console.warn("[Greeting] Erreur :", err);
+    } finally {
+      setOrbState("listening");
+    }
+  }
+
+  // ── Caméra (MediaPipe) ─────────────────────────────────────────────
+  let _camStream = null;
+
+  async function startCamera() {
+    try {
+      _camStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "user", width: { ideal: 640 }, height: { ideal: 480 } },
+      });
+      const video = document.getElementById("cam-video");
+      if (video) {
+        video.srcObject = _camStream;
+        await video.play();
+      }
+      document.getElementById("cam-overlay")?.classList.add("is-open");
+      // Initialise MediaPipe (charge les modèles si nécessaire)
+      if (typeof mpInit === "function") {
+        await mpInit();
+        mpStart();
+      }
+      return true;
+    } catch (err) {
+      console.error("[Camera] Erreur :", err);
+      return false;
+    }
+  }
+
+  function stopCamera() {
+    if (typeof mpStop === "function") mpStop();
+    if (_camStream) {
+      _camStream.getTracks().forEach(t => t.stop());
+      _camStream = null;
+    }
+    const video = document.getElementById("cam-video");
+    if (video) video.srcObject = null;
+    document.getElementById("cam-overlay")?.classList.remove("is-open");
+  }
+
+
+  // ── Widget Musique ─────────────────────────────────────────────────
+  let _musicPollTimer = null;
+  let _musicPlaying   = false;
+
+  function startMusicPoll() {
+    fetchMusicStatus();
+    _musicPollTimer = setInterval(fetchMusicStatus, 5000);
+  }
+
+  function stopMusicPoll() {
+    clearInterval(_musicPollTimer);
+    _musicPollTimer = null;
+  }
+
+  async function fetchMusicStatus() {
+    try {
+      const s = await J.api.get("/api/music/status");
+      updateMusicWidget(s);
+    } catch (_) {}
+  }
+
+  function updateMusicWidget(s) {
+    const trackEl  = document.getElementById("hcw-music-track");
+    const artistEl = document.getElementById("hcw-music-artist");
+    const srcEl    = document.getElementById("hcw-music-source");
+    const artEl    = document.getElementById("hcw-album-art");
+    const fillEl   = document.getElementById("hcw-progress-fill");
+    const playIcon = document.getElementById("hcw-play-icon");
+
+    if (!s || !s.connected) {
+      if (trackEl)  trackEl.textContent  = "Non connecté";
+      if (artistEl) artistEl.textContent = s?.provider ? "Configurer dans les paramètres" : "Aucun service configuré";
+      if (srcEl)    srcEl.textContent    = s?.provider || "—";
+      return;
+    }
+
+    _musicPlaying = s.is_playing || false;
+
+    const providerLabel = (s.provider || "").toUpperCase();
+    if (srcEl) srcEl.textContent = providerLabel || "—";
+
+    if (!s.track) {
+      if (trackEl)  trackEl.textContent  = "Aucune lecture";
+      if (artistEl) artistEl.textContent = providerLabel ? providerLabel + " CONNECTÉ" : "—";
+    } else {
+      if (trackEl)  trackEl.textContent  = s.track;
+      if (artistEl) artistEl.textContent = s.last_played
+        ? (s.artist || "") + (s.artist ? " — DERNIER JOUÉ" : "DERNIER JOUÉ")
+        : (s.artist || "");
+    }
+
+    // Album art
+    if (artEl) {
+      if (s.album_art) {
+        artEl.src = s.album_art;
+        artEl.classList.add("loaded");
+      } else {
+        artEl.classList.remove("loaded");
+      }
+    }
+
+    // Barre de progression
+    if (fillEl && s.duration_ms > 0) {
+      const pct = Math.min(100, (s.progress_ms / s.duration_ms) * 100);
+      fillEl.style.width = pct + "%";
+    }
+
+    // Icône play/pause
+    if (playIcon) {
+      playIcon.innerHTML = _musicPlaying
+        ? '<line x1="5" y1="2" x2="5" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="10" y1="2" x2="10" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>'
+        : '<path fill="currentColor" d="M3 2l10 4.5L3 11V2z"/>';
+    }
+  }
+
+  // ── Spotify Web Playback SDK ───────────────────────────────────────
+  let _spotifyPlayer   = null;
+  let _spotifyDeviceId = null;
+  let _sdkProgressTimer = null;
+  let _currentTrackId  = null;
+
+  async function fetchTrackBeat(trackId) {
+    // Fallback immédiat — l'API audio-features est dépréciée pour les nouvelles apps
+    const applyBeat = (tempo, energy) => { if (_orb) _orb.setMusicBeat(tempo, energy); };
+    try {
+      const { token } = await (await fetch("/api/spotify/token", { headers: J.authHeaders ? J.authHeaders() : {} })).json();
+      if (!token) return applyBeat(120, 0.6);
+      const resp = await fetch(
+        `https://api.spotify.com/v1/audio-features/${trackId}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      if (!resp.ok) return applyBeat(120, 0.6);
+      const f = await resp.json();
+      applyBeat(f.tempo || 120, f.energy ?? 0.6);
+    } catch (_) {
+      applyBeat(120, 0.6);
+    }
+  }
+
+  function _tickSDKProgress() {
+    if (!_spotifyPlayer || !_musicPlaying) return;
+    _spotifyPlayer.getCurrentState().then(state => {
+      if (!state) return;
+      const fillEl = document.getElementById("hcw-progress-fill");
+      if (fillEl && state.duration) {
+        fillEl.style.width = Math.min(100, (state.position / state.duration) * 100) + "%";
+      }
+    }).catch(() => {});
+  }
+
+  async function initSpotifySDK() {
+    if (_spotifyPlayer || window._sdkInitStarted) return;
+    window._sdkInitStarted = true;
+
+    try {
+      const status = await J.api.get("/api/music/provider-status");
+      if (status.provider !== "spotify") return;
+    } catch (_) { return; }
+
+    window.onSpotifyWebPlaybackSDKReady = () => {
+      _spotifyPlayer = new Spotify.Player({
+        name: "JARVIS",
+        getOAuthToken: async (cb) => {
+          try {
+            const res = await fetch("/api/spotify/token", { headers: J.authHeaders ? J.authHeaders() : {} });
+            const data = await res.json();
+            cb(data.token || "");
+          } catch (_) { cb(""); }
+        },
+        volume: 0.7,
+      });
+
+      _spotifyPlayer.addListener("ready", ({ device_id }) => {
+        _spotifyDeviceId = device_id;
+        // Enregistre le device sans transférer la lecture
+        fetch("/api/spotify/transfer", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...(J.authHeaders ? J.authHeaders() : {}) },
+          body: JSON.stringify({ device_id }),
+        }).catch(() => {});
+        // Charge l'état initial (dernier joué)
+        if (_ctrlState.music) fetchMusicStatus();
+      });
+
+      _spotifyPlayer.addListener("not_ready", () => {
+        _spotifyDeviceId = null;
+      });
+
+      _spotifyPlayer.addListener("player_state_changed", (state) => {
+        if (!state) return;
+        const track = state.track_window?.current_track;
+        if (!track) return;
+        _musicPlaying = !state.paused;
+
+        // Beat sync
+        const tid = track.id;
+        const wasPlaying = _musicPlaying;
+        if (tid && (tid !== _currentTrackId || (!wasPlaying && !state.paused))) {
+          _currentTrackId = tid;
+          if (!state.paused) fetchTrackBeat(tid);
+        }
+        if (state.paused && _orb) _orb.setMusicBeat(0, 0);
+
+        updateMusicWidget({
+          connected: true,
+          is_playing: !state.paused,
+          track: track.name,
+          artist: track.artists?.map(a => a.name).join(", ") || "",
+          album: track.album?.name || "",
+          album_art: track.album?.images?.[0]?.url || null,
+          progress_ms: state.position,
+          duration_ms: track.duration_ms,
+          provider: "spotify",
+        });
+      });
+
+      _spotifyPlayer.connect();
+      _sdkProgressTimer = setInterval(_tickSDKProgress, 1000);
+    };
+
+    const script = document.createElement("script");
+    script.src = "https://sdk.scdn.co/spotify-player.js";
+    document.head.appendChild(script);
+  }
+
+  // Démarrage SDK au chargement de la page
+  initSpotifySDK();
+
+  // Boutons du widget musique — SDK en priorité, API en fallback
+  document.getElementById("hcw-prev")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.previousTrack().catch(() => {}); return; }
+    J.api.post("/api/music/prev").then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-play")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.togglePlay().catch(() => {}); return; }
+    J.api.post(_musicPlaying ? "/api/music/pause" : "/api/music/play")
+      .then(fetchMusicStatus).catch(() => {});
+  });
+  document.getElementById("hcw-next")?.addEventListener("click", () => {
+    if (_spotifyPlayer) { _spotifyPlayer.nextTrack().catch(() => {}); return; }
+    J.api.post("/api/music/next").then(fetchMusicStatus).catch(() => {});
+  });
+
+
+  // ── Widget Chat ────────────────────────────────────────────────────
+  async function loadChatWidget() {
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (!msgsEl) return;
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucune session</div>';
+        return;
+      }
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=30");
+      if (countEl) countEl.textContent = msgs.length + " msg";
+      msgsEl.innerHTML = "";
+      const recent = msgs.slice(-14);
+      if (!recent.length) {
+        msgsEl.innerHTML = '<div class="hcw-empty">Aucun message</div>';
+        return;
+      }
+      recent.forEach(m => {
+        const text = m.content || m.text || "";
+        if (!text) return;
+        const wrap = document.createElement("div");
+        wrap.className = "hcw-msg";
+        const role = document.createElement("span");
+        role.className = "hcw-msg-role " + (m.role === "assistant" ? "assistant" : "");
+        role.textContent = m.role === "assistant" ? "JARVIS" : "VOUS";
+        const body = document.createElement("span");
+        body.className = "hcw-msg-text";
+        body.textContent = text.length > 220 ? text.slice(0, 217) + "…" : text;
+        wrap.appendChild(role);
+        wrap.appendChild(body);
+        msgsEl.appendChild(wrap);
+      });
+      msgsEl.scrollTop = msgsEl.scrollHeight;
+    } catch (_) {
+      msgsEl.innerHTML = '<div class="hcw-empty">Erreur de chargement</div>';
+    }
+  }
+
+  // ── Widget Chat : envoi de message texte ──────────────────────────
+  let _chatSending = false;
+
+  function appendChatMsg(role, text, streaming) {
+    const msgsEl = document.getElementById("hcw-chat-msgs");
+    if (!msgsEl) return null;
+    const empty = msgsEl.querySelector(".hcw-empty");
+    if (empty) empty.remove();
+
+    const wrap = document.createElement("div");
+    wrap.className = "hcw-msg";
+    const roleEl = document.createElement("span");
+    roleEl.className = "hcw-msg-role" + (role === "assistant" ? " assistant" : "");
+    roleEl.textContent = role === "assistant" ? "JARVIS" : "VOUS";
+    const bodyEl = document.createElement("span");
+    bodyEl.className = "hcw-msg-text";
+    bodyEl.textContent = text;
+    wrap.appendChild(roleEl);
+    wrap.appendChild(bodyEl);
+    msgsEl.appendChild(wrap);
+    msgsEl.scrollTop = msgsEl.scrollHeight;
+    if (streaming) return bodyEl;
+    return null;
+  }
+
+  async function sendChatMessage() {
+    if (_chatSending) return;
+    const input = document.getElementById("hcw-input");
+    const sendBtn = document.getElementById("hcw-send");
+    const text = (input?.value || "").trim();
+    if (!text) return;
+
+    _chatSending = true;
+    if (sendBtn) sendBtn.disabled = true;
+    input.value = "";
+
+    appendChatMsg("user", text, false);
+
+    const streamTarget = appendChatMsg("assistant", "", true);
+    setOrbState("thinking");
+
+    try {
+      const sessionId = localStorage.getItem("jarvis_voice_session") || null;
+      const resp = await fetch("/api/voice/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...(J.authHeaders ? J.authHeaders() : {}) },
+        body: JSON.stringify({ message: text, session_id: sessionId }),
+      });
+      const returnedSid = resp.headers.get("x-session-id");
+      if (returnedSid) localStorage.setItem("jarvis_voice_session", returnedSid);
+
+      if (!resp.ok || !resp.body) throw new Error("Erreur réseau");
+
+      const reader = resp.body.getReader();
+      const decoder = new TextDecoder();
+      let full = "";
+      setOrbState("speaking");
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        full += decoder.decode(value, { stream: true });
+        if (streamTarget) {
+          streamTarget.textContent = full;
+          document.getElementById("hcw-chat-msgs").scrollTop = 9999;
+        }
+      }
+
+      const countEl = document.getElementById("hcw-chat-count");
+      if (countEl) {
+        const cur = parseInt(countEl.textContent) || 0;
+        countEl.textContent = (cur + 2) + " msg";
+      }
+    } catch (err) {
+      if (streamTarget) streamTarget.textContent = "Erreur de communication.";
+    } finally {
+      _chatSending = false;
+      if (sendBtn) sendBtn.disabled = false;
+      setTimeout(() => setOrbState("idle"), 1200);
+    }
+  }
+
+  document.getElementById("hcw-new-session")?.addEventListener("click", () => {
+    localStorage.removeItem("jarvis_voice_session");
+    const msgsEl  = document.getElementById("hcw-chat-msgs");
+    const countEl = document.getElementById("hcw-chat-count");
+    if (msgsEl)  msgsEl.innerHTML = '<div class="hcw-empty">Nouvelle conversation</div>';
+    if (countEl) countEl.textContent = "—";
+    document.getElementById("hcw-input")?.focus();
+  });
+
+  document.getElementById("hcw-send")?.addEventListener("click", sendChatMessage);
+
+  document.getElementById("hcw-input")?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendChatMessage();
+    }
+  });
+
+
+  // ── WebSocket — sync état orbe + canal passif ──────────────────────
+  function connectWS() {
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    try {
+      _ws = new WebSocket(proto + "//" + location.host + "/ws");
+    } catch (_) { return; }
+
+    _ws.onmessage = (ev) => {
+      let data;
+      try { data = JSON.parse(ev.data); } catch (_) { return; }
+
+      if (data.type === "voice_state") setOrbState(data.state || "idle");
+      if (data.type === "audio_level" && _orb) _orb.setAudioLevel(data.level || 0);
+      if (data.type === "wake_up") window.dispatchEvent(new CustomEvent("jarvis-wake", { detail: data }));
+
+      if (data.type === "message" && data.role === "assistant" && data.text) {
+        showChannel(data.text);
+        if (_ctrlState.chat) loadChatWidget();
+      }
+
+      // ── View routing ──────────────────────────────────────────────
+      if (data.type === "reload_views") {
+        const _prevActive = J.views._active;
+        if (_prevActive) J.views.deactivate(_prevActive);
+        // Supprime aussi les scripts sans data-view-skill (chargés avant le fix)
+        document.querySelectorAll('script[src*="/skills/"]').forEach(el => el.remove());
+        document.querySelectorAll('link[href*="/skills/"]').forEach(el => el.remove());
+        window.loadViewSkills?.().then?.(() => {
+          if (_prevActive) J.views.activate(_prevActive);
+        });
+      }
+      if (data.type === "show_home")  { const a = J.views._active; if (a) J.views.deactivate(a); }
+      if (data.type === "show_view")    J.views.activate(data.view_id, data.params);
+      if (data.type === "hide_view")    J.views.deactivate(data.view_id);
+      if (data.type === "view_command") J.views.dispatch(data.view_id, data.command, data.params);
+
+      // Backward compat (map_control legacy events)
+      if (data.type === "map_fly_to")    { J.views.activate("globe"); J.views.dispatch("globe", "fly_to", data); }
+      if (data.type === "map_zoom_out")  J.views.dispatch("globe", "zoom_out", {});
+      if (data.type === "map_zoom_in")   J.views.dispatch("globe", "zoom_in", {});
+      if (data.type === "map_globe_view"){ J.views.activate("globe"); J.views.dispatch("globe", "globe_view", {}); }
+      if (data.type === "toggle_panels") J.views.dispatch("globe", "toggle_panels", {});
+    };
+
+    _ws.onclose = () => setTimeout(connectWS, 3000);
+  }
+  connectWS();
+
+  // ── Canal passif (bas-droite) ──────────────────────────────────────
+  let _channelTs    = null;
+  let _channelTimer = null;
+
+  function relativeTime(ts) {
+    const mins = Math.round((Date.now() - ts) / 60000);
+    if (mins < 1)  return "À L'INSTANT";
+    if (mins === 1) return "IL Y A 1 MIN";
+    if (mins < 60) return "IL Y A " + mins + " MIN";
+    return "IL Y A " + Math.floor(mins / 60) + " H";
+  }
+
+  function updateChannelTime() {
+    if (!_channelTs) return;
+    const el = document.getElementById("channel-time");
+    if (el) el.textContent = relativeTime(_channelTs);
+  }
+
+  function showChannel(text) {
+    const el  = document.getElementById("home-channel");
+    const msg = document.getElementById("channel-msg");
+    if (!el || !msg) return;
+    msg.textContent = text.length > 160 ? text.slice(0, 157) + "…" : text;
+    _channelTs = Date.now();
+    updateChannelTime();
+    el.style.display = "";
+    if (_channelTimer) clearInterval(_channelTimer);
+    _channelTimer = setInterval(updateChannelTime, 30000);
+  }
+
+  (async function loadLastMessage() {
+    try {
+      const sessions = await J.api.get("/api/sessions");
+      if (!sessions.length) return;
+      const msgs = await J.api.get("/api/sessions/" + sessions[0].id + "/messages?limit=10");
+      const last = [...msgs].reverse().find(m => m.role === "assistant");
+      if (last && (last.content || last.text)) showChannel(last.content || last.text);
+    } catch (_) {}
+  })();
+
+  // ── Navigation iframe — shell persistant ─────────────────────────
+  const _frame = document.getElementById("page-frame");
+  let _frameActive = false;
+
+  Jarvis.navigateFrame = function (url) {
+    if (!url || url === "/" || url === window.location.origin + "/") {
+      // Retour home — cacher l'iframe
+      if (_frame) {
+        _frame.classList.remove("is-active");
+        _frame.src = "about:blank";
+      }
+      _frameActive = false;
+      history.replaceState(null, "", "/");
+    } else {
+      // Fermer toute vue active (globe, etc.) avant de naviguer
+      Jarvis.views.deactivate();
+      if (_frame) {
+        _frame.src = url;
+        _frame.classList.add("is-active");
+      }
+      _frameActive = true;
+      history.pushState({ frame: url }, "", url);
+    }
+  };
+
+  // Bouton retour navigateur
+  window.addEventListener("popstate", (e) => {
+    if (e.state?.frame) {
+      if (_frame) { _frame.src = e.state.frame; _frame.classList.add("is-active"); }
+      _frameActive = true;
+    } else {
+      if (_frame) { _frame.classList.remove("is-active"); _frame.src = "about:blank"; }
+      _frameActive = false;
+    }
+  });
+
+  // ── Touche espace → dashboard (ou ferme l'iframe si déjà ouvert) ──
+  document.addEventListener("keydown", (e) => {
+    if (e.key === " " && !e.metaKey && !e.ctrlKey) {
+      const active = document.activeElement;
+      if (active && (active.tagName === "INPUT" || active.tagName === "TEXTAREA")) return;
+      e.preventDefault();
+      if (_frameActive) {
+        Jarvis.navigateFrame("/");
+      } else {
+        Jarvis.navigateFrame("/dashboard");
+      }
+    }
+  });
+
+  // ── Helper drag-and-drop pour widgets / overlay ────────────────────
+  function makeDraggable(el, handle) {
+    if (!el) return;
+    const grip = handle || el;
+
+    grip.addEventListener("mousedown", (e) => {
+      if (e.target.closest("button, input, textarea, .hcw-resize-handle")) return;
+      e.preventDefault();
+      let ex = e.clientX, ey = e.clientY;
+      el.classList.add("dragging");
+
+      function onMove(e) {
+        const dx = e.clientX - ex;
+        const dy = e.clientY - ey;
+        ex = e.clientX; ey = e.clientY;
+        const rect = el.getBoundingClientRect();
+        el.style.left   = (rect.left + dx) + "px";
+        el.style.top    = (rect.top  + dy) + "px";
+        el.style.right  = "auto";
+        el.style.bottom = "auto";
+      }
+
+      function onUp() {
+        el.classList.remove("dragging");
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // ── Helper redimensionnement pour widgets ──────────────────────────
+  function makeResizable(el, handleEl, minW, minH) {
+    if (!el || !handleEl) return;
+    minW = minW || 180;
+    minH = minH || 80;
+
+    handleEl.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Ancrer en top/left au moment du resize
+      const rect = el.getBoundingClientRect();
+      el.style.left   = rect.left   + "px";
+      el.style.top    = rect.top    + "px";
+      el.style.right  = "auto";
+      el.style.bottom = "auto";
+      el.style.width  = rect.width  + "px";
+      el.style.height = rect.height + "px";
+
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const startW = rect.width;
+      const startH = rect.height;
+
+      function onMove(e) {
+        const w = Math.max(minW, startW + (e.clientX - startX));
+        const h = Math.max(minH, startH + (e.clientY - startY));
+        el.style.width  = w + "px";
+        el.style.height = h + "px";
+        // Enleve max-height sur le corps messages si present
+        const msgs = el.querySelector(".hcw-messages");
+        if (msgs) msgs.style.maxHeight = "none";
+      }
+
+      function onUp() {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup",   onUp);
+      }
+
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup",   onUp);
+    });
+  }
+
+  // Attacher drag + resize aux widgets
+  makeDraggable(document.getElementById("cam-overlay"), document.getElementById("cam-drag-handle"));
+  makeResizable(document.getElementById("cam-overlay"), document.getElementById("cam-resize-handle"), 180, 120);
+
+  makeDraggable(document.getElementById("hc-widget-music"));
+  makeResizable(document.getElementById("hc-widget-music"), document.getElementById("music-resize-handle"), 180, 100);
+
+  makeDraggable(document.getElementById("hc-widget-chat"));
+  makeResizable(document.getElementById("hc-widget-chat"), document.getElementById("chat-resize-handle"), 220, 160);
+})();

--- a/src/jarvis/interfaces/ui/static/jarvis-color-picker.js
+++ b/src/jarvis/interfaces/ui/static/jarvis-color-picker.js
@@ -1,0 +1,242 @@
+/**
+ * jarvis-color-picker.js — color picker custom pour l'UI Jarvis
+ * Usage :
+ *   const p = new JarvisColorPicker({ value: '#4A9EFF', onChange: hex => ... });
+ *   container.appendChild(p.el);
+ *   p.destroy(); // cleanup
+ */
+(function (global) {
+  'use strict';
+
+  const PRESETS = [
+    '#4A9EFF','#36D399','#B8963E','#E5484D',
+    '#A78BFA','#F59E0B','#FF6B6B','#06080D','#DCE8FF','#ffffff',
+  ];
+
+  function hexToHsv(hex) {
+    let r = parseInt(hex.slice(1,3),16)/255;
+    let g = parseInt(hex.slice(3,5),16)/255;
+    let b = parseInt(hex.slice(5,7),16)/255;
+    const max = Math.max(r,g,b), min = Math.min(r,g,b), d = max - min;
+    let h = 0, s = max === 0 ? 0 : d/max, v = max;
+    if (d !== 0) {
+      if      (max === r) h = ((g-b)/d + (g<b?6:0)) / 6;
+      else if (max === g) h = ((b-r)/d + 2) / 6;
+      else                h = ((r-g)/d + 4) / 6;
+    }
+    return { h: h*360, s, v };
+  }
+
+  function hsvToHex(h, s, v) {
+    h = h / 60;
+    const i = Math.floor(h) % 6;
+    const f = h - Math.floor(h);
+    const p = v*(1-s), q = v*(1-f*s), t = v*(1-(1-f)*s);
+    const sets = [[v,t,p],[q,v,p],[p,v,t],[p,q,v],[t,p,v],[v,p,q]];
+    const [r,g,b] = sets[i];
+    return '#' + [r,g,b].map(x => Math.round(x*255).toString(16).padStart(2,'0')).join('');
+  }
+
+  function clamp(x, a, b) { return Math.max(a, Math.min(b, x)); }
+
+  function JarvisColorPicker(opts) {
+    this._onChange = opts.onChange || function(){};
+    const hsv = hexToHsv(opts.value || '#4A9EFF');
+    this._h = hsv.h; this._s = hsv.s; this._v = hsv.v;
+    this._build();
+    this._drawAll();
+  }
+
+  JarvisColorPicker.prototype._build = function () {
+    const self = this;
+
+    // Conteneur principal
+    const root = document.createElement('div');
+    root.className = 'jcp-root';
+    const closeBtn = document.createElement('button');
+    closeBtn.textContent = '×';
+    closeBtn.style.cssText = 'display:block;margin-left:auto;background:none;border:none;color:var(--fg-2);font-size:0.875rem;cursor:pointer;padding:0 2px 6px;line-height:1;';
+    closeBtn.addEventListener('click', () => self.hide());
+    root.style.position = 'relative';
+    root.appendChild(closeBtn);
+    root.style.cssText = 'display:none; flex-direction:column; gap:10px; padding:12px; background:var(--bg-1); border:0.5px solid var(--line-2); border-radius:10px; margin-top:8px; width:240px;';
+
+    // Canvas spectre SV
+    const specWrap = document.createElement('div');
+    specWrap.style.cssText = 'position:relative; border-radius:6px; overflow:hidden; cursor:crosshair; user-select:none;';
+    const spec = document.createElement('canvas');
+    spec.width = 200; spec.height = 110;
+    spec.style.cssText = 'display:block; width:100%; height:140px;';
+    const specCursor = document.createElement('div');
+    specCursor.style.cssText = 'position:absolute; width:12px; height:12px; border-radius:50%; border:2px solid #fff; box-shadow:0 0 0 1px rgba(0,0,0,0.5); pointer-events:none; transform:translate(-50%,-50%);';
+    specWrap.appendChild(spec);
+    specWrap.appendChild(specCursor);
+
+    // Canvas hue
+    const hueWrap = document.createElement('div');
+    hueWrap.style.cssText = 'position:relative; height:12px;';
+    const hueBar = document.createElement('canvas');
+    hueBar.width = 200; hueBar.height = 10;
+    hueBar.style.cssText = 'display:block; width:100%; height:12px; border-radius:6px; cursor:pointer;';
+    const hueThumb = document.createElement('div');
+    hueThumb.style.cssText = 'position:absolute; top:50%; width:14px; height:14px; border-radius:50%; background:#fff; border:2px solid #fff; box-shadow:0 0 0 1px rgba(0,0,0,0.4); transform:translate(-50%,-50%); pointer-events:none;';
+    hueWrap.appendChild(hueBar);
+    hueWrap.appendChild(hueThumb);
+
+    // Hex row
+    const hexRow = document.createElement('div');
+    hexRow.style.cssText = 'display:flex; align-items:center; gap:8px;';
+    const swatch = document.createElement('div');
+    swatch.style.cssText = 'width:28px; height:28px; border-radius:6px; border:0.5px solid var(--line-2); flex-shrink:0;';
+    const hexInput = document.createElement('input');
+    hexInput.type = 'text';
+    hexInput.maxLength = 7;
+    hexInput.style.cssText = 'flex:1; background:var(--bg-2,#0F141F); border:0.5px solid var(--line-2); border-radius:6px; color:var(--fg-2); font-family:var(--mono); font-size:0.6875rem; padding:5px 8px; letter-spacing:0.08em; outline:none;';
+    hexRow.appendChild(swatch);
+    hexRow.appendChild(hexInput);
+
+    // Presets
+    const presetsEl = document.createElement('div');
+    presetsEl.style.cssText = 'display:flex; flex-wrap:wrap; gap:5px;';
+    PRESETS.forEach(c => {
+      const d = document.createElement('div');
+      d.style.cssText = `width:18px; height:18px; border-radius:4px; background:${c}; border:0.5px solid var(--line-2); cursor:pointer; flex-shrink:0;`;
+      d.addEventListener('click', () => { const hsv = hexToHsv(c); self._h=hsv.h; self._s=hsv.s; self._v=hsv.v; self._drawAll(); self._emit(); });
+      presetsEl.appendChild(d);
+    });
+
+    root.appendChild(specWrap);
+    root.appendChild(hueWrap);
+    root.appendChild(hexRow);
+    root.appendChild(presetsEl);
+
+    // Refs
+    this._root = root;
+    this._spec = spec;
+    this._specCursor = specCursor;
+    this._hueBar = hueBar;
+    this._hueThumb = hueThumb;
+    this._swatch = swatch;
+    this._hexInput = hexInput;
+
+    // Events spectre
+    let draggingSpec = false;
+    const onSpecMove = e => {
+      const r = spec.getBoundingClientRect();
+      const cx = e.touches ? e.touches[0].clientX : e.clientX;
+      const cy = e.touches ? e.touches[0].clientY : e.clientY;
+      self._s = clamp((cx - r.left) / r.width, 0, 1);
+      self._v = clamp(1 - (cy - r.top) / r.height, 0, 1);
+      self._drawAll(); self._emit();
+    };
+    specWrap.addEventListener('mousedown', e => { draggingSpec = true; onSpecMove(e); e.preventDefault(); });
+    specWrap.addEventListener('touchstart', e => { draggingSpec = true; onSpecMove(e); }, { passive: true });
+    document.addEventListener('mousemove', e => { if (draggingSpec) onSpecMove(e); });
+    document.addEventListener('touchmove', e => { if (draggingSpec) onSpecMove(e); }, { passive: true });
+    document.addEventListener('mouseup',  () => { draggingSpec = false; });
+    document.addEventListener('touchend', () => { draggingSpec = false; });
+
+    // Events hue
+    let draggingHue = false;
+    const onHueMove = e => {
+      const r = hueBar.getBoundingClientRect();
+      const cx = e.touches ? e.touches[0].clientX : e.clientX;
+      self._h = clamp((cx - r.left) / r.width, 0, 1) * 360;
+      self._drawAll(); self._emit();
+    };
+    hueBar.addEventListener('mousedown', e => { draggingHue = true; onHueMove(e); e.preventDefault(); });
+    hueBar.addEventListener('touchstart', e => { draggingHue = true; onHueMove(e); }, { passive: true });
+    document.addEventListener('mousemove', e => { if (draggingHue) onHueMove(e); });
+    document.addEventListener('touchmove', e => { if (draggingHue) onHueMove(e); }, { passive: true });
+    document.addEventListener('mouseup',  () => { draggingHue = false; });
+    document.addEventListener('touchend', () => { draggingHue = false; });
+
+    // Hex input
+    hexInput.addEventListener('input', () => {
+      const v = hexInput.value;
+      if (/^#[0-9a-fA-F]{6}$/.test(v)) {
+        const hsv = hexToHsv(v);
+        self._h = hsv.h; self._s = hsv.s; self._v = hsv.v;
+        self._drawSpec(); self._updateUI(); self._emit();
+      }
+    });
+
+    this.el = root;
+  };
+
+  JarvisColorPicker.prototype._drawSpec = function () {
+    const canvas = this._spec;
+    const ctx = canvas.getContext('2d');
+    const W = canvas.width, H = canvas.height;
+    const gW = ctx.createLinearGradient(0, 0, W, 0);
+    gW.addColorStop(0, '#fff');
+    gW.addColorStop(1, `hsl(${this._h}, 100%, 50%)`);
+    ctx.fillStyle = gW;
+    ctx.fillRect(0, 0, W, H);
+    const gB = ctx.createLinearGradient(0, 0, 0, H);
+    gB.addColorStop(0, 'rgba(0,0,0,0)');
+    gB.addColorStop(1, '#000');
+    ctx.fillStyle = gB;
+    ctx.fillRect(0, 0, W, H);
+  };
+
+  JarvisColorPicker.prototype._drawHue = function () {
+    const canvas = this._hueBar;
+    const ctx = canvas.getContext('2d');
+    const g = ctx.createLinearGradient(0, 0, canvas.width, 0);
+    for (let i = 0; i <= 12; i++) g.addColorStop(i/12, `hsl(${i*30}, 100%, 50%)`);
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  };
+
+  JarvisColorPicker.prototype._updateUI = function () {
+    const hex = hsvToHex(this._h, this._s, this._v);
+    this._swatch.style.background = hex;
+    this._hexInput.value = hex;
+    // Cursor position
+    const sw = this._spec.getBoundingClientRect().width || this._spec.width;
+    const sh = this._spec.getBoundingClientRect().height || this._spec.height;
+    this._specCursor.style.left = (this._s * 100) + '%';
+    this._specCursor.style.top  = ((1 - this._v) * 100) + '%';
+    // Hue thumb
+    this._hueThumb.style.left = (this._h / 360 * 100) + '%';
+  };
+
+  JarvisColorPicker.prototype._drawAll = function () {
+    this._drawSpec();
+    this._drawHue();
+    this._updateUI();
+  };
+
+  JarvisColorPicker.prototype._emit = function () {
+    this._onChange(hsvToHex(this._h, this._s, this._v));
+  };
+
+  JarvisColorPicker.prototype.setValue = function (hex) {
+    if (!/^#[0-9a-fA-F]{6}$/.test(hex)) return;
+    const hsv = hexToHsv(hex);
+    this._h = hsv.h; this._s = hsv.s; this._v = hsv.v;
+    this._drawAll();
+  };
+
+  JarvisColorPicker.prototype.show = function () {
+    this._root.style.display = 'flex';
+    this._drawAll(); // redraw au cas où le canvas était caché
+  };
+
+  JarvisColorPicker.prototype.hide = function () {
+    this._root.style.display = 'none';
+  };
+
+  JarvisColorPicker.prototype.toggle = function () {
+    if (this._root.style.display === 'none' || !this._root.style.display) this.show();
+    else this.hide();
+  };
+
+  JarvisColorPicker.prototype.destroy = function () {
+    if (this._root.parentNode) this._root.parentNode.removeChild(this._root);
+  };
+
+  global.JarvisColorPicker = JarvisColorPicker;
+
+})(window);

--- a/src/jarvis/interfaces/ui/static/macropad_2k.css
+++ b/src/jarvis/interfaces/ui/static/macropad_2k.css
@@ -79,18 +79,18 @@
   transition: color .15s, border-color .15s, background .15s;
   font-family: inherit;
 }
-.kp-tab:hover { color: var(--fg-0); background: rgba(74,158,255,0.04); }
+.kp-tab:hover { color: var(--fg-0); background: rgba(var(--c-accent), 0.04); }
 .kp-tab.is-on {
   color: var(--accent);
   border-bottom-color: var(--accent);
-  background: rgba(74,158,255,0.05);
+  background: rgba(var(--c-accent), 0.05);
 }
 .kp-tab svg { width: 14px; height: 14px; }
 
 .kp-page-title {
   font-family: var(--serif);
   font-weight: 400;
-  font-size: 22px;
+  font-size: 1.375rem;
   letter-spacing: -0.02em;
   color: var(--fg-0);
   line-height: 1;
@@ -98,7 +98,7 @@
 .kp-page-subtitle {
   margin-top: 4px;
   color: var(--fg-2);
-  font-size: 12px;
+  font-size: 0.75rem;
   letter-spacing: -0.005em;
   max-width: 64ch;
 }
@@ -163,14 +163,14 @@ body.is-embedded .kp-grid--wide {
 .kp-card-title {
   font-family: var(--serif);
   font-weight: 500;
-  font-size: 15px;
+  font-size: 0.9375rem;
   color: var(--fg-0);
   letter-spacing: -0.01em;
 }
 .kp-card-sub {
   margin-top: 4px;
   color: var(--fg-2);
-  font-size: 12px;
+  font-size: 0.75rem;
   letter-spacing: -0.005em;
   line-height: 1.45;
 }
@@ -178,7 +178,7 @@ body.is-embedded .kp-grid--wide {
 .kp-label {
   display: block;
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 0.625rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--fg-3);
@@ -223,17 +223,17 @@ body.is-embedded .kp-grid--wide {
   color: var(--fg-2);
 }
 .kp-btn--ghost:hover:not(:disabled) {
-  background: rgba(220,232,255,0.04);
+  background: rgba(var(--c-fg), 0.04);
   color: var(--fg-0);
 }
 .kp-btn--danger {
   color: var(--red);
-  border-color: rgba(229,72,77,.30);
+  border-color: rgba(var(--c-red), .30);
   background: var(--red-soft);
 }
 .kp-btn--sm {
   padding: 5px 9px;
-  font-size: 11px;
+  font-size: 0.6875rem;
 }
 .kp-btn-row {
   display: flex;
@@ -256,9 +256,9 @@ body.is-embedded .kp-grid--wide {
 .kp-field:focus {
   outline: none;
   border-color: var(--accent-line);
-  box-shadow: 0 0 0 3px rgba(74,158,255,.12);
+  box-shadow: 0 0 0 3px rgba(var(--c-accent), .12);
 }
-.kp-field--mono { font-family: var(--mono); font-size: 11.5px; }
+.kp-field--mono { font-family: var(--mono); font-size: 0.7188rem; }
 .kp-field-row {
   display: flex;
   gap: 8px;
@@ -304,17 +304,17 @@ select.kp-field {
   display: block;
   margin-top: 4px;
   color: var(--fg-2);
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 1.45;
 }
 
 .kp-slider-row { display: flex; flex-direction: column; gap: 6px; }
 .kp-slider-hd {
   display: flex; justify-content: space-between; align-items: center;
-  font-size: 12.5px; color: var(--fg-1);
+  font-size: 0.7812rem; color: var(--fg-1);
 }
 .kp-slider-hd .num {
-  font-family: var(--mono); font-size: 11px;
+  font-family: var(--mono); font-size: 0.6875rem;
   color: var(--fg-2); font-variant-numeric: tabular-nums;
 }
 .kp-slider {
@@ -368,7 +368,7 @@ select.kp-field {
   background: var(--accent-soft);
   border-color: var(--accent-line);
   color: var(--accent);
-  box-shadow: 0 0 0 1px rgba(74,158,255,.18) inset;
+  box-shadow: 0 0 0 1px rgba(var(--c-accent), .18) inset;
 }
 .kp-chip:disabled { opacity: .35; cursor: not-allowed; }
 
@@ -389,9 +389,9 @@ select.kp-field {
   width: 7px; height: 7px; border-radius: 50%;
   background: var(--fg-3);
 }
-.kp-status-pill.is-connected { color: var(--green); border-color: rgba(54,211,153,.32); background: var(--green-soft); }
+.kp-status-pill.is-connected { color: var(--green); border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
 .kp-status-pill.is-connected .dot { background: var(--green); box-shadow: 0 0 6px var(--green); }
-.kp-status-pill.is-bootloader { color: var(--gold); border-color: rgba(184,150,62,.32); background: var(--gold-soft); }
+.kp-status-pill.is-bootloader { color: var(--gold); border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
 .kp-status-pill.is-bootloader .dot { background: var(--gold); box-shadow: 0 0 6px var(--gold); }
 
 .kp-canvas-wrap {
@@ -436,7 +436,7 @@ select.kp-field {
 .kp-key-card:hover { border-color: var(--line-3); }
 .kp-key-card.is-on {
   border-color: var(--accent-line);
-  background: rgba(74,158,255,0.08);
+  background: rgba(var(--c-accent), 0.08);
   color: var(--fg-0);
   box-shadow: 0 0 0 1px var(--accent-line) inset, 0 0 18px -8px var(--accent);
 }
@@ -451,7 +451,7 @@ select.kp-field {
   margin-top: 6px;
   font-family: var(--serif);
   font-weight: 500;
-  font-size: 16px;
+  font-size: 1rem;
   letter-spacing: -0.01em;
   color: var(--fg-0);
 }
@@ -466,7 +466,7 @@ select.kp-field {
   padding: 22px;
   font-family: var(--serif);
   font-weight: 400;
-  font-size: 36px;
+  font-size: 2.25rem;
   letter-spacing: -0.02em;
   color: var(--fg-0);
 }
@@ -475,7 +475,7 @@ select.kp-field {
   display: flex; flex-wrap: wrap;
   align-items: center; gap: 6px;
   margin-top: 12px;
-  font-size: 11.5px;
+  font-size: 0.7188rem;
   color: var(--fg-3);
 }
 .kp-kbd {
@@ -540,14 +540,14 @@ select.kp-field {
 .kp-step-list li > div p { margin: 0; }
 .kp-step-list li > div p:first-child {
   color: var(--fg-0);
-  font-size: 13px;
+  font-size: 0.8125rem;
   font-weight: 500;
   letter-spacing: -0.005em;
 }
 .kp-step-list li > div p:last-child {
   margin-top: 4px;
   color: var(--fg-2);
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 1.5;
 }
 
@@ -562,11 +562,11 @@ select.kp-field {
   overflow: auto;
   white-space: pre-wrap;
   scrollbar-width: thin;
-  scrollbar-color: rgba(220,232,255,0.10) transparent;
+  scrollbar-color: rgba(var(--c-fg), 0.10) transparent;
   line-height: 1.55;
 }
 .kp-log::-webkit-scrollbar { width: 6px; }
-.kp-log::-webkit-scrollbar-thumb { background: rgba(220,232,255,0.08); border-radius: 3px; }
+.kp-log::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
 .kp-log:empty::after {
   content: attr(data-empty);
   color: var(--fg-3);
@@ -601,7 +601,7 @@ select.kp-field {
   transition: all .15s ease;
 }
 .kp-link-row:hover {
-  background: rgba(220,232,255,0.04);
+  background: rgba(var(--c-fg), 0.04);
   color: var(--fg-0);
 }
 
@@ -644,13 +644,13 @@ select.kp-field {
 .kp-feature .dot--limit { background: var(--fg-3); }
 .kp-feature p {
   margin: 0; color: var(--fg-0);
-  font-size: 12.5px; font-weight: 500;
+  font-size: 0.7812rem; font-weight: 500;
 }
 .kp-feature span {
   display: block;
   margin-top: 4px;
   color: var(--fg-2);
-  font-size: 11.5px;
+  font-size: 0.7188rem;
   line-height: 1.5;
 }
 
@@ -658,14 +658,14 @@ select.kp-field {
   padding: 10px 14px;
   border-radius: 10px;
   margin-bottom: 18px;
-  font-size: 12.5px;
+  font-size: 0.7812rem;
   background: var(--gold-soft);
-  border: 1px solid rgba(184,150,62,.32);
+  border: 1px solid rgba(var(--c-gold), .32);
   color: var(--gold);
 }
 .kp-banner--err {
   background: var(--red-soft);
-  border-color: rgba(229,72,77,.30);
+  border-color: rgba(var(--c-red), .30);
   color: var(--red);
 }
 
@@ -719,7 +719,7 @@ body.is-embedded .kp-root {
   border: none;
   color: var(--fg-3);
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 0.625rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   padding: 5px 10px;
@@ -733,5 +733,5 @@ body.is-embedded .kp-root {
 }
 .kp-emb-tab.is-on {
   color: var(--accent);
-  background: rgba(74, 158, 255, 0.1);
+  background: rgba(var(--c-accent), 0.1);
 }

--- a/src/jarvis/interfaces/ui/static/macropad_2k.css.bak-1782254922
+++ b/src/jarvis/interfaces/ui/static/macropad_2k.css.bak-1782254922
@@ -1,0 +1,737 @@
+/* ─────────────────────────────────────────────────────────────────────
+   Keypad Studio — surface tied to Jarvis V4 design system.
+   Depends on _shared.css (palette, .app, .sidebar, .main, .card, .badge).
+   ───────────────────────────────────────────────────────────────────── */
+
+.kp-root {
+  padding: 14px var(--density-pad) 76px;
+  max-width: 1480px;
+  height: calc(100vh - 52px);
+  max-height: calc(100vh - 52px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.kp-page-wrap {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.kp-page-wrap > * {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.kp-toolbar {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 10px;
+  flex: 0 0 auto;
+}
+.kp-toolbar-spacer { flex: 1; }
+.kp-ws-pill {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 12px;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  background: var(--bg-2);
+  color: var(--fg-1);
+  font: 500 11.5px var(--sans);
+  cursor: pointer;
+  max-width: 360px;
+  transition: all .15s ease;
+}
+.kp-ws-pill:hover { border-color: var(--line-3); color: var(--fg-0); }
+.kp-ws-pill .ico { width: 13px; height: 13px; flex-shrink: 0; opacity: .7; }
+.kp-ws-pill .label { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 22ch; }
+
+.kp-tabs {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 22px;
+  border-bottom: 1px solid var(--line-1);
+  flex-wrap: wrap;
+}
+.kp-tab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  color: var(--fg-2);
+  font: 500 11.5px var(--mono);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 10px 14px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: color .15s, border-color .15s, background .15s;
+  font-family: inherit;
+}
+.kp-tab:hover { color: var(--fg-0); background: rgba(74,158,255,0.04); }
+.kp-tab.is-on {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  background: rgba(74,158,255,0.05);
+}
+.kp-tab svg { width: 14px; height: 14px; }
+
+.kp-page-title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 22px;
+  letter-spacing: -0.02em;
+  color: var(--fg-0);
+  line-height: 1;
+}
+.kp-page-subtitle {
+  margin-top: 4px;
+  color: var(--fg-2);
+  font-size: 12px;
+  letter-spacing: -0.005em;
+  max-width: 64ch;
+}
+.kp-page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+  flex: 0 0 auto;
+}
+.kp-page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.kp-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: 12px;
+  flex: 1 1 auto;
+  min-height: 0;
+  align-content: start;
+}
+.kp-grid--equal {
+  grid-template-columns: 1fr 1fr;
+}
+.kp-grid--wide {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+}
+@media (max-width: 980px) {
+  .kp-grid, .kp-grid--equal, .kp-grid--wide { grid-template-columns: 1fr; }
+}
+body.is-embedded .kp-grid,
+body.is-embedded .kp-grid--equal,
+body.is-embedded .kp-grid--wide {
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+}
+@media (max-width: 640px) {
+  body.is-embedded .kp-grid,
+  body.is-embedded .kp-grid--equal,
+  body.is-embedded .kp-grid--wide { grid-template-columns: 1fr; }
+}
+
+.kp-card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 12px;
+  padding: 14px;
+  min-height: 0;
+  overflow: hidden;
+}
+.kp-card-hd {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+  flex: 0 0 auto;
+}
+.kp-card-title {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 15px;
+  color: var(--fg-0);
+  letter-spacing: -0.01em;
+}
+.kp-card-sub {
+  margin-top: 4px;
+  color: var(--fg-2);
+  font-size: 12px;
+  letter-spacing: -0.005em;
+  line-height: 1.45;
+}
+
+.kp-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  margin-bottom: 8px;
+}
+
+.kp-btn {
+  appearance: none;
+  border: 1px solid var(--line-2);
+  background: var(--bg-2);
+  color: var(--fg-1);
+  padding: 7px 12px;
+  border-radius: 8px;
+  font: 500 11.5px var(--sans);
+  letter-spacing: 0.005em;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: all .15s ease;
+  font-family: inherit;
+}
+.kp-btn:hover:not(:disabled) {
+  background: var(--bg-3);
+  border-color: var(--line-3);
+  color: var(--fg-0);
+}
+.kp-btn:disabled { opacity: .4; cursor: not-allowed; }
+.kp-btn--primary {
+  background: var(--accent);
+  border-color: transparent;
+  color: #001127;
+  font-weight: 600;
+}
+.kp-btn--primary:hover:not(:disabled) {
+  background: #6BB0FF;
+  color: #001127;
+}
+.kp-btn--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--fg-2);
+}
+.kp-btn--ghost:hover:not(:disabled) {
+  background: rgba(220,232,255,0.04);
+  color: var(--fg-0);
+}
+.kp-btn--danger {
+  color: var(--red);
+  border-color: rgba(229,72,77,.30);
+  background: var(--red-soft);
+}
+.kp-btn--sm {
+  padding: 5px 9px;
+  font-size: 11px;
+}
+.kp-btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.kp-field {
+  appearance: none;
+  width: 100%;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: var(--fg-0);
+  font: 12px var(--sans);
+  font-family: inherit;
+  transition: border-color .15s, box-shadow .15s;
+}
+.kp-field:focus {
+  outline: none;
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px rgba(74,158,255,.12);
+}
+.kp-field--mono { font-family: var(--mono); font-size: 11.5px; }
+.kp-field-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+select.kp-field {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+  cursor: pointer;
+}
+
+.kp-color {
+  width: 44px; height: 30px;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  overflow: hidden;
+}
+.kp-color::-webkit-color-swatch-wrapper { padding: 0; }
+.kp-color::-webkit-color-swatch { border: 0; border-radius: 6px; }
+.kp-color::-moz-color-swatch { border: 0; border-radius: 6px; }
+
+.kp-toggle-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 4px 0;
+  cursor: pointer;
+}
+.kp-toggle-row .kp-toggle-text { flex: 1; }
+.kp-toggle-row strong {
+  display: block;
+  color: var(--fg-0);
+  font: 500 13px var(--sans);
+  font-family: inherit;
+}
+.kp-toggle-row span.help {
+  display: block;
+  margin-top: 4px;
+  color: var(--fg-2);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.kp-slider-row { display: flex; flex-direction: column; gap: 6px; }
+.kp-slider-hd {
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 12.5px; color: var(--fg-1);
+}
+.kp-slider-hd .num {
+  font-family: var(--mono); font-size: 11px;
+  color: var(--fg-2); font-variant-numeric: tabular-nums;
+}
+.kp-slider {
+  appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--bg-3);
+  outline: none;
+  border: 0;
+}
+.kp-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  box-shadow: 0 0 8px var(--accent-soft);
+  border: 2px solid var(--bg-0);
+}
+.kp-slider::-moz-range-thumb {
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  border: 2px solid var(--bg-0);
+}
+
+.kp-chip-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 6px;
+}
+.kp-chip {
+  appearance: none;
+  border: 1px solid var(--line-2);
+  background: var(--bg-2);
+  color: var(--fg-2);
+  font: 500 11.5px var(--sans);
+  font-family: inherit;
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all .15s ease;
+}
+.kp-chip:hover:not(.is-on):not(:disabled) {
+  border-color: var(--line-3);
+  color: var(--fg-0);
+}
+.kp-chip.is-on {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+  color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(74,158,255,.18) inset;
+}
+.kp-chip:disabled { opacity: .35; cursor: not-allowed; }
+
+.kp-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line-2);
+  background: var(--bg-2);
+  color: var(--fg-2);
+  font: 500 10.5px var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.kp-status-pill .dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--fg-3);
+}
+.kp-status-pill.is-connected { color: var(--green); border-color: rgba(54,211,153,.32); background: var(--green-soft); }
+.kp-status-pill.is-connected .dot { background: var(--green); box-shadow: 0 0 6px var(--green); }
+.kp-status-pill.is-bootloader { color: var(--gold); border-color: rgba(184,150,62,.32); background: var(--gold-soft); }
+.kp-status-pill.is-bootloader .dot { background: var(--gold); box-shadow: 0 0 6px var(--gold); }
+
+.kp-canvas-wrap {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+.kp-canvas {
+  position: relative;
+  width: 100%;
+  max-width: 38rem;
+  aspect-ratio: 64.408 / 56.886;
+  max-height: 320px;
+}
+.kp-canvas svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.kp-key-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-top: 16px;
+}
+.kp-key-card {
+  appearance: none;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  padding: 12px 14px;
+  text-align: left;
+  cursor: pointer;
+  color: var(--fg-1);
+  font-family: inherit;
+  transition: all .15s ease;
+}
+.kp-key-card:hover { border-color: var(--line-3); }
+.kp-key-card.is-on {
+  border-color: var(--accent-line);
+  background: rgba(74,158,255,0.08);
+  color: var(--fg-0);
+  box-shadow: 0 0 0 1px var(--accent-line) inset, 0 0 18px -8px var(--accent);
+}
+.kp-key-card .lbl {
+  font: 500 9.5px var(--mono);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.kp-key-card .val {
+  display: block;
+  margin-top: 6px;
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 16px;
+  letter-spacing: -0.01em;
+  color: var(--fg-0);
+}
+
+.kp-key-pill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  padding: 22px;
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 36px;
+  letter-spacing: -0.02em;
+  color: var(--fg-0);
+}
+
+.kp-kbd-line {
+  display: flex; flex-wrap: wrap;
+  align-items: center; gap: 6px;
+  margin-top: 12px;
+  font-size: 11.5px;
+  color: var(--fg-3);
+}
+.kp-kbd {
+  display: inline-flex; align-items: center;
+  font: 500 10px var(--mono);
+  letter-spacing: 0.06em;
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  padding: 3px 7px;
+  color: var(--fg-2);
+  background: var(--bg-2);
+}
+
+.kp-stack { display: flex; flex-direction: column; gap: 16px; }
+.kp-stack--tight { gap: 10px; }
+.kp-row { display: flex; align-items: center; gap: 10px; }
+.kp-row--justify { justify-content: space-between; }
+
+.kp-sub-tabs {
+  display: inline-flex;
+  gap: 2px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  padding: 3px;
+  border-radius: 8px;
+}
+.kp-sub-tab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--fg-2);
+  font: 500 11px var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all .15s ease;
+}
+.kp-sub-tab:hover { color: var(--fg-0); }
+.kp-sub-tab.is-on {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.kp-fade-in { animation: kpFade .18s ease both; }
+@keyframes kpFade { from { opacity: 0; transform: translateY(2px); } to { opacity: 1; transform: none; } }
+
+.kp-step-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 14px; }
+.kp-step-list li { display: flex; gap: 12px; align-items: flex-start; }
+.kp-step-num {
+  flex-shrink: 0;
+  width: 28px; height: 28px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  font: 500 11px var(--mono);
+  color: var(--fg-1);
+}
+.kp-step-list li > div p { margin: 0; }
+.kp-step-list li > div p:first-child {
+  color: var(--fg-0);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+.kp-step-list li > div p:last-child {
+  margin-top: 4px;
+  color: var(--fg-2);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.kp-log {
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  padding: 12px 14px;
+  font: 11px var(--mono);
+  color: var(--fg-1);
+  height: 320px;
+  overflow: auto;
+  white-space: pre-wrap;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(220,232,255,0.10) transparent;
+  line-height: 1.55;
+}
+.kp-log::-webkit-scrollbar { width: 6px; }
+.kp-log::-webkit-scrollbar-thumb { background: rgba(220,232,255,0.08); border-radius: 3px; }
+.kp-log:empty::after {
+  content: attr(data-empty);
+  color: var(--fg-3);
+  font-style: italic;
+}
+
+.kp-list-divided {
+  list-style: none; padding: 0; margin: 0;
+}
+.kp-list-divided > li {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 12px 0;
+  border-top: 1px solid var(--line-1);
+}
+.kp-list-divided > li:first-child { border-top: 0; }
+
+.kp-link-row {
+  appearance: none;
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  color: var(--fg-1);
+  font: 13px var(--sans);
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all .15s ease;
+}
+.kp-link-row:hover {
+  background: rgba(220,232,255,0.04);
+  color: var(--fg-0);
+}
+
+.kp-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 14px;
+}
+.kp-info-cell {
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.kp-info-cell .kp-label { margin: 0 0 4px; }
+.kp-info-cell .val {
+  font: 500 13px var(--mono);
+  color: var(--fg-0);
+}
+
+.kp-feature-grid {
+  list-style: none; padding: 0; margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.kp-feature {
+  display: flex; gap: 10px; align-items: flex-start;
+  padding: 10px 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+}
+.kp-feature .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0; margin-top: 6px;
+}
+.kp-feature .dot--ok { background: var(--green); box-shadow: 0 0 6px var(--green); }
+.kp-feature .dot--limit { background: var(--fg-3); }
+.kp-feature p {
+  margin: 0; color: var(--fg-0);
+  font-size: 12.5px; font-weight: 500;
+}
+.kp-feature span {
+  display: block;
+  margin-top: 4px;
+  color: var(--fg-2);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+
+.kp-banner {
+  padding: 10px 14px;
+  border-radius: 10px;
+  margin-bottom: 18px;
+  font-size: 12.5px;
+  background: var(--gold-soft);
+  border: 1px solid rgba(184,150,62,.32);
+  color: var(--gold);
+}
+.kp-banner--err {
+  background: var(--red-soft);
+  border-color: rgba(229,72,77,.30);
+  color: var(--red);
+}
+
+.kp-empty-pane {
+  height: 130px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  color: var(--fg-3);
+  font: 12px var(--mono);
+  letter-spacing: 0.08em;
+}
+
+/* ── Mode drawer (embedded) ─────────────────────────────────────── */
+body.is-embedded #sidebar {
+  display: none;
+}
+body.is-embedded .topbar {
+  display: none;
+}
+body.is-embedded .app {
+  grid-template-columns: 1fr;
+  grid-template-rows: 100vh;
+}
+body.is-embedded .main {
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+body.is-embedded .kp-root {
+  flex: 1;
+  min-height: 0;
+  height: auto;
+  max-height: none;
+}
+
+.kp-emb-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 var(--density-pad) 6px;
+  border-bottom: 1px solid var(--line-1);
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+}
+.kp-emb-tab {
+  background: none;
+  border: none;
+  color: var(--fg-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s;
+}
+.kp-emb-tab:hover {
+  color: var(--fg-0);
+  background: var(--bg-2);
+}
+.kp-emb-tab.is-on {
+  color: var(--accent);
+  background: rgba(74, 158, 255, 0.1);
+}

--- a/src/jarvis/interfaces/ui/static/macropad_2k.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/macropad_2k.css.bak-1782259625
@@ -1,0 +1,737 @@
+/* ─────────────────────────────────────────────────────────────────────
+   Keypad Studio — surface tied to Jarvis V4 design system.
+   Depends on _shared.css (palette, .app, .sidebar, .main, .card, .badge).
+   ───────────────────────────────────────────────────────────────────── */
+
+.kp-root {
+  padding: 14px var(--density-pad) 76px;
+  max-width: 1480px;
+  height: calc(100vh - 52px);
+  max-height: calc(100vh - 52px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.kp-page-wrap {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.kp-page-wrap > * {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.kp-toolbar {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 10px;
+  flex: 0 0 auto;
+}
+.kp-toolbar-spacer { flex: 1; }
+.kp-ws-pill {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 12px;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  background: var(--bg-2);
+  color: var(--fg-1);
+  font: 500 11.5px var(--sans);
+  cursor: pointer;
+  max-width: 360px;
+  transition: all .15s ease;
+}
+.kp-ws-pill:hover { border-color: var(--line-3); color: var(--fg-0); }
+.kp-ws-pill .ico { width: 13px; height: 13px; flex-shrink: 0; opacity: .7; }
+.kp-ws-pill .label { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 22ch; }
+
+.kp-tabs {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 22px;
+  border-bottom: 1px solid var(--line-1);
+  flex-wrap: wrap;
+}
+.kp-tab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  color: var(--fg-2);
+  font: 500 11.5px var(--mono);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  padding: 10px 14px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: color .15s, border-color .15s, background .15s;
+  font-family: inherit;
+}
+.kp-tab:hover { color: var(--fg-0); background: rgba(var(--c-accent), 0.04); }
+.kp-tab.is-on {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  background: rgba(var(--c-accent), 0.05);
+}
+.kp-tab svg { width: 14px; height: 14px; }
+
+.kp-page-title {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 22px;
+  letter-spacing: -0.02em;
+  color: var(--fg-0);
+  line-height: 1;
+}
+.kp-page-subtitle {
+  margin-top: 4px;
+  color: var(--fg-2);
+  font-size: 12px;
+  letter-spacing: -0.005em;
+  max-width: 64ch;
+}
+.kp-page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 12px;
+  flex: 0 0 auto;
+}
+.kp-page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.kp-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: 12px;
+  flex: 1 1 auto;
+  min-height: 0;
+  align-content: start;
+}
+.kp-grid--equal {
+  grid-template-columns: 1fr 1fr;
+}
+.kp-grid--wide {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+}
+@media (max-width: 980px) {
+  .kp-grid, .kp-grid--equal, .kp-grid--wide { grid-template-columns: 1fr; }
+}
+body.is-embedded .kp-grid,
+body.is-embedded .kp-grid--equal,
+body.is-embedded .kp-grid--wide {
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+}
+@media (max-width: 640px) {
+  body.is-embedded .kp-grid,
+  body.is-embedded .kp-grid--equal,
+  body.is-embedded .kp-grid--wide { grid-template-columns: 1fr; }
+}
+
+.kp-card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 12px;
+  padding: 14px;
+  min-height: 0;
+  overflow: hidden;
+}
+.kp-card-hd {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+  flex: 0 0 auto;
+}
+.kp-card-title {
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 15px;
+  color: var(--fg-0);
+  letter-spacing: -0.01em;
+}
+.kp-card-sub {
+  margin-top: 4px;
+  color: var(--fg-2);
+  font-size: 12px;
+  letter-spacing: -0.005em;
+  line-height: 1.45;
+}
+
+.kp-label {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+  margin-bottom: 8px;
+}
+
+.kp-btn {
+  appearance: none;
+  border: 1px solid var(--line-2);
+  background: var(--bg-2);
+  color: var(--fg-1);
+  padding: 7px 12px;
+  border-radius: 8px;
+  font: 500 11.5px var(--sans);
+  letter-spacing: 0.005em;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: all .15s ease;
+  font-family: inherit;
+}
+.kp-btn:hover:not(:disabled) {
+  background: var(--bg-3);
+  border-color: var(--line-3);
+  color: var(--fg-0);
+}
+.kp-btn:disabled { opacity: .4; cursor: not-allowed; }
+.kp-btn--primary {
+  background: var(--accent);
+  border-color: transparent;
+  color: #001127;
+  font-weight: 600;
+}
+.kp-btn--primary:hover:not(:disabled) {
+  background: #6BB0FF;
+  color: #001127;
+}
+.kp-btn--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--fg-2);
+}
+.kp-btn--ghost:hover:not(:disabled) {
+  background: rgba(var(--c-fg), 0.04);
+  color: var(--fg-0);
+}
+.kp-btn--danger {
+  color: var(--red);
+  border-color: rgba(var(--c-red), .30);
+  background: var(--red-soft);
+}
+.kp-btn--sm {
+  padding: 5px 9px;
+  font-size: 11px;
+}
+.kp-btn-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.kp-field {
+  appearance: none;
+  width: 100%;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: var(--fg-0);
+  font: 12px var(--sans);
+  font-family: inherit;
+  transition: border-color .15s, box-shadow .15s;
+}
+.kp-field:focus {
+  outline: none;
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px rgba(var(--c-accent), .12);
+}
+.kp-field--mono { font-family: var(--mono); font-size: 11.5px; }
+.kp-field-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+select.kp-field {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6' fill='none'><path d='M1 1L5 5L9 1' stroke='%23DCE8FF' stroke-opacity='.5' stroke-width='1.2'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 28px;
+  cursor: pointer;
+}
+
+.kp-color {
+  width: 44px; height: 30px;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+  overflow: hidden;
+}
+.kp-color::-webkit-color-swatch-wrapper { padding: 0; }
+.kp-color::-webkit-color-swatch { border: 0; border-radius: 6px; }
+.kp-color::-moz-color-swatch { border: 0; border-radius: 6px; }
+
+.kp-toggle-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 4px 0;
+  cursor: pointer;
+}
+.kp-toggle-row .kp-toggle-text { flex: 1; }
+.kp-toggle-row strong {
+  display: block;
+  color: var(--fg-0);
+  font: 500 13px var(--sans);
+  font-family: inherit;
+}
+.kp-toggle-row span.help {
+  display: block;
+  margin-top: 4px;
+  color: var(--fg-2);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.kp-slider-row { display: flex; flex-direction: column; gap: 6px; }
+.kp-slider-hd {
+  display: flex; justify-content: space-between; align-items: center;
+  font-size: 12.5px; color: var(--fg-1);
+}
+.kp-slider-hd .num {
+  font-family: var(--mono); font-size: 11px;
+  color: var(--fg-2); font-variant-numeric: tabular-nums;
+}
+.kp-slider {
+  appearance: none;
+  width: 100%;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--bg-3);
+  outline: none;
+  border: 0;
+}
+.kp-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  box-shadow: 0 0 8px var(--accent-soft);
+  border: 2px solid var(--bg-0);
+}
+.kp-slider::-moz-range-thumb {
+  width: 14px; height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  cursor: pointer;
+  border: 2px solid var(--bg-0);
+}
+
+.kp-chip-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 6px;
+}
+.kp-chip {
+  appearance: none;
+  border: 1px solid var(--line-2);
+  background: var(--bg-2);
+  color: var(--fg-2);
+  font: 500 11.5px var(--sans);
+  font-family: inherit;
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all .15s ease;
+}
+.kp-chip:hover:not(.is-on):not(:disabled) {
+  border-color: var(--line-3);
+  color: var(--fg-0);
+}
+.kp-chip.is-on {
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+  color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(var(--c-accent), .18) inset;
+}
+.kp-chip:disabled { opacity: .35; cursor: not-allowed; }
+
+.kp-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line-2);
+  background: var(--bg-2);
+  color: var(--fg-2);
+  font: 500 10.5px var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.kp-status-pill .dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--fg-3);
+}
+.kp-status-pill.is-connected { color: var(--green); border-color: rgba(var(--c-green), .32); background: var(--green-soft); }
+.kp-status-pill.is-connected .dot { background: var(--green); box-shadow: 0 0 6px var(--green); }
+.kp-status-pill.is-bootloader { color: var(--gold); border-color: rgba(var(--c-gold), .32); background: var(--gold-soft); }
+.kp-status-pill.is-bootloader .dot { background: var(--gold); box-shadow: 0 0 6px var(--gold); }
+
+.kp-canvas-wrap {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+.kp-canvas {
+  position: relative;
+  width: 100%;
+  max-width: 38rem;
+  aspect-ratio: 64.408 / 56.886;
+  max-height: 320px;
+}
+.kp-canvas svg {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.kp-key-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-top: 16px;
+}
+.kp-key-card {
+  appearance: none;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  padding: 12px 14px;
+  text-align: left;
+  cursor: pointer;
+  color: var(--fg-1);
+  font-family: inherit;
+  transition: all .15s ease;
+}
+.kp-key-card:hover { border-color: var(--line-3); }
+.kp-key-card.is-on {
+  border-color: var(--accent-line);
+  background: rgba(var(--c-accent), 0.08);
+  color: var(--fg-0);
+  box-shadow: 0 0 0 1px var(--accent-line) inset, 0 0 18px -8px var(--accent);
+}
+.kp-key-card .lbl {
+  font: 500 9.5px var(--mono);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.kp-key-card .val {
+  display: block;
+  margin-top: 6px;
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 16px;
+  letter-spacing: -0.01em;
+  color: var(--fg-0);
+}
+
+.kp-key-pill {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  padding: 22px;
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 36px;
+  letter-spacing: -0.02em;
+  color: var(--fg-0);
+}
+
+.kp-kbd-line {
+  display: flex; flex-wrap: wrap;
+  align-items: center; gap: 6px;
+  margin-top: 12px;
+  font-size: 11.5px;
+  color: var(--fg-3);
+}
+.kp-kbd {
+  display: inline-flex; align-items: center;
+  font: 500 10px var(--mono);
+  letter-spacing: 0.06em;
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+  padding: 3px 7px;
+  color: var(--fg-2);
+  background: var(--bg-2);
+}
+
+.kp-stack { display: flex; flex-direction: column; gap: 16px; }
+.kp-stack--tight { gap: 10px; }
+.kp-row { display: flex; align-items: center; gap: 10px; }
+.kp-row--justify { justify-content: space-between; }
+
+.kp-sub-tabs {
+  display: inline-flex;
+  gap: 2px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  padding: 3px;
+  border-radius: 8px;
+}
+.kp-sub-tab {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--fg-2);
+  font: 500 11px var(--mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all .15s ease;
+}
+.kp-sub-tab:hover { color: var(--fg-0); }
+.kp-sub-tab.is-on {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.kp-fade-in { animation: kpFade .18s ease both; }
+@keyframes kpFade { from { opacity: 0; transform: translateY(2px); } to { opacity: 1; transform: none; } }
+
+.kp-step-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 14px; }
+.kp-step-list li { display: flex; gap: 12px; align-items: flex-start; }
+.kp-step-num {
+  flex-shrink: 0;
+  width: 28px; height: 28px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  font: 500 11px var(--mono);
+  color: var(--fg-1);
+}
+.kp-step-list li > div p { margin: 0; }
+.kp-step-list li > div p:first-child {
+  color: var(--fg-0);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+.kp-step-list li > div p:last-child {
+  margin-top: 4px;
+  color: var(--fg-2);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.kp-log {
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  padding: 12px 14px;
+  font: 11px var(--mono);
+  color: var(--fg-1);
+  height: 320px;
+  overflow: auto;
+  white-space: pre-wrap;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.10) transparent;
+  line-height: 1.55;
+}
+.kp-log::-webkit-scrollbar { width: 6px; }
+.kp-log::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+.kp-log:empty::after {
+  content: attr(data-empty);
+  color: var(--fg-3);
+  font-style: italic;
+}
+
+.kp-list-divided {
+  list-style: none; padding: 0; margin: 0;
+}
+.kp-list-divided > li {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 12px 0;
+  border-top: 1px solid var(--line-1);
+}
+.kp-list-divided > li:first-child { border-top: 0; }
+
+.kp-link-row {
+  appearance: none;
+  display: block;
+  width: 100%;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  color: var(--fg-1);
+  font: 13px var(--sans);
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all .15s ease;
+}
+.kp-link-row:hover {
+  background: rgba(var(--c-fg), 0.04);
+  color: var(--fg-0);
+}
+
+.kp-info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 14px;
+}
+.kp-info-cell {
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.kp-info-cell .kp-label { margin: 0 0 4px; }
+.kp-info-cell .val {
+  font: 500 13px var(--mono);
+  color: var(--fg-0);
+}
+
+.kp-feature-grid {
+  list-style: none; padding: 0; margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+.kp-feature {
+  display: flex; gap: 10px; align-items: flex-start;
+  padding: 10px 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+}
+.kp-feature .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  flex-shrink: 0; margin-top: 6px;
+}
+.kp-feature .dot--ok { background: var(--green); box-shadow: 0 0 6px var(--green); }
+.kp-feature .dot--limit { background: var(--fg-3); }
+.kp-feature p {
+  margin: 0; color: var(--fg-0);
+  font-size: 12.5px; font-weight: 500;
+}
+.kp-feature span {
+  display: block;
+  margin-top: 4px;
+  color: var(--fg-2);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+
+.kp-banner {
+  padding: 10px 14px;
+  border-radius: 10px;
+  margin-bottom: 18px;
+  font-size: 12.5px;
+  background: var(--gold-soft);
+  border: 1px solid rgba(var(--c-gold), .32);
+  color: var(--gold);
+}
+.kp-banner--err {
+  background: var(--red-soft);
+  border-color: rgba(var(--c-red), .30);
+  color: var(--red);
+}
+
+.kp-empty-pane {
+  height: 130px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  color: var(--fg-3);
+  font: 12px var(--mono);
+  letter-spacing: 0.08em;
+}
+
+/* ── Mode drawer (embedded) ─────────────────────────────────────── */
+body.is-embedded #sidebar {
+  display: none;
+}
+body.is-embedded .topbar {
+  display: none;
+}
+body.is-embedded .app {
+  grid-template-columns: 1fr;
+  grid-template-rows: 100vh;
+}
+body.is-embedded .main {
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+body.is-embedded .kp-root {
+  flex: 1;
+  min-height: 0;
+  height: auto;
+  max-height: none;
+}
+
+.kp-emb-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 0 var(--density-pad) 6px;
+  border-bottom: 1px solid var(--line-1);
+  flex: 0 0 auto;
+  flex-wrap: wrap;
+}
+.kp-emb-tab {
+  background: none;
+  border: none;
+  color: var(--fg-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s;
+}
+.kp-emb-tab:hover {
+  color: var(--fg-0);
+  background: var(--bg-2);
+}
+.kp-emb-tab.is-on {
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.1);
+}

--- a/src/jarvis/interfaces/ui/static/macropad_2k.html
+++ b/src/jarvis/interfaces/ui/static/macropad_2k.html
@@ -8,6 +8,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
 <link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
 <link rel="stylesheet" href="/macropad_2k.css" />
 </head>
 <body>
@@ -19,6 +20,7 @@
   </main>
 </div>
 <script src="/_shared.js"></script>
+<script src="/mission_control.js"></script>
 <script src="/macropad_2k.js"></script>
 </body>
 </html>

--- a/src/jarvis/interfaces/ui/static/macropad_2k.html.bak-1782249020
+++ b/src/jarvis/interfaces/ui/static/macropad_2k.html.bak-1782249020
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Macropad 2 touches Le Labo</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/macropad_2k.css" />
+</head>
+<body>
+<div class="app">
+  <aside id="sidebar"></aside>
+  <main class="main">
+    <header id="topbar"></header>
+    <div id="page-root" class="kp-root"></div>
+  </main>
+</div>
+<script src="/_shared.js"></script>
+<script src="/macropad_2k.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/mc.css
+++ b/src/jarvis/interfaces/ui/static/mc.css
@@ -1,0 +1,217 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mc.css — page Mission Control (/mc)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Reset page ──────────────────────────────────────────────────────── */
+
+body[data-mode="mc"] {
+  margin: 0; padding: 0;
+  background: var(--bg-0);
+  height: 100vh; overflow: hidden;
+  display: flex; flex-direction: column;
+}
+
+/* ── Topbar sticky ───────────────────────────────────────────────────── */
+
+.mc-topbar {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--bg-0);
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+}
+
+.mc-topbar-inner {
+  display: flex; align-items: center; justify-content: center; gap: 0;
+  height: 52px; padding: 0 24px;
+  position: relative;
+}
+
+/* Logo / retour home */
+.mc-brand {
+  display: flex; align-items: center; gap: 12px;
+  color: var(--accent); text-decoration: none;
+  font-family: var(--mono); font-size: 1rem;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  position: absolute; left: 24px;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+.mc-brand:hover { color: var(--accent); }
+.mc-brand svg { font-size: 0; flex-shrink: 0; }
+
+/* Nav onglets */
+.mc-nav {
+  display: flex; align-items: stretch;
+  height: 100%;
+}
+
+.mc-nav-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.10em; text-transform: uppercase; font-size: 1rem;
+  padding: 0 20px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px; /* aligne sur le border-bottom du topbar */
+}
+.mc-nav-btn:hover { color: var(--fg-1); }
+.mc-nav-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Fin de topbar (logs badge, etc.) */
+.mc-topbar-end {
+  display: flex; align-items: center; gap: 8px;
+  position: absolute; right: 24px;
+}
+
+.mc-logs-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-3);
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 5px 12px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.mc-logs-btn:hover { color: var(--fg-0); border-color: var(--line-3); }
+.mc-logs-btn.is-active { color: var(--accent); border-color: var(--accent-line); }
+
+/* ── Zone principale ─────────────────────────────────────────────────── */
+
+.mc-main {
+  flex: 1; overflow: hidden;
+  position: relative;
+  display: flex; flex-direction: column;
+}
+
+/* Iframe pleine hauteur */
+.mc-iframe {
+  width: 100%; height: 100%;
+  border: none; display: block;
+  background: transparent;
+}
+.mc-iframe.is-hidden { display: none; }
+
+/* Panneau Interface */
+.mc-panel-interface {
+  flex: 1; overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+  padding: 40px 24px;
+  display: flex; flex-direction: column; align-items: center;
+}
+
+.mc-panel-interface > * {
+  width: 100%; max-width: 600px;
+}
+
+/* ── Panneau Interface : styles internes ─────────────────────────────── */
+
+.mci-section {
+  display: flex; flex-direction: column; gap: 16px;
+  padding-bottom: 32px; margin-bottom: 32px;
+  border-bottom: 0.5px solid var(--line-1);
+  max-width: 560px;
+}
+.mci-section:last-child { border-bottom: none; }
+
+.mci-section-label {
+  font-family: var(--mono); font-size: 0.5625rem;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-4); margin-bottom: 4px;
+}
+
+.mci-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 34px;
+}
+.mci-row--toggle {
+  flex-direction: column; align-items: flex-start; gap: 10px;
+}
+
+.mci-label {
+  font-family: var(--sans); font-size: 0.7812rem; color: var(--fg-2);
+  min-width: 140px; flex-shrink: 0;
+}
+.mci-sublabel {
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.mci-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.mci-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.mci-color-input {
+  width: 36px; height: 28px;
+  border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  cursor: pointer; padding: 2px; background: var(--bg-2);
+}
+.mci-color-hex {
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.mci-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.mci-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent); cursor: pointer;
+}
+.mci-range-val {
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3);
+  min-width: 40px; text-align: right;
+}
+
+/* Boutons */
+.mci-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.08em;
+  padding: 8px 18px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.mci-btn:hover { color: var(--fg-0); border-color: var(--line-3); background: var(--bg-3); }
+.mci-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.mci-actions { gap: 10px; flex-wrap: wrap; }
+.mci-file-input { display: none; }
+
+/* Toggle switch */
+.mci-toggle {
+  background: none; border: none; padding: 0; cursor: pointer; flex-shrink: 0;
+}
+.mci-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+.mci-toggle.is-on .mci-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.mci-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.mci-toggle.is-on .mci-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── État vide (aucun onglet actif) ──────────────────────────────────── */
+
+.mc-empty {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 12px;
+  color: var(--fg-4);
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.16em; text-transform: uppercase;
+}

--- a/src/jarvis/interfaces/ui/static/mc.css.bak-1782255122
+++ b/src/jarvis/interfaces/ui/static/mc.css.bak-1782255122
@@ -1,0 +1,212 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mc.css — page Mission Control (/mc)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Reset page ──────────────────────────────────────────────────────── */
+
+body[data-mode="mc"] {
+  margin: 0; padding: 0;
+  background: var(--bg-0);
+  height: 100vh; overflow: hidden;
+  display: flex; flex-direction: column;
+}
+
+/* ── Topbar sticky ───────────────────────────────────────────────────── */
+
+.mc-topbar {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--bg-0);
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+}
+
+.mc-topbar-inner {
+  display: flex; align-items: center; gap: 0;
+  height: 52px; padding: 0 24px;
+}
+
+/* Logo / retour home */
+.mc-brand {
+  display: flex; align-items: center; gap: 8px;
+  color: var(--fg-3); text-decoration: none;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.22em; text-transform: uppercase;
+  padding-right: 28px;
+  border-right: 0.5px solid var(--line-1);
+  margin-right: 4px;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+.mc-brand:hover { color: var(--accent); }
+
+/* Nav onglets */
+.mc-nav {
+  display: flex; align-items: stretch;
+  height: 100%; flex: 1;
+}
+
+.mc-nav-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 0 20px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px; /* aligne sur le border-bottom du topbar */
+}
+.mc-nav-btn:hover { color: var(--fg-1); }
+.mc-nav-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Fin de topbar (logs badge, etc.) */
+.mc-topbar-end {
+  display: flex; align-items: center; gap: 8px;
+  margin-left: auto; padding-left: 16px;
+}
+
+.mc-logs-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-3);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 5px 12px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.mc-logs-btn:hover { color: var(--fg-0); border-color: var(--line-3); }
+.mc-logs-btn.is-active { color: var(--accent); border-color: var(--accent-line); }
+
+/* ── Zone principale ─────────────────────────────────────────────────── */
+
+.mc-main {
+  flex: 1; overflow: hidden;
+  position: relative;
+  display: flex; flex-direction: column;
+}
+
+/* Iframe pleine hauteur */
+.mc-iframe {
+  width: 100%; height: 100%;
+  border: none; display: block;
+  background: var(--bg-0);
+}
+.mc-iframe.is-hidden { display: none; }
+
+/* Panneau Interface */
+.mc-panel-interface {
+  flex: 1; overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+  padding: 40px min(80px, 6vw);
+}
+
+/* ── Panneau Interface : styles internes ─────────────────────────────── */
+
+.mci-section {
+  display: flex; flex-direction: column; gap: 16px;
+  padding-bottom: 32px; margin-bottom: 32px;
+  border-bottom: 0.5px solid var(--line-1);
+  max-width: 560px;
+}
+.mci-section:last-child { border-bottom: none; }
+
+.mci-section-label {
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-4); margin-bottom: 4px;
+}
+
+.mci-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 34px;
+}
+.mci-row--toggle {
+  flex-direction: column; align-items: flex-start; gap: 10px;
+}
+
+.mci-label {
+  font-family: var(--sans); font-size: 12.5px; color: var(--fg-2);
+  min-width: 140px; flex-shrink: 0;
+}
+.mci-sublabel {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.mci-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.mci-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.mci-color-input {
+  width: 36px; height: 28px;
+  border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  cursor: pointer; padding: 2px; background: var(--bg-2);
+}
+.mci-color-hex {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.mci-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.mci-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent); cursor: pointer;
+}
+.mci-range-val {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  min-width: 40px; text-align: right;
+}
+
+/* Boutons */
+.mci-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  padding: 8px 18px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.mci-btn:hover { color: var(--fg-0); border-color: var(--line-3); background: var(--bg-3); }
+.mci-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.mci-actions { gap: 10px; flex-wrap: wrap; }
+.mci-file-input { display: none; }
+
+/* Toggle switch */
+.mci-toggle {
+  background: none; border: none; padding: 0; cursor: pointer; flex-shrink: 0;
+}
+.mci-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+.mci-toggle.is-on .mci-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.mci-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.mci-toggle.is-on .mci-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── État vide (aucun onglet actif) ──────────────────────────────────── */
+
+.mc-empty {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 12px;
+  color: var(--fg-4);
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.16em; text-transform: uppercase;
+}

--- a/src/jarvis/interfaces/ui/static/mc.css.bak-1782255590
+++ b/src/jarvis/interfaces/ui/static/mc.css.bak-1782255590
@@ -1,0 +1,216 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mc.css — page Mission Control (/mc)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Reset page ──────────────────────────────────────────────────────── */
+
+body[data-mode="mc"] {
+  margin: 0; padding: 0;
+  background: var(--bg-0);
+  height: 100vh; overflow: hidden;
+  display: flex; flex-direction: column;
+}
+
+/* ── Topbar sticky ───────────────────────────────────────────────────── */
+
+.mc-topbar {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--bg-0);
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+}
+
+.mc-topbar-inner {
+  display: flex; align-items: center; justify-content: center; gap: 0;
+  height: 52px; padding: 0 24px;
+  position: relative;
+}
+
+/* Logo / retour home */
+.mc-brand {
+  display: flex; align-items: center; gap: 8px;
+  color: var(--fg-3); text-decoration: none;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.22em; text-transform: uppercase;
+  position: absolute; left: 24px;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+.mc-brand:hover { color: var(--accent); }
+
+/* Nav onglets */
+.mc-nav {
+  display: flex; align-items: stretch;
+  height: 100%;
+}
+
+.mc-nav-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 0 20px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px; /* aligne sur le border-bottom du topbar */
+}
+.mc-nav-btn:hover { color: var(--fg-1); }
+.mc-nav-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Fin de topbar (logs badge, etc.) */
+.mc-topbar-end {
+  display: flex; align-items: center; gap: 8px;
+  position: absolute; right: 24px;
+}
+
+.mc-logs-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-3);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 5px 12px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.mc-logs-btn:hover { color: var(--fg-0); border-color: var(--line-3); }
+.mc-logs-btn.is-active { color: var(--accent); border-color: var(--accent-line); }
+
+/* ── Zone principale ─────────────────────────────────────────────────── */
+
+.mc-main {
+  flex: 1; overflow: hidden;
+  position: relative;
+  display: flex; flex-direction: column;
+}
+
+/* Iframe pleine hauteur */
+.mc-iframe {
+  width: 100%; height: 100%;
+  border: none; display: block;
+  background: var(--bg-0);
+}
+.mc-iframe.is-hidden { display: none; }
+
+/* Panneau Interface */
+.mc-panel-interface {
+  flex: 1; overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+  padding: 40px 24px;
+  display: flex; flex-direction: column; align-items: center;
+}
+
+.mc-panel-interface > * {
+  width: 100%; max-width: 600px;
+}
+
+/* ── Panneau Interface : styles internes ─────────────────────────────── */
+
+.mci-section {
+  display: flex; flex-direction: column; gap: 16px;
+  padding-bottom: 32px; margin-bottom: 32px;
+  border-bottom: 0.5px solid var(--line-1);
+  max-width: 560px;
+}
+.mci-section:last-child { border-bottom: none; }
+
+.mci-section-label {
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-4); margin-bottom: 4px;
+}
+
+.mci-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 34px;
+}
+.mci-row--toggle {
+  flex-direction: column; align-items: flex-start; gap: 10px;
+}
+
+.mci-label {
+  font-family: var(--sans); font-size: 12.5px; color: var(--fg-2);
+  min-width: 140px; flex-shrink: 0;
+}
+.mci-sublabel {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.mci-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.mci-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.mci-color-input {
+  width: 36px; height: 28px;
+  border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  cursor: pointer; padding: 2px; background: var(--bg-2);
+}
+.mci-color-hex {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.mci-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.mci-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent); cursor: pointer;
+}
+.mci-range-val {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  min-width: 40px; text-align: right;
+}
+
+/* Boutons */
+.mci-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  padding: 8px 18px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.mci-btn:hover { color: var(--fg-0); border-color: var(--line-3); background: var(--bg-3); }
+.mci-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.mci-actions { gap: 10px; flex-wrap: wrap; }
+.mci-file-input { display: none; }
+
+/* Toggle switch */
+.mci-toggle {
+  background: none; border: none; padding: 0; cursor: pointer; flex-shrink: 0;
+}
+.mci-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+.mci-toggle.is-on .mci-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.mci-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.mci-toggle.is-on .mci-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── État vide (aucun onglet actif) ──────────────────────────────────── */
+
+.mc-empty {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 12px;
+  color: var(--fg-4);
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.16em; text-transform: uppercase;
+}

--- a/src/jarvis/interfaces/ui/static/mc.css.bak-1782257286
+++ b/src/jarvis/interfaces/ui/static/mc.css.bak-1782257286
@@ -1,0 +1,216 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mc.css — page Mission Control (/mc)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Reset page ──────────────────────────────────────────────────────── */
+
+body[data-mode="mc"] {
+  margin: 0; padding: 0;
+  background: var(--bg-0);
+  height: 100vh; overflow: hidden;
+  display: flex; flex-direction: column;
+}
+
+/* ── Topbar sticky ───────────────────────────────────────────────────── */
+
+.mc-topbar {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--bg-0);
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+}
+
+.mc-topbar-inner {
+  display: flex; align-items: center; justify-content: center; gap: 0;
+  height: 52px; padding: 0 24px;
+  position: relative;
+}
+
+/* Logo / retour home */
+.mc-brand {
+  display: flex; align-items: center; gap: 12px;
+  color: var(--fg-3); text-decoration: none;
+  font-family: var(--mono); font-size: 16px;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  position: absolute; left: 24px;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+.mc-brand:hover { color: var(--accent); }
+
+/* Nav onglets */
+.mc-nav {
+  display: flex; align-items: stretch;
+  height: 100%;
+}
+
+.mc-nav-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.10em; text-transform: uppercase; font-size: 16px;
+  padding: 0 20px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px; /* aligne sur le border-bottom du topbar */
+}
+.mc-nav-btn:hover { color: var(--fg-1); }
+.mc-nav-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Fin de topbar (logs badge, etc.) */
+.mc-topbar-end {
+  display: flex; align-items: center; gap: 8px;
+  position: absolute; right: 24px;
+}
+
+.mc-logs-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-3);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 5px 12px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.mc-logs-btn:hover { color: var(--fg-0); border-color: var(--line-3); }
+.mc-logs-btn.is-active { color: var(--accent); border-color: var(--accent-line); }
+
+/* ── Zone principale ─────────────────────────────────────────────────── */
+
+.mc-main {
+  flex: 1; overflow: hidden;
+  position: relative;
+  display: flex; flex-direction: column;
+}
+
+/* Iframe pleine hauteur */
+.mc-iframe {
+  width: 100%; height: 100%;
+  border: none; display: block;
+  background: var(--bg-0);
+}
+.mc-iframe.is-hidden { display: none; }
+
+/* Panneau Interface */
+.mc-panel-interface {
+  flex: 1; overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+  padding: 40px 24px;
+  display: flex; flex-direction: column; align-items: center;
+}
+
+.mc-panel-interface > * {
+  width: 100%; max-width: 600px;
+}
+
+/* ── Panneau Interface : styles internes ─────────────────────────────── */
+
+.mci-section {
+  display: flex; flex-direction: column; gap: 16px;
+  padding-bottom: 32px; margin-bottom: 32px;
+  border-bottom: 0.5px solid var(--line-1);
+  max-width: 560px;
+}
+.mci-section:last-child { border-bottom: none; }
+
+.mci-section-label {
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-4); margin-bottom: 4px;
+}
+
+.mci-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 34px;
+}
+.mci-row--toggle {
+  flex-direction: column; align-items: flex-start; gap: 10px;
+}
+
+.mci-label {
+  font-family: var(--sans); font-size: 12.5px; color: var(--fg-2);
+  min-width: 140px; flex-shrink: 0;
+}
+.mci-sublabel {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.mci-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.mci-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.mci-color-input {
+  width: 36px; height: 28px;
+  border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  cursor: pointer; padding: 2px; background: var(--bg-2);
+}
+.mci-color-hex {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.mci-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.mci-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent); cursor: pointer;
+}
+.mci-range-val {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  min-width: 40px; text-align: right;
+}
+
+/* Boutons */
+.mci-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  padding: 8px 18px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.mci-btn:hover { color: var(--fg-0); border-color: var(--line-3); background: var(--bg-3); }
+.mci-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.mci-actions { gap: 10px; flex-wrap: wrap; }
+.mci-file-input { display: none; }
+
+/* Toggle switch */
+.mci-toggle {
+  background: none; border: none; padding: 0; cursor: pointer; flex-shrink: 0;
+}
+.mci-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+.mci-toggle.is-on .mci-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.mci-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.mci-toggle.is-on .mci-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── État vide (aucun onglet actif) ──────────────────────────────────── */
+
+.mc-empty {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 12px;
+  color: var(--fg-4);
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.16em; text-transform: uppercase;
+}

--- a/src/jarvis/interfaces/ui/static/mc.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/mc.css.bak-1782259625
@@ -1,0 +1,216 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mc.css — page Mission Control (/mc)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Reset page ──────────────────────────────────────────────────────── */
+
+body[data-mode="mc"] {
+  margin: 0; padding: 0;
+  background: var(--bg-0);
+  height: 100vh; overflow: hidden;
+  display: flex; flex-direction: column;
+}
+
+/* ── Topbar sticky ───────────────────────────────────────────────────── */
+
+.mc-topbar {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--bg-0);
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+}
+
+.mc-topbar-inner {
+  display: flex; align-items: center; justify-content: center; gap: 0;
+  height: 52px; padding: 0 24px;
+  position: relative;
+}
+
+/* Logo / retour home */
+.mc-brand {
+  display: flex; align-items: center; gap: 12px;
+  color: var(--fg-3); text-decoration: none;
+  font-family: var(--mono); font-size: 16px;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  position: absolute; left: 24px;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+.mc-brand:hover { color: var(--accent); }
+
+/* Nav onglets */
+.mc-nav {
+  display: flex; align-items: stretch;
+  height: 100%;
+}
+
+.mc-nav-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.10em; text-transform: uppercase; font-size: 16px;
+  padding: 0 20px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px; /* aligne sur le border-bottom du topbar */
+}
+.mc-nav-btn:hover { color: var(--fg-1); }
+.mc-nav-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Fin de topbar (logs badge, etc.) */
+.mc-topbar-end {
+  display: flex; align-items: center; gap: 8px;
+  position: absolute; right: 24px;
+}
+
+.mc-logs-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-3);
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 5px 12px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.mc-logs-btn:hover { color: var(--fg-0); border-color: var(--line-3); }
+.mc-logs-btn.is-active { color: var(--accent); border-color: var(--accent-line); }
+
+/* ── Zone principale ─────────────────────────────────────────────────── */
+
+.mc-main {
+  flex: 1; overflow: hidden;
+  position: relative;
+  display: flex; flex-direction: column;
+}
+
+/* Iframe pleine hauteur */
+.mc-iframe {
+  width: 100%; height: 100%;
+  border: none; display: block;
+  background: transparent;
+}
+.mc-iframe.is-hidden { display: none; }
+
+/* Panneau Interface */
+.mc-panel-interface {
+  flex: 1; overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+  padding: 40px 24px;
+  display: flex; flex-direction: column; align-items: center;
+}
+
+.mc-panel-interface > * {
+  width: 100%; max-width: 600px;
+}
+
+/* ── Panneau Interface : styles internes ─────────────────────────────── */
+
+.mci-section {
+  display: flex; flex-direction: column; gap: 16px;
+  padding-bottom: 32px; margin-bottom: 32px;
+  border-bottom: 0.5px solid var(--line-1);
+  max-width: 560px;
+}
+.mci-section:last-child { border-bottom: none; }
+
+.mci-section-label {
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-4); margin-bottom: 4px;
+}
+
+.mci-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 34px;
+}
+.mci-row--toggle {
+  flex-direction: column; align-items: flex-start; gap: 10px;
+}
+
+.mci-label {
+  font-family: var(--sans); font-size: 12.5px; color: var(--fg-2);
+  min-width: 140px; flex-shrink: 0;
+}
+.mci-sublabel {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.mci-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.mci-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.mci-color-input {
+  width: 36px; height: 28px;
+  border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  cursor: pointer; padding: 2px; background: var(--bg-2);
+}
+.mci-color-hex {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.mci-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.mci-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent); cursor: pointer;
+}
+.mci-range-val {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  min-width: 40px; text-align: right;
+}
+
+/* Boutons */
+.mci-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  padding: 8px 18px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.mci-btn:hover { color: var(--fg-0); border-color: var(--line-3); background: var(--bg-3); }
+.mci-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.mci-actions { gap: 10px; flex-wrap: wrap; }
+.mci-file-input { display: none; }
+
+/* Toggle switch */
+.mci-toggle {
+  background: none; border: none; padding: 0; cursor: pointer; flex-shrink: 0;
+}
+.mci-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+.mci-toggle.is-on .mci-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.mci-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.mci-toggle.is-on .mci-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── État vide (aucun onglet actif) ──────────────────────────────────── */
+
+.mc-empty {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 12px;
+  color: var(--fg-4);
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.16em; text-transform: uppercase;
+}

--- a/src/jarvis/interfaces/ui/static/mc.css.bak-1782259956
+++ b/src/jarvis/interfaces/ui/static/mc.css.bak-1782259956
@@ -1,0 +1,216 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mc.css — page Mission Control (/mc)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Reset page ──────────────────────────────────────────────────────── */
+
+body[data-mode="mc"] {
+  margin: 0; padding: 0;
+  background: var(--bg-0);
+  height: 100vh; overflow: hidden;
+  display: flex; flex-direction: column;
+}
+
+/* ── Topbar sticky ───────────────────────────────────────────────────── */
+
+.mc-topbar {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--bg-0);
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+}
+
+.mc-topbar-inner {
+  display: flex; align-items: center; justify-content: center; gap: 0;
+  height: 52px; padding: 0 24px;
+  position: relative;
+}
+
+/* Logo / retour home */
+.mc-brand {
+  display: flex; align-items: center; gap: 12px;
+  color: var(--fg-3); text-decoration: none;
+  font-family: var(--mono); font-size: 1rem;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  position: absolute; left: 24px;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+.mc-brand:hover { color: var(--accent); }
+
+/* Nav onglets */
+.mc-nav {
+  display: flex; align-items: stretch;
+  height: 100%;
+}
+
+.mc-nav-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.10em; text-transform: uppercase; font-size: 1rem;
+  padding: 0 20px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px; /* aligne sur le border-bottom du topbar */
+}
+.mc-nav-btn:hover { color: var(--fg-1); }
+.mc-nav-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Fin de topbar (logs badge, etc.) */
+.mc-topbar-end {
+  display: flex; align-items: center; gap: 8px;
+  position: absolute; right: 24px;
+}
+
+.mc-logs-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-3);
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 5px 12px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.mc-logs-btn:hover { color: var(--fg-0); border-color: var(--line-3); }
+.mc-logs-btn.is-active { color: var(--accent); border-color: var(--accent-line); }
+
+/* ── Zone principale ─────────────────────────────────────────────────── */
+
+.mc-main {
+  flex: 1; overflow: hidden;
+  position: relative;
+  display: flex; flex-direction: column;
+}
+
+/* Iframe pleine hauteur */
+.mc-iframe {
+  width: 100%; height: 100%;
+  border: none; display: block;
+  background: transparent;
+}
+.mc-iframe.is-hidden { display: none; }
+
+/* Panneau Interface */
+.mc-panel-interface {
+  flex: 1; overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+  padding: 40px 24px;
+  display: flex; flex-direction: column; align-items: center;
+}
+
+.mc-panel-interface > * {
+  width: 100%; max-width: 600px;
+}
+
+/* ── Panneau Interface : styles internes ─────────────────────────────── */
+
+.mci-section {
+  display: flex; flex-direction: column; gap: 16px;
+  padding-bottom: 32px; margin-bottom: 32px;
+  border-bottom: 0.5px solid var(--line-1);
+  max-width: 560px;
+}
+.mci-section:last-child { border-bottom: none; }
+
+.mci-section-label {
+  font-family: var(--mono); font-size: 0.5625rem;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-4); margin-bottom: 4px;
+}
+
+.mci-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 34px;
+}
+.mci-row--toggle {
+  flex-direction: column; align-items: flex-start; gap: 10px;
+}
+
+.mci-label {
+  font-family: var(--sans); font-size: 0.7812rem; color: var(--fg-2);
+  min-width: 140px; flex-shrink: 0;
+}
+.mci-sublabel {
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.mci-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.mci-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.mci-color-input {
+  width: 36px; height: 28px;
+  border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  cursor: pointer; padding: 2px; background: var(--bg-2);
+}
+.mci-color-hex {
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.mci-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.mci-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent); cursor: pointer;
+}
+.mci-range-val {
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3);
+  min-width: 40px; text-align: right;
+}
+
+/* Boutons */
+.mci-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.08em;
+  padding: 8px 18px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.mci-btn:hover { color: var(--fg-0); border-color: var(--line-3); background: var(--bg-3); }
+.mci-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.mci-actions { gap: 10px; flex-wrap: wrap; }
+.mci-file-input { display: none; }
+
+/* Toggle switch */
+.mci-toggle {
+  background: none; border: none; padding: 0; cursor: pointer; flex-shrink: 0;
+}
+.mci-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+.mci-toggle.is-on .mci-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.mci-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.mci-toggle.is-on .mci-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── État vide (aucun onglet actif) ──────────────────────────────────── */
+
+.mc-empty {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 12px;
+  color: var(--fg-4);
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.16em; text-transform: uppercase;
+}

--- a/src/jarvis/interfaces/ui/static/mc.css.bak-1782260130
+++ b/src/jarvis/interfaces/ui/static/mc.css.bak-1782260130
@@ -1,0 +1,216 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mc.css — page Mission Control (/mc)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Reset page ──────────────────────────────────────────────────────── */
+
+body[data-mode="mc"] {
+  margin: 0; padding: 0;
+  background: var(--bg-0);
+  height: 100vh; overflow: hidden;
+  display: flex; flex-direction: column;
+}
+
+/* ── Topbar sticky ───────────────────────────────────────────────────── */
+
+.mc-topbar {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--bg-0);
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+}
+
+.mc-topbar-inner {
+  display: flex; align-items: center; justify-content: center; gap: 0;
+  height: 52px; padding: 0 24px;
+  position: relative;
+}
+
+/* Logo / retour home */
+.mc-brand {
+  display: flex; align-items: center; gap: 12px;
+  color: var(--fg-0); text-decoration: none;
+  font-family: var(--mono); font-size: 1rem;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  position: absolute; left: 24px;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+.mc-brand:hover { color: var(--accent); }
+
+/* Nav onglets */
+.mc-nav {
+  display: flex; align-items: stretch;
+  height: 100%;
+}
+
+.mc-nav-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.10em; text-transform: uppercase; font-size: 1rem;
+  padding: 0 20px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px; /* aligne sur le border-bottom du topbar */
+}
+.mc-nav-btn:hover { color: var(--fg-1); }
+.mc-nav-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Fin de topbar (logs badge, etc.) */
+.mc-topbar-end {
+  display: flex; align-items: center; gap: 8px;
+  position: absolute; right: 24px;
+}
+
+.mc-logs-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-3);
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 5px 12px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.mc-logs-btn:hover { color: var(--fg-0); border-color: var(--line-3); }
+.mc-logs-btn.is-active { color: var(--accent); border-color: var(--accent-line); }
+
+/* ── Zone principale ─────────────────────────────────────────────────── */
+
+.mc-main {
+  flex: 1; overflow: hidden;
+  position: relative;
+  display: flex; flex-direction: column;
+}
+
+/* Iframe pleine hauteur */
+.mc-iframe {
+  width: 100%; height: 100%;
+  border: none; display: block;
+  background: transparent;
+}
+.mc-iframe.is-hidden { display: none; }
+
+/* Panneau Interface */
+.mc-panel-interface {
+  flex: 1; overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+  padding: 40px 24px;
+  display: flex; flex-direction: column; align-items: center;
+}
+
+.mc-panel-interface > * {
+  width: 100%; max-width: 600px;
+}
+
+/* ── Panneau Interface : styles internes ─────────────────────────────── */
+
+.mci-section {
+  display: flex; flex-direction: column; gap: 16px;
+  padding-bottom: 32px; margin-bottom: 32px;
+  border-bottom: 0.5px solid var(--line-1);
+  max-width: 560px;
+}
+.mci-section:last-child { border-bottom: none; }
+
+.mci-section-label {
+  font-family: var(--mono); font-size: 0.5625rem;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-4); margin-bottom: 4px;
+}
+
+.mci-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 34px;
+}
+.mci-row--toggle {
+  flex-direction: column; align-items: flex-start; gap: 10px;
+}
+
+.mci-label {
+  font-family: var(--sans); font-size: 0.7812rem; color: var(--fg-2);
+  min-width: 140px; flex-shrink: 0;
+}
+.mci-sublabel {
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.mci-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.mci-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.mci-color-input {
+  width: 36px; height: 28px;
+  border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  cursor: pointer; padding: 2px; background: var(--bg-2);
+}
+.mci-color-hex {
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.mci-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.mci-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent); cursor: pointer;
+}
+.mci-range-val {
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3);
+  min-width: 40px; text-align: right;
+}
+
+/* Boutons */
+.mci-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.08em;
+  padding: 8px 18px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.mci-btn:hover { color: var(--fg-0); border-color: var(--line-3); background: var(--bg-3); }
+.mci-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.mci-actions { gap: 10px; flex-wrap: wrap; }
+.mci-file-input { display: none; }
+
+/* Toggle switch */
+.mci-toggle {
+  background: none; border: none; padding: 0; cursor: pointer; flex-shrink: 0;
+}
+.mci-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+.mci-toggle.is-on .mci-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.mci-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.mci-toggle.is-on .mci-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── État vide (aucun onglet actif) ──────────────────────────────────── */
+
+.mc-empty {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 12px;
+  color: var(--fg-4);
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.16em; text-transform: uppercase;
+}

--- a/src/jarvis/interfaces/ui/static/mc.css.bak-1782260482
+++ b/src/jarvis/interfaces/ui/static/mc.css.bak-1782260482
@@ -1,0 +1,217 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mc.css — page Mission Control (/mc)
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Reset page ──────────────────────────────────────────────────────── */
+
+body[data-mode="mc"] {
+  margin: 0; padding: 0;
+  background: var(--bg-0);
+  height: 100vh; overflow: hidden;
+  display: flex; flex-direction: column;
+}
+
+/* ── Topbar sticky ───────────────────────────────────────────────────── */
+
+.mc-topbar {
+  position: sticky; top: 0; z-index: 100;
+  background: var(--bg-0);
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+}
+
+.mc-topbar-inner {
+  display: flex; align-items: center; justify-content: center; gap: 0;
+  height: 52px; padding: 0 24px;
+  position: relative;
+}
+
+/* Logo / retour home */
+.mc-brand {
+  display: flex; align-items: center; gap: 12px;
+  color: var(--fg-0); text-decoration: none;
+  font-family: var(--mono); font-size: 1rem;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  position: absolute; left: 24px;
+  transition: color 0.15s;
+  flex-shrink: 0;
+}
+.mc-brand:hover { color: var(--accent); }
+.mc-brand svg { font-size: 0; flex-shrink: 0; }
+
+/* Nav onglets */
+.mc-nav {
+  display: flex; align-items: stretch;
+  height: 100%;
+}
+
+.mc-nav-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.10em; text-transform: uppercase; font-size: 1rem;
+  padding: 0 20px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px; /* aligne sur le border-bottom du topbar */
+}
+.mc-nav-btn:hover { color: var(--fg-1); }
+.mc-nav-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* Fin de topbar (logs badge, etc.) */
+.mc-topbar-end {
+  display: flex; align-items: center; gap: 8px;
+  position: absolute; right: 24px;
+}
+
+.mc-logs-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-3);
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  padding: 5px 12px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.mc-logs-btn:hover { color: var(--fg-0); border-color: var(--line-3); }
+.mc-logs-btn.is-active { color: var(--accent); border-color: var(--accent-line); }
+
+/* ── Zone principale ─────────────────────────────────────────────────── */
+
+.mc-main {
+  flex: 1; overflow: hidden;
+  position: relative;
+  display: flex; flex-direction: column;
+}
+
+/* Iframe pleine hauteur */
+.mc-iframe {
+  width: 100%; height: 100%;
+  border: none; display: block;
+  background: transparent;
+}
+.mc-iframe.is-hidden { display: none; }
+
+/* Panneau Interface */
+.mc-panel-interface {
+  flex: 1; overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+  padding: 40px 24px;
+  display: flex; flex-direction: column; align-items: center;
+}
+
+.mc-panel-interface > * {
+  width: 100%; max-width: 600px;
+}
+
+/* ── Panneau Interface : styles internes ─────────────────────────────── */
+
+.mci-section {
+  display: flex; flex-direction: column; gap: 16px;
+  padding-bottom: 32px; margin-bottom: 32px;
+  border-bottom: 0.5px solid var(--line-1);
+  max-width: 560px;
+}
+.mci-section:last-child { border-bottom: none; }
+
+.mci-section-label {
+  font-family: var(--mono); font-size: 0.5625rem;
+  letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-4); margin-bottom: 4px;
+}
+
+.mci-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 34px;
+}
+.mci-row--toggle {
+  flex-direction: column; align-items: flex-start; gap: 10px;
+}
+
+.mci-label {
+  font-family: var(--sans); font-size: 0.7812rem; color: var(--fg-2);
+  min-width: 140px; flex-shrink: 0;
+}
+.mci-sublabel {
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.mci-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.mci-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.mci-color-input {
+  width: 36px; height: 28px;
+  border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  cursor: pointer; padding: 2px; background: var(--bg-2);
+}
+.mci-color-hex {
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.mci-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.mci-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent); cursor: pointer;
+}
+.mci-range-val {
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3);
+  min-width: 40px; text-align: right;
+}
+
+/* Boutons */
+.mci-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.08em;
+  padding: 8px 18px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.mci-btn:hover { color: var(--fg-0); border-color: var(--line-3); background: var(--bg-3); }
+.mci-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.mci-actions { gap: 10px; flex-wrap: wrap; }
+.mci-file-input { display: none; }
+
+/* Toggle switch */
+.mci-toggle {
+  background: none; border: none; padding: 0; cursor: pointer; flex-shrink: 0;
+}
+.mci-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px;
+  transition: background 0.2s, border-color 0.2s;
+}
+.mci-toggle.is-on .mci-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.mci-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.mci-toggle.is-on .mci-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── État vide (aucun onglet actif) ──────────────────────────────────── */
+
+.mc-empty {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 12px;
+  color: var(--fg-4);
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.16em; text-transform: uppercase;
+}

--- a/src/jarvis/interfaces/ui/static/mc.html
+++ b/src/jarvis/interfaces/ui/static/mc.html
@@ -72,6 +72,7 @@
 </main>
 
 <script src="/_shared.js"></script>
+<script src="/jarvis-color-picker.js"></script>
 <script src="/mc.js"></script>
 </body>
 </html>

--- a/src/jarvis/interfaces/ui/static/mc.html
+++ b/src/jarvis/interfaces/ui/static/mc.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Mission Control</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
+<link rel="stylesheet" href="/mc.css" />
+</head>
+<body data-mode="mc">
+
+<!-- Topbar sticky -->
+<header class="mc-topbar" id="mc-topbar">
+  <div class="mc-topbar-inner">
+
+    <!-- Logo / retour home -->
+    <a href="/" class="mc-brand" title="Retour Home">
+      <svg width="36" height="36" viewBox="-36 -36 72 72" xmlns="http://www.w3.org/2000/svg" class="mc-arc-reactor" aria-hidden="true">
+        <style>
+          @keyframes jmc-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+          @keyframes jmc-spinrev { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+          @keyframes jmc-pulse { 0%,100%{opacity:0.5}50%{opacity:1} }
+          .jmc-r1 { transform-origin:0 0; animation: jmc-spin 8s linear infinite; }
+          .jmc-r2 { transform-origin:0 0; animation: jmc-spinrev 12s linear infinite; }
+          .jmc-p  { animation: jmc-pulse 2.4s ease-in-out infinite; }
+        </style>
+        <circle cx="0" cy="0" r="32" fill="none" stroke="currentColor" stroke-width="0.6" opacity="0.35"/>
+        <circle cx="0" cy="0" r="22" fill="none" stroke="currentColor" stroke-width="8" opacity="0.28"/>
+        <g class="jmc-r1">
+          <path d="M0,-28 A28,28 0 0,1 24.2,-14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+          <path d="M24.2,14 A28,28 0 0,1 0,28"  fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+          <path d="M-24.2,-14 A28,28 0 0,1 -24.2,14" fill="none" stroke="currentColor" stroke-width="0.6" stroke-linecap="round" opacity="0.4"/>
+        </g>
+        <g class="jmc-r2">
+          <path d="M0,-18 A18,18 0 0,1 18,0"  fill="none" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" opacity="0.7"/>
+          <path d="M0,18 A18,18 0 0,1 -18,0"  fill="none" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" opacity="0.7"/>
+        </g>
+        <circle cx="0" cy="0" r="6" fill="currentColor" stroke="none" opacity="0.35" class="jmc-p"/>
+        <circle cx="0" cy="0" r="2.5" fill="currentColor"/>
+      </svg>
+      <span>JARVIS</span>
+    </a>
+
+    <!-- Onglets -->
+    <nav class="mc-nav" id="mc-nav">
+      <button class="mc-nav-btn" data-tab="workspace"     onclick="MCPage.show('workspace')">Workspace</button>
+      <button class="mc-nav-btn" data-tab="capacites"     onclick="MCPage.show('capacites')">Capacités</button>
+      <button class="mc-nav-btn" data-tab="configuration" onclick="MCPage.show('configuration')">Configuration</button>
+      <button class="mc-nav-btn" data-tab="interface"     onclick="MCPage.show('interface')">Interface</button>
+    </nav>
+
+    <!-- Indicateur logs (mode avancé) -->
+    <div class="mc-topbar-end" id="mc-topbar-end"></div>
+
+  </div>
+</header>
+
+<!-- Zone de contenu -->
+<main class="mc-main" id="mc-main">
+
+  <!-- Iframe pour les pages existantes -->
+  <iframe class="mc-iframe" id="mc-iframe" src="about:blank" frameborder="0" allowfullscreen allowtransparency="true"></iframe>
+
+  <!-- Panneau Interface (pas d'iframe) -->
+  <div class="mc-panel-interface" id="mc-panel-interface" style="display:none"></div>
+
+</main>
+
+<script src="/_shared.js"></script>
+<script src="/mc.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/mc.html.bak-1782255590
+++ b/src/jarvis/interfaces/ui/static/mc.html.bak-1782255590
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Mission Control</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
+<link rel="stylesheet" href="/mc.css" />
+</head>
+<body data-mode="mc">
+
+<!-- Topbar sticky -->
+<header class="mc-topbar" id="mc-topbar">
+  <div class="mc-topbar-inner">
+
+    <!-- Logo / retour home -->
+    <a href="/" class="mc-brand" title="Retour Home">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 12L12 3l9 9"/>
+        <path d="M9 21V12h6v9"/>
+      </svg>
+      <span>JARVIS</span>
+    </a>
+
+    <!-- Onglets -->
+    <nav class="mc-nav" id="mc-nav">
+      <button class="mc-nav-btn" data-tab="workspace"     onclick="MCPage.show('workspace')">Workspace</button>
+      <button class="mc-nav-btn" data-tab="capacites"     onclick="MCPage.show('capacites')">Capacités</button>
+      <button class="mc-nav-btn" data-tab="configuration" onclick="MCPage.show('configuration')">Configuration</button>
+      <button class="mc-nav-btn" data-tab="interface"     onclick="MCPage.show('interface')">Interface</button>
+    </nav>
+
+    <!-- Indicateur logs (mode avancé) -->
+    <div class="mc-topbar-end" id="mc-topbar-end"></div>
+
+  </div>
+</header>
+
+<!-- Zone de contenu -->
+<main class="mc-main" id="mc-main">
+
+  <!-- Iframe pour les pages existantes -->
+  <iframe class="mc-iframe" id="mc-iframe" src="about:blank" frameborder="0" allowfullscreen></iframe>
+
+  <!-- Panneau Interface (pas d'iframe) -->
+  <div class="mc-panel-interface" id="mc-panel-interface" style="display:none"></div>
+
+</main>
+
+<script src="/_shared.js"></script>
+<script src="/mc.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/mc.html.bak-1782257390
+++ b/src/jarvis/interfaces/ui/static/mc.html.bak-1782257390
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Mission Control</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
+<link rel="stylesheet" href="/mc.css" />
+</head>
+<body data-mode="mc">
+
+<!-- Topbar sticky -->
+<header class="mc-topbar" id="mc-topbar">
+  <div class="mc-topbar-inner">
+
+    <!-- Logo / retour home -->
+    <a href="/" class="mc-brand" title="Retour Home">
+      <svg width="36" height="36" viewBox="-36 -36 72 72" xmlns="http://www.w3.org/2000/svg" class="mc-arc-reactor" aria-hidden="true">
+        <style>
+          @keyframes jmc-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+          @keyframes jmc-spinrev { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+          @keyframes jmc-pulse { 0%,100%{opacity:0.5}50%{opacity:1} }
+          .jmc-r1 { transform-origin:0 0; animation: jmc-spin 8s linear infinite; }
+          .jmc-r2 { transform-origin:0 0; animation: jmc-spinrev 12s linear infinite; }
+          .jmc-p  { animation: jmc-pulse 2.4s ease-in-out infinite; }
+        </style>
+        <circle cx="0" cy="0" r="32" fill="none" stroke="rgba(74,158,255,0.12)" stroke-width="1"/>
+        <circle cx="0" cy="0" r="22" fill="none" stroke="rgba(74,158,255,0.10)" stroke-width="8"/>
+        <g class="jmc-r1">
+          <path d="M0,-28 A28,28 0 0,1 24.2,-14" fill="none" stroke="#4A9EFF" stroke-width="2" stroke-linecap="round"/>
+          <path d="M24.2,14 A28,28 0 0,1 0,28"  fill="none" stroke="#4A9EFF" stroke-width="2" stroke-linecap="round"/>
+          <path d="M-24.2,-14 A28,28 0 0,1 -24.2,14" fill="none" stroke="#4A9EFF" stroke-width="1" stroke-linecap="round" opacity="0.4"/>
+        </g>
+        <g class="jmc-r2">
+          <path d="M0,-18 A18,18 0 0,1 18,0"  fill="none" stroke="#4A9EFF" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+          <path d="M0,18 A18,18 0 0,1 -18,0"  fill="none" stroke="#4A9EFF" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+        </g>
+        <circle cx="0" cy="0" r="6" fill="rgba(74,158,255,0.2)" stroke="#4A9EFF" stroke-width="1" class="jmc-p"/>
+        <circle cx="0" cy="0" r="2.5" fill="#4A9EFF"/>
+      </svg>
+      <span>JARVIS</span>
+    </a>
+
+    <!-- Onglets -->
+    <nav class="mc-nav" id="mc-nav">
+      <button class="mc-nav-btn" data-tab="workspace"     onclick="MCPage.show('workspace')">Workspace</button>
+      <button class="mc-nav-btn" data-tab="capacites"     onclick="MCPage.show('capacites')">Capacités</button>
+      <button class="mc-nav-btn" data-tab="configuration" onclick="MCPage.show('configuration')">Configuration</button>
+      <button class="mc-nav-btn" data-tab="interface"     onclick="MCPage.show('interface')">Interface</button>
+    </nav>
+
+    <!-- Indicateur logs (mode avancé) -->
+    <div class="mc-topbar-end" id="mc-topbar-end"></div>
+
+  </div>
+</header>
+
+<!-- Zone de contenu -->
+<main class="mc-main" id="mc-main">
+
+  <!-- Iframe pour les pages existantes -->
+  <iframe class="mc-iframe" id="mc-iframe" src="about:blank" frameborder="0" allowfullscreen></iframe>
+
+  <!-- Panneau Interface (pas d'iframe) -->
+  <div class="mc-panel-interface" id="mc-panel-interface" style="display:none"></div>
+
+</main>
+
+<script src="/_shared.js"></script>
+<script src="/mc.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/mc.html.bak-1782259902
+++ b/src/jarvis/interfaces/ui/static/mc.html.bak-1782259902
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Mission Control</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
+<link rel="stylesheet" href="/mc.css" />
+</head>
+<body data-mode="mc">
+
+<!-- Topbar sticky -->
+<header class="mc-topbar" id="mc-topbar">
+  <div class="mc-topbar-inner">
+
+    <!-- Logo / retour home -->
+    <a href="/" class="mc-brand" title="Retour Home">
+      <svg width="36" height="36" viewBox="-36 -36 72 72" xmlns="http://www.w3.org/2000/svg" class="mc-arc-reactor" aria-hidden="true">
+        <style>
+          @keyframes jmc-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+          @keyframes jmc-spinrev { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+          @keyframes jmc-pulse { 0%,100%{opacity:0.5}50%{opacity:1} }
+          .jmc-r1 { transform-origin:0 0; animation: jmc-spin 8s linear infinite; }
+          .jmc-r2 { transform-origin:0 0; animation: jmc-spinrev 12s linear infinite; }
+          .jmc-p  { animation: jmc-pulse 2.4s ease-in-out infinite; }
+        </style>
+        <circle cx="0" cy="0" r="32" fill="none" stroke="rgba(74,158,255,0.12)" stroke-width="1"/>
+        <circle cx="0" cy="0" r="22" fill="none" stroke="rgba(74,158,255,0.10)" stroke-width="8"/>
+        <g class="jmc-r1">
+          <path d="M0,-28 A28,28 0 0,1 24.2,-14" fill="none" stroke="#4A9EFF" stroke-width="2" stroke-linecap="round"/>
+          <path d="M24.2,14 A28,28 0 0,1 0,28"  fill="none" stroke="#4A9EFF" stroke-width="2" stroke-linecap="round"/>
+          <path d="M-24.2,-14 A28,28 0 0,1 -24.2,14" fill="none" stroke="#4A9EFF" stroke-width="1" stroke-linecap="round" opacity="0.4"/>
+        </g>
+        <g class="jmc-r2">
+          <path d="M0,-18 A18,18 0 0,1 18,0"  fill="none" stroke="#4A9EFF" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+          <path d="M0,18 A18,18 0 0,1 -18,0"  fill="none" stroke="#4A9EFF" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+        </g>
+        <circle cx="0" cy="0" r="6" fill="rgba(74,158,255,0.2)" stroke="#4A9EFF" stroke-width="1" class="jmc-p"/>
+        <circle cx="0" cy="0" r="2.5" fill="#4A9EFF"/>
+      </svg>
+      <span>JARVIS</span>
+    </a>
+
+    <!-- Onglets -->
+    <nav class="mc-nav" id="mc-nav">
+      <button class="mc-nav-btn" data-tab="workspace"     onclick="MCPage.show('workspace')">Workspace</button>
+      <button class="mc-nav-btn" data-tab="capacites"     onclick="MCPage.show('capacites')">Capacités</button>
+      <button class="mc-nav-btn" data-tab="configuration" onclick="MCPage.show('configuration')">Configuration</button>
+      <button class="mc-nav-btn" data-tab="interface"     onclick="MCPage.show('interface')">Interface</button>
+    </nav>
+
+    <!-- Indicateur logs (mode avancé) -->
+    <div class="mc-topbar-end" id="mc-topbar-end"></div>
+
+  </div>
+</header>
+
+<!-- Zone de contenu -->
+<main class="mc-main" id="mc-main">
+
+  <!-- Iframe pour les pages existantes -->
+  <iframe class="mc-iframe" id="mc-iframe" src="about:blank" frameborder="0" allowfullscreen allowtransparency="true"></iframe>
+
+  <!-- Panneau Interface (pas d'iframe) -->
+  <div class="mc-panel-interface" id="mc-panel-interface" style="display:none"></div>
+
+</main>
+
+<script src="/_shared.js"></script>
+<script src="/mc.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/mc.html.bak-1782260168
+++ b/src/jarvis/interfaces/ui/static/mc.html.bak-1782260168
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Mission Control</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
+<link rel="stylesheet" href="/mc.css" />
+</head>
+<body data-mode="mc">
+
+<!-- Topbar sticky -->
+<header class="mc-topbar" id="mc-topbar">
+  <div class="mc-topbar-inner">
+
+    <!-- Logo / retour home -->
+    <a href="/" class="mc-brand" title="Retour Home">
+      <svg width="36" height="36" viewBox="-36 -36 72 72" xmlns="http://www.w3.org/2000/svg" class="mc-arc-reactor" aria-hidden="true">
+        <style>
+          @keyframes jmc-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+          @keyframes jmc-spinrev { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+          @keyframes jmc-pulse { 0%,100%{opacity:0.5}50%{opacity:1} }
+          .jmc-r1 { transform-origin:0 0; animation: jmc-spin 8s linear infinite; }
+          .jmc-r2 { transform-origin:0 0; animation: jmc-spinrev 12s linear infinite; }
+          .jmc-p  { animation: jmc-pulse 2.4s ease-in-out infinite; }
+        </style>
+        <circle cx="0" cy="0" r="32" fill="none" stroke="currentColor" stroke-width="1"/>
+        <circle cx="0" cy="0" r="22" fill="none" stroke="currentColor" stroke-width="8"/>
+        <g class="jmc-r1">
+          <path d="M0,-28 A28,28 0 0,1 24.2,-14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <path d="M24.2,14 A28,28 0 0,1 0,28"  fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          <path d="M-24.2,-14 A28,28 0 0,1 -24.2,14" fill="none" stroke="currentColor" stroke-width="1" stroke-linecap="round" opacity="0.4"/>
+        </g>
+        <g class="jmc-r2">
+          <path d="M0,-18 A18,18 0 0,1 18,0"  fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+          <path d="M0,18 A18,18 0 0,1 -18,0"  fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+        </g>
+        <circle cx="0" cy="0" r="6" fill="currentColor" stroke="currentColor" stroke-width="1" class="jmc-p"/>
+        <circle cx="0" cy="0" r="2.5" fill="currentColor"/>
+      </svg>
+      <span>JARVIS</span>
+    </a>
+
+    <!-- Onglets -->
+    <nav class="mc-nav" id="mc-nav">
+      <button class="mc-nav-btn" data-tab="workspace"     onclick="MCPage.show('workspace')">Workspace</button>
+      <button class="mc-nav-btn" data-tab="capacites"     onclick="MCPage.show('capacites')">Capacités</button>
+      <button class="mc-nav-btn" data-tab="configuration" onclick="MCPage.show('configuration')">Configuration</button>
+      <button class="mc-nav-btn" data-tab="interface"     onclick="MCPage.show('interface')">Interface</button>
+    </nav>
+
+    <!-- Indicateur logs (mode avancé) -->
+    <div class="mc-topbar-end" id="mc-topbar-end"></div>
+
+  </div>
+</header>
+
+<!-- Zone de contenu -->
+<main class="mc-main" id="mc-main">
+
+  <!-- Iframe pour les pages existantes -->
+  <iframe class="mc-iframe" id="mc-iframe" src="about:blank" frameborder="0" allowfullscreen allowtransparency="true"></iframe>
+
+  <!-- Panneau Interface (pas d'iframe) -->
+  <div class="mc-panel-interface" id="mc-panel-interface" style="display:none"></div>
+
+</main>
+
+<script src="/_shared.js"></script>
+<script src="/mc.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/mc.html.bak-1782260260
+++ b/src/jarvis/interfaces/ui/static/mc.html.bak-1782260260
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Mission Control</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
+<link rel="stylesheet" href="/mc.css" />
+</head>
+<body data-mode="mc">
+
+<!-- Topbar sticky -->
+<header class="mc-topbar" id="mc-topbar">
+  <div class="mc-topbar-inner">
+
+    <!-- Logo / retour home -->
+    <a href="/" class="mc-brand" title="Retour Home">
+      <svg width="36" height="36" viewBox="-36 -36 72 72" xmlns="http://www.w3.org/2000/svg" class="mc-arc-reactor" aria-hidden="true">
+        <style>
+          @keyframes jmc-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+          @keyframes jmc-spinrev { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+          @keyframes jmc-pulse { 0%,100%{opacity:0.5}50%{opacity:1} }
+          .jmc-r1 { transform-origin:0 0; animation: jmc-spin 8s linear infinite; }
+          .jmc-r2 { transform-origin:0 0; animation: jmc-spinrev 12s linear infinite; }
+          .jmc-p  { animation: jmc-pulse 2.4s ease-in-out infinite; }
+        </style>
+        <circle cx="0" cy="0" r="32" fill="none" stroke="currentColor" stroke-width="0.6"/>
+        <circle cx="0" cy="0" r="22" fill="none" stroke="currentColor" stroke-width="8"/>
+        <g class="jmc-r1">
+          <path d="M0,-28 A28,28 0 0,1 24.2,-14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+          <path d="M24.2,14 A28,28 0 0,1 0,28"  fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+          <path d="M-24.2,-14 A28,28 0 0,1 -24.2,14" fill="none" stroke="currentColor" stroke-width="0.6" stroke-linecap="round" opacity="0.4"/>
+        </g>
+        <g class="jmc-r2">
+          <path d="M0,-18 A18,18 0 0,1 18,0"  fill="none" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" opacity="0.7"/>
+          <path d="M0,18 A18,18 0 0,1 -18,0"  fill="none" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" opacity="0.7"/>
+        </g>
+        <circle cx="0" cy="0" r="6" fill="currentColor" stroke="currentColor" stroke-width="0.6" class="jmc-p"/>
+        <circle cx="0" cy="0" r="2.5" fill="currentColor"/>
+      </svg>
+      <span>JARVIS</span>
+    </a>
+
+    <!-- Onglets -->
+    <nav class="mc-nav" id="mc-nav">
+      <button class="mc-nav-btn" data-tab="workspace"     onclick="MCPage.show('workspace')">Workspace</button>
+      <button class="mc-nav-btn" data-tab="capacites"     onclick="MCPage.show('capacites')">Capacités</button>
+      <button class="mc-nav-btn" data-tab="configuration" onclick="MCPage.show('configuration')">Configuration</button>
+      <button class="mc-nav-btn" data-tab="interface"     onclick="MCPage.show('interface')">Interface</button>
+    </nav>
+
+    <!-- Indicateur logs (mode avancé) -->
+    <div class="mc-topbar-end" id="mc-topbar-end"></div>
+
+  </div>
+</header>
+
+<!-- Zone de contenu -->
+<main class="mc-main" id="mc-main">
+
+  <!-- Iframe pour les pages existantes -->
+  <iframe class="mc-iframe" id="mc-iframe" src="about:blank" frameborder="0" allowfullscreen allowtransparency="true"></iframe>
+
+  <!-- Panneau Interface (pas d'iframe) -->
+  <div class="mc-panel-interface" id="mc-panel-interface" style="display:none"></div>
+
+</main>
+
+<script src="/_shared.js"></script>
+<script src="/mc.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/mc.html.bak-1782260328
+++ b/src/jarvis/interfaces/ui/static/mc.html.bak-1782260328
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Mission Control</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
+<link rel="stylesheet" href="/mc.css" />
+</head>
+<body data-mode="mc">
+
+<!-- Topbar sticky -->
+<header class="mc-topbar" id="mc-topbar">
+  <div class="mc-topbar-inner">
+
+    <!-- Logo / retour home -->
+    <a href="/" class="mc-brand" title="Retour Home">
+      <svg width="36" height="36" viewBox="-36 -36 72 72" xmlns="http://www.w3.org/2000/svg" class="mc-arc-reactor" aria-hidden="true">
+        <style>
+          @keyframes jmc-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+          @keyframes jmc-spinrev { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+          @keyframes jmc-pulse { 0%,100%{opacity:0.5}50%{opacity:1} }
+          .jmc-r1 { transform-origin:0 0; animation: jmc-spin 8s linear infinite; }
+          .jmc-r2 { transform-origin:0 0; animation: jmc-spinrev 12s linear infinite; }
+          .jmc-p  { animation: jmc-pulse 2.4s ease-in-out infinite; }
+        </style>
+        <circle cx="0" cy="0" r="32" fill="none" stroke="currentColor" stroke-width="0.6" opacity="0.15"/>
+        <circle cx="0" cy="0" r="22" fill="none" stroke="currentColor" stroke-width="8" opacity="0.08"/>
+        <g class="jmc-r1">
+          <path d="M0,-28 A28,28 0 0,1 24.2,-14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+          <path d="M24.2,14 A28,28 0 0,1 0,28"  fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+          <path d="M-24.2,-14 A28,28 0 0,1 -24.2,14" fill="none" stroke="currentColor" stroke-width="0.6" stroke-linecap="round" opacity="0.4"/>
+        </g>
+        <g class="jmc-r2">
+          <path d="M0,-18 A18,18 0 0,1 18,0"  fill="none" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" opacity="0.7"/>
+          <path d="M0,18 A18,18 0 0,1 -18,0"  fill="none" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" opacity="0.7"/>
+        </g>
+        <circle cx="0" cy="0" r="6" fill="currentColor" stroke="none" opacity="0.2" class="jmc-p"/>
+        <circle cx="0" cy="0" r="2.5" fill="currentColor"/>
+      </svg>
+      <span>JARVIS</span>
+    </a>
+
+    <!-- Onglets -->
+    <nav class="mc-nav" id="mc-nav">
+      <button class="mc-nav-btn" data-tab="workspace"     onclick="MCPage.show('workspace')">Workspace</button>
+      <button class="mc-nav-btn" data-tab="capacites"     onclick="MCPage.show('capacites')">Capacités</button>
+      <button class="mc-nav-btn" data-tab="configuration" onclick="MCPage.show('configuration')">Configuration</button>
+      <button class="mc-nav-btn" data-tab="interface"     onclick="MCPage.show('interface')">Interface</button>
+    </nav>
+
+    <!-- Indicateur logs (mode avancé) -->
+    <div class="mc-topbar-end" id="mc-topbar-end"></div>
+
+  </div>
+</header>
+
+<!-- Zone de contenu -->
+<main class="mc-main" id="mc-main">
+
+  <!-- Iframe pour les pages existantes -->
+  <iframe class="mc-iframe" id="mc-iframe" src="about:blank" frameborder="0" allowfullscreen allowtransparency="true"></iframe>
+
+  <!-- Panneau Interface (pas d'iframe) -->
+  <div class="mc-panel-interface" id="mc-panel-interface" style="display:none"></div>
+
+</main>
+
+<script src="/_shared.js"></script>
+<script src="/mc.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/mc.html.bak-1782260403
+++ b/src/jarvis/interfaces/ui/static/mc.html.bak-1782260403
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Mission Control</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&family=Syne:wght@500;600&family=DM+Mono:wght@400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
+<link rel="stylesheet" href="/mc.css" />
+</head>
+<body data-mode="mc">
+
+<!-- Topbar sticky -->
+<header class="mc-topbar" id="mc-topbar">
+  <div class="mc-topbar-inner">
+
+    <!-- Logo / retour home -->
+    <a href="/" class="mc-brand" title="Retour Home">
+      <svg width="36" height="36" viewBox="-36 -36 72 72" xmlns="http://www.w3.org/2000/svg" class="mc-arc-reactor" aria-hidden="true">
+        <style>
+          @keyframes jmc-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+          @keyframes jmc-spinrev { from { transform: rotate(0deg); } to { transform: rotate(-360deg); } }
+          @keyframes jmc-pulse { 0%,100%{opacity:0.5}50%{opacity:1} }
+          .jmc-r1 { transform-origin:0 0; animation: jmc-spin 8s linear infinite; }
+          .jmc-r2 { transform-origin:0 0; animation: jmc-spinrev 12s linear infinite; }
+          .jmc-p  { animation: jmc-pulse 2.4s ease-in-out infinite; }
+        </style>
+        <circle cx="0" cy="0" r="32" fill="none" stroke="currentColor" stroke-width="0.6" opacity="0.35"/>
+        <circle cx="0" cy="0" r="22" fill="none" stroke="currentColor" stroke-width="8" opacity="0.15"/>
+        <g class="jmc-r1">
+          <path d="M0,-28 A28,28 0 0,1 24.2,-14" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+          <path d="M24.2,14 A28,28 0 0,1 0,28"  fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/>
+          <path d="M-24.2,-14 A28,28 0 0,1 -24.2,14" fill="none" stroke="currentColor" stroke-width="0.6" stroke-linecap="round" opacity="0.4"/>
+        </g>
+        <g class="jmc-r2">
+          <path d="M0,-18 A18,18 0 0,1 18,0"  fill="none" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" opacity="0.7"/>
+          <path d="M0,18 A18,18 0 0,1 -18,0"  fill="none" stroke="currentColor" stroke-width="0.8" stroke-linecap="round" opacity="0.7"/>
+        </g>
+        <circle cx="0" cy="0" r="6" fill="currentColor" stroke="none" opacity="0.35" class="jmc-p"/>
+        <circle cx="0" cy="0" r="2.5" fill="currentColor"/>
+      </svg>
+      <span>JARVIS</span>
+    </a>
+
+    <!-- Onglets -->
+    <nav class="mc-nav" id="mc-nav">
+      <button class="mc-nav-btn" data-tab="workspace"     onclick="MCPage.show('workspace')">Workspace</button>
+      <button class="mc-nav-btn" data-tab="capacites"     onclick="MCPage.show('capacites')">Capacités</button>
+      <button class="mc-nav-btn" data-tab="configuration" onclick="MCPage.show('configuration')">Configuration</button>
+      <button class="mc-nav-btn" data-tab="interface"     onclick="MCPage.show('interface')">Interface</button>
+    </nav>
+
+    <!-- Indicateur logs (mode avancé) -->
+    <div class="mc-topbar-end" id="mc-topbar-end"></div>
+
+  </div>
+</header>
+
+<!-- Zone de contenu -->
+<main class="mc-main" id="mc-main">
+
+  <!-- Iframe pour les pages existantes -->
+  <iframe class="mc-iframe" id="mc-iframe" src="about:blank" frameborder="0" allowfullscreen allowtransparency="true"></iframe>
+
+  <!-- Panneau Interface (pas d'iframe) -->
+  <div class="mc-panel-interface" id="mc-panel-interface" style="display:none"></div>
+
+</main>
+
+<script src="/_shared.js"></script>
+<script src="/mc.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/mc.js
+++ b/src/jarvis/interfaces/ui/static/mc.js
@@ -1,0 +1,338 @@
+/**
+ * mc.js — logique de la page Mission Control (/mc)
+ *
+ * Gère :
+ *  - Navigation par onglets (iframe pour workspace/capacites/config/logs,
+ *    panneau natif pour interface)
+ *  - Panneau Interface : thème CSS vars, export/import, reset, mode avancé
+ *  - Lecture/écriture localStorage pour le thème et le mode avancé
+ *  - Application du thème sauvegardé au boot (avant rendu)
+ */
+
+(function () {
+  'use strict';
+
+  /* ── Config ──────────────────────────────────────────────────────────── */
+
+  const TABS = [
+    { id: 'workspace',     label: 'Workspace',     href: '/dashboard'    },
+    { id: 'capacites',     label: 'Capacités',     href: '/capabilities' },
+    { id: 'configuration', label: 'Configuration', href: '/settings'     },
+    { id: 'interface',     label: 'Interface',     href: null            },
+    { id: 'logs',          label: 'Logs',          href: '/admin'        },
+  ];
+
+  const THEME_VARS = [
+    { key: '--bg-0',             label: 'Fond principal',  type: 'color', default: '#06080D' },
+    { key: '--accent',           label: 'Accent',          type: 'color', default: '#4A9EFF' },
+    { key: '--fg-0',             label: 'Texte principal', type: 'color', default: '#DCE8FF' },
+    { key: '--grain-opacity',    label: 'Grain',           type: 'range', default: 0.035, min: 0,   max: 0.12, step: 0.005 },
+    { key: '--vignette-opacity', label: 'Vignette',        type: 'range', default: 0.55,  min: 0,   max: 1,    step: 0.05  },
+  ];
+
+  const BASE_FONT_DEFAULT = 14;
+  const LS_THEME_KEY      = 'jarvis_theme_v1';
+  const LS_ADVANCED_KEY   = 'jarvis_advanced_mode';
+
+  /* ── Helpers DOM ─────────────────────────────────────────────────────── */
+
+  function h(tag, attrs, children) {
+    const el = document.createElement(tag);
+    if (attrs) Object.entries(attrs).forEach(([k, v]) => {
+      if      (k === 'class')   el.className = v;
+      else if (k === 'text')    el.textContent = v;
+      else if (k === 'onclick') el.addEventListener('click', v);
+      else                      el.setAttribute(k, v);
+    });
+    (children || []).forEach(c => c && el.appendChild(c));
+    return el;
+  }
+
+  /* ── Thème ───────────────────────────────────────────────────────────── */
+
+  function loadTheme() {
+    try { return JSON.parse(localStorage.getItem(LS_THEME_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+
+  function saveTheme(t) { localStorage.setItem(LS_THEME_KEY, JSON.stringify(t)); }
+
+  function applyTheme(patch) {
+    const root = document.documentElement;
+    THEME_VARS.forEach(v => {
+      if (patch[v.key] !== undefined) root.style.setProperty(v.key, patch[v.key]);
+    });
+    if (patch['--base-font-size']) {
+      root.style.setProperty('font-size', patch['--base-font-size'] + 'px');
+    }
+    /* Dériver accent-soft / accent-line depuis --accent */
+    const acc = patch['--accent'] || root.style.getPropertyValue('--accent');
+    if (acc && acc.startsWith('#') && acc.length === 7) {
+      const r = parseInt(acc.slice(1,3),16);
+      const g = parseInt(acc.slice(3,5),16);
+      const b = parseInt(acc.slice(5,7),16);
+      root.style.setProperty('--accent-soft', `rgba(${r},${g},${b},0.14)`);
+      root.style.setProperty('--accent-line', `rgba(${r},${g},${b},0.32)`);
+    }
+    /* Dériver fg-1..fg-4 depuis --fg-0 */
+    const fg = patch['--fg-0'] || root.style.getPropertyValue('--fg-0');
+    if (fg && fg.startsWith('#') && fg.length === 7) {
+      const r = parseInt(fg.slice(1,3),16);
+      const g = parseInt(fg.slice(3,5),16);
+      const b = parseInt(fg.slice(5,7),16);
+      root.style.setProperty('--fg-1', `rgba(${r},${g},${b},0.78)`);
+      root.style.setProperty('--fg-2', `rgba(${r},${g},${b},0.55)`);
+      root.style.setProperty('--fg-3', `rgba(${r},${g},${b},0.36)`);
+      root.style.setProperty('--fg-4', `rgba(${r},${g},${b},0.20)`);
+    }
+  }
+
+  /* Appliquer le thème sauvegardé immédiatement */
+  applyTheme(loadTheme());
+
+  /* ── Mode avancé ─────────────────────────────────────────────────────── */
+
+  function isAdvanced() { return localStorage.getItem(LS_ADVANCED_KEY) === '1'; }
+  function setAdvanced(v) { localStorage.setItem(LS_ADVANCED_KEY, v ? '1' : '0'); }
+
+  /* ── Navigation onglets ──────────────────────────────────────────────── */
+
+  let _activeTab = null;
+
+  const iframe = document.getElementById('mc-iframe');
+  const ifacePanel = document.getElementById('mc-panel-interface');
+
+  window.MCPage = {
+    show: function(tabId) {
+      /* Si logs et pas mode avancé, ignorer */
+      if (tabId === 'logs' && !isAdvanced()) return;
+
+      _activeTab = tabId;
+
+      /* Mettre à jour les boutons nav */
+      document.querySelectorAll('.mc-nav-btn').forEach(b => {
+        b.classList.toggle('is-active', b.dataset.tab === tabId);
+      });
+
+      const tab = TABS.find(t => t.id === tabId);
+      if (!tab) return;
+
+      if (tab.href) {
+        /* Charger dans l'iframe */
+        ifacePanel.style.display = 'none';
+        iframe.classList.remove('is-hidden');
+        if (iframe.dataset.src !== tab.href) {
+          iframe.src = tab.href;
+          iframe.dataset.src = tab.href;
+        }
+      } else {
+        /* Panneau Interface natif */
+        iframe.classList.add('is-hidden');
+        ifacePanel.style.display = 'flex';
+        if (!ifacePanel.dataset.built) {
+          buildInterfacePanel(ifacePanel);
+          ifacePanel.dataset.built = '1';
+        }
+      }
+    },
+  };
+
+  /* ── Bouton Logs en mode avancé ──────────────────────────────────────── */
+
+  function refreshLogsBtn() {
+    const end = document.getElementById('mc-topbar-end');
+    if (!end) return;
+    end.innerHTML = '';
+    if (isAdvanced()) {
+      const btn = h('button', {
+        class: 'mc-logs-btn' + (_activeTab === 'logs' ? ' is-active' : ''),
+        text:  'Logs',
+        onclick: () => MCPage.show('logs'),
+      });
+      end.appendChild(btn);
+    }
+  }
+
+  /* ── Panneau Interface ───────────────────────────────────────────────── */
+
+  function buildInterfacePanel(root) {
+    const theme   = loadTheme();
+    const pending = {};
+
+    function section(label) {
+      const s = h('div', { class: 'mci-section' });
+      s.appendChild(h('div', { class: 'mci-section-label', text: label }));
+      return s;
+    }
+
+    /* ── Apparence ── */
+    const secApp = section('APPARENCE');
+
+    THEME_VARS.forEach(v => {
+      const row = h('div', { class: 'mci-row' });
+      row.appendChild(h('label', { class: 'mci-label', text: v.label }));
+      const cur = theme[v.key] !== undefined ? theme[v.key] : v.default;
+
+      if (v.type === 'color') {
+        const wrap = h('div', { class: 'mci-color-wrap' });
+        const inp  = h('input', { type: 'color', class: 'mci-color-input', value: cur });
+        const hex  = h('span',  { class: 'mci-color-hex', text: cur });
+        inp.addEventListener('input', () => {
+          hex.textContent = inp.value;
+          pending[v.key]  = inp.value;
+          const merged = Object.assign({}, loadTheme(), pending);
+          saveTheme(merged);
+          applyTheme(merged);
+        });
+        wrap.appendChild(inp); wrap.appendChild(hex);
+        row.appendChild(wrap);
+      } else {
+        const wrap = h('div', { class: 'mci-range-wrap' });
+        const inp  = h('input', { type: 'range', class: 'mci-range-input',
+          min: String(v.min), max: String(v.max), step: String(v.step), value: String(cur) });
+        const val  = h('span', { class: 'mci-range-val', text: String(cur) });
+        inp.addEventListener('input', () => {
+          val.textContent = inp.value;
+          pending[v.key]  = inp.value;
+          const merged = Object.assign({}, loadTheme(), pending);
+          saveTheme(merged);
+          applyTheme(merged);
+        });
+        wrap.appendChild(inp); wrap.appendChild(val);
+        row.appendChild(wrap);
+      }
+      secApp.appendChild(row);
+    });
+
+    /* Taille texte */
+    const fontRow  = h('div', { class: 'mci-row' });
+    const curFont  = theme['--base-font-size'] || BASE_FONT_DEFAULT;
+    fontRow.appendChild(h('label', { class: 'mci-label', text: 'Taille texte' }));
+    const fontWrap = h('div', { class: 'mci-range-wrap' });
+    const fontInp  = h('input', { type: 'range', class: 'mci-range-input',
+      min: '11', max: '24', step: '1', value: String(curFont) });
+    const fontVal  = h('span', { class: 'mci-range-val', text: curFont + 'px' });
+    fontInp.addEventListener('input', () => {
+      fontVal.textContent = fontInp.value + 'px';
+      pending['--base-font-size'] = Number(fontInp.value);
+      const merged = Object.assign({}, loadTheme(), pending);
+      saveTheme(merged);
+      applyTheme(merged);
+    });
+    fontWrap.appendChild(fontInp); fontWrap.appendChild(fontVal);
+    fontRow.appendChild(fontWrap);
+    secApp.appendChild(fontRow);
+    root.appendChild(secApp);
+
+    /* ── Mode avancé ── */
+    const secAdv = section('MODE AVANCÉ');
+    const advRow = h('div', { class: 'mci-row mci-row--toggle' });
+    const advGrp = h('div', { class: 'mci-toggle-group' });
+    advGrp.appendChild(h('span', { class: 'mci-sublabel', text: 'Expose les logs Jarvis dans la topbar' }));
+
+    const toggle = h('button', {
+      class: 'mci-toggle' + (isAdvanced() ? ' is-on' : ''),
+      'aria-pressed': isAdvanced() ? 'true' : 'false',
+    });
+    const track = h('span', { class: 'mci-toggle-track' });
+    track.appendChild(h('span', { class: 'mci-toggle-thumb' }));
+    toggle.appendChild(track);
+    toggle.addEventListener('click', () => {
+      const next = !isAdvanced();
+      setAdvanced(next);
+      toggle.classList.toggle('is-on', next);
+      toggle.setAttribute('aria-pressed', next ? 'true' : 'false');
+      refreshLogsBtn();
+    });
+
+    advGrp.appendChild(toggle);
+    advRow.appendChild(h('span', { class: 'mci-label', text: 'Mode avancé' }));
+    advRow.appendChild(advGrp);
+    secAdv.appendChild(advRow);
+    root.appendChild(secAdv);
+
+    /* ── Thème export / import / reset ── */
+    const secTheme = section('THÈME');
+    const actRow   = h('div', { class: 'mci-row mci-actions' });
+
+    const exportBtn = h('button', { class: 'mci-btn', text: '↓ Exporter', onclick: () => {
+      const blob = new Blob([JSON.stringify(loadTheme(), null, 2)], { type: 'application/json' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'jarvis-theme.json';
+      a.click();
+      URL.revokeObjectURL(a.href);
+    }});
+
+    const fileInput = h('input', { type: 'file', class: 'mci-file-input', accept: '.json' });
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = e => {
+        try {
+          const imported = JSON.parse(e.target.result);
+          saveTheme(imported);
+          applyTheme(imported);
+          /* Reconstruire le panneau pour refléter les nouvelles valeurs */
+          root.innerHTML = '';
+          root.removeAttribute('data-built');
+          buildInterfacePanel(root);
+          root.dataset.built = '1';
+        } catch (err) {
+          console.error('[MC] Import thème invalide', err);
+        }
+      };
+      reader.readAsText(file);
+    });
+    const importBtn = h('button', { class: 'mci-btn', text: '↑ Importer', onclick: () => fileInput.click() });
+
+    const resetBtn = h('button', { class: 'mci-btn mci-btn--danger', text: 'Réinitialiser', onclick: () => {
+      localStorage.removeItem(LS_THEME_KEY);
+      const r = document.documentElement;
+      THEME_VARS.forEach(v => r.style.removeProperty(v.key));
+      ['--accent-soft','--accent-line','--fg-1','--fg-2','--fg-3','--fg-4','font-size'].forEach(p => r.style.removeProperty(p));
+      root.innerHTML = '';
+      root.removeAttribute('data-built');
+      buildInterfacePanel(root);
+      root.dataset.built = '1';
+    }});
+
+    actRow.appendChild(exportBtn);
+    actRow.appendChild(importBtn);
+    actRow.appendChild(resetBtn);
+    actRow.appendChild(fileInput);
+    secTheme.appendChild(actRow);
+    root.appendChild(secTheme);
+  }
+
+  /* ── Init ────────────────────────────────────────────────────────────── */
+
+  document.addEventListener('DOMContentLoaded', function () {
+    /* Effet atmosphère (aurora, vignette, grain) */
+    if (window.Jarvis && typeof Jarvis.mountAtmosphere === 'function') {
+      Jarvis.mountAtmosphere();
+    }
+    /* Bouton Logs si mode avancé actif */
+    refreshLogsBtn();
+
+    /* Ouvrir l'onglet depuis l'URL hash ou workspace par défaut */
+    const hash = window.location.hash.replace('#', '');
+    const valid = TABS.map(t => t.id);
+    const initial = valid.includes(hash) ? hash : 'workspace';
+    MCPage.show(initial);
+
+    /* Mettre à jour le hash à la nav */
+    const origShow = MCPage.show;
+    MCPage.show = function(tabId) {
+      origShow(tabId);
+      history.replaceState(null, '', '#' + tabId);
+    };
+  });
+
+  /* ── Raccourci : Escape → retour Home ───────────────────────────────── */
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') window.location.href = '/';
+  });
+
+})();

--- a/src/jarvis/interfaces/ui/static/mc.js
+++ b/src/jarvis/interfaces/ui/static/mc.js
@@ -19,7 +19,7 @@
     { id: 'capacites',     label: 'Capacités',     href: '/capabilities' },
     { id: 'configuration', label: 'Configuration', href: '/settings'     },
     { id: 'interface',     label: 'Interface',     href: null            },
-    { id: 'logs',          label: 'Logs',          href: '/admin'        },
+    /* logs désactivé temporairement */
   ];
 
   const THEME_VARS = [
@@ -124,6 +124,35 @@
         if (iframe.dataset.src !== tab.href) {
           iframe.src = tab.href;
           iframe.dataset.src = tab.href;
+          /* Injecter le thème dans l'iframe après chargement */
+          iframe.onload = function () {
+            try {
+              const doc = iframe.contentDocument;
+              if (!doc) return;
+              const existing = doc.getElementById('jarvis-theme-inject');
+              if (existing) existing.remove();
+              const t = loadTheme();
+              const bg   = t['--bg-0']   || '#06080D';
+              const acc  = t['--accent'] || '#4A9EFF';
+              const fg   = t['--fg-0']   || '#DCE8FF';
+              const r = parseInt(acc.slice(1,3),16);
+              const g = parseInt(acc.slice(3,5),16);
+              const b = parseInt(acc.slice(5,7),16);
+              const style = doc.createElement('style');
+              style.id = 'jarvis-theme-inject';
+              style.textContent = ':root {'
+                + '--bg:' + bg + ';'
+                + '--b1:' + acc + ';'
+                + '--b2:rgba(' + r + ',' + g + ',' + b + ',0.55);'
+                + '--b3:rgba(' + r + ',' + g + ',' + b + ',0.18);'
+                + '--b4:rgba(' + r + ',' + g + ',' + b + ',0.08);'
+                + '--panel:' + bg + ';'
+                + '--glass:' + bg + ';'
+                + '--text:' + fg + ';'
+                + '}';
+              doc.head.appendChild(style);
+            } catch(e) {}
+          };
         }
       } else {
         /* Panneau Interface natif */
@@ -139,19 +168,7 @@
 
   /* ── Bouton Logs en mode avancé ──────────────────────────────────────── */
 
-  function refreshLogsBtn() {
-    const end = document.getElementById('mc-topbar-end');
-    if (!end) return;
-    end.innerHTML = '';
-    if (isAdvanced()) {
-      const btn = h('button', {
-        class: 'mc-logs-btn' + (_activeTab === 'logs' ? ' is-active' : ''),
-        text:  'Logs',
-        onclick: () => MCPage.show('logs'),
-      });
-      end.appendChild(btn);
-    }
-  }
+  function refreshLogsBtn() { /* logs désactivé temporairement */ }
 
   /* ── Panneau Interface ───────────────────────────────────────────────── */
 
@@ -175,16 +192,35 @@
 
       if (v.type === 'color') {
         const wrap = h('div', { class: 'mci-color-wrap' });
-        const inp  = h('input', { type: 'color', class: 'mci-color-input', value: cur });
-        const hex  = h('span',  { class: 'mci-color-hex', text: cur });
-        inp.addEventListener('input', () => {
-          hex.textContent = inp.value;
-          pending[v.key]  = inp.value;
-          const merged = Object.assign({}, loadTheme(), pending);
-          saveTheme(merged);
-          applyTheme(merged);
+        const swatch = h('div', { class: 'mci-color-swatch' });
+        swatch.style.cssText = 'width:28px;height:28px;border-radius:6px;background:'+cur+';border:1.5px solid var(--line-3);cursor:pointer;flex-shrink:0;box-shadow:0 0 0 1px var(--line-1);';
+        const hexLabel = h('span', { class: 'mci-color-hex', text: cur });
+
+        let picker = null;
+        const pickerWrap = h('div');
+        pickerWrap.style.cssText = 'grid-column:1/-1; position:relative;';
+
+        swatch.addEventListener('click', () => {
+          if (!picker) {
+            picker = new JarvisColorPicker({
+              value: pending[v.key] || cur,
+              onChange: (hex) => {
+                swatch.style.background = hex;
+                hexLabel.textContent = hex;
+                pending[v.key] = hex;
+                const merged = Object.assign({}, loadTheme(), pending);
+                saveTheme(merged);
+                applyTheme(merged);
+              }
+            });
+            pickerWrap.appendChild(picker.el);
+            row.parentNode.insertBefore(pickerWrap, row.nextSibling);
+          }
+          picker.toggle();
         });
-        wrap.appendChild(inp); wrap.appendChild(hex);
+
+        wrap.appendChild(swatch);
+        wrap.appendChild(hexLabel);
         row.appendChild(wrap);
       } else {
         const wrap = h('div', { class: 'mci-range-wrap' });
@@ -249,7 +285,7 @@
     advRow.appendChild(h('span', { class: 'mci-label', text: 'Mode avancé' }));
     advRow.appendChild(advGrp);
     secAdv.appendChild(advRow);
-    root.appendChild(secAdv);
+    /* root.appendChild(secAdv); — mode avancé masqué temporairement */
 
     /* ── Thème export / import / reset ── */
     const secTheme = section('THÈME');

--- a/src/jarvis/interfaces/ui/static/mc.js.bak-1782256193
+++ b/src/jarvis/interfaces/ui/static/mc.js.bak-1782256193
@@ -1,0 +1,335 @@
+/**
+ * mc.js — logique de la page Mission Control (/mc)
+ *
+ * Gère :
+ *  - Navigation par onglets (iframe pour workspace/capacites/config/logs,
+ *    panneau natif pour interface)
+ *  - Panneau Interface : thème CSS vars, export/import, reset, mode avancé
+ *  - Lecture/écriture localStorage pour le thème et le mode avancé
+ *  - Application du thème sauvegardé au boot (avant rendu)
+ */
+
+(function () {
+  'use strict';
+
+  /* ── Config ──────────────────────────────────────────────────────────── */
+
+  const TABS = [
+    { id: 'workspace',     label: 'Workspace',     href: '/dashboard'    },
+    { id: 'capacites',     label: 'Capacités',     href: '/capabilities' },
+    { id: 'configuration', label: 'Configuration', href: '/settings'     },
+    { id: 'interface',     label: 'Interface',     href: null            },
+    { id: 'logs',          label: 'Logs',          href: '/admin'        },
+  ];
+
+  const THEME_VARS = [
+    { key: '--bg-0',             label: 'Fond principal',  type: 'color', default: '#06080D' },
+    { key: '--bg-2',             label: 'Fond surfaces',   type: 'color', default: '#0F141F' },
+    { key: '--accent',           label: 'Accent',          type: 'color', default: '#4A9EFF' },
+    { key: '--fg-0',             label: 'Texte principal', type: 'color', default: '#DCE8FF' },
+    { key: '--grain-opacity',    label: 'Grain',           type: 'range', default: 0.035, min: 0,   max: 0.12, step: 0.005 },
+    { key: '--vignette-opacity', label: 'Vignette',        type: 'range', default: 0.55,  min: 0,   max: 1,    step: 0.05  },
+  ];
+
+  const BASE_FONT_DEFAULT = 14;
+  const LS_THEME_KEY      = 'jarvis_theme_v1';
+  const LS_ADVANCED_KEY   = 'jarvis_advanced_mode';
+
+  /* ── Helpers DOM ─────────────────────────────────────────────────────── */
+
+  function h(tag, attrs, children) {
+    const el = document.createElement(tag);
+    if (attrs) Object.entries(attrs).forEach(([k, v]) => {
+      if      (k === 'class')   el.className = v;
+      else if (k === 'text')    el.textContent = v;
+      else if (k === 'onclick') el.addEventListener('click', v);
+      else                      el.setAttribute(k, v);
+    });
+    (children || []).forEach(c => c && el.appendChild(c));
+    return el;
+  }
+
+  /* ── Thème ───────────────────────────────────────────────────────────── */
+
+  function loadTheme() {
+    try { return JSON.parse(localStorage.getItem(LS_THEME_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+
+  function saveTheme(t) { localStorage.setItem(LS_THEME_KEY, JSON.stringify(t)); }
+
+  function applyTheme(patch) {
+    const root = document.documentElement;
+    THEME_VARS.forEach(v => {
+      if (patch[v.key] !== undefined) root.style.setProperty(v.key, patch[v.key]);
+    });
+    if (patch['--base-font-size']) {
+      root.style.setProperty('font-size', patch['--base-font-size'] + 'px');
+    }
+    /* Dériver accent-soft / accent-line depuis --accent */
+    const acc = patch['--accent'] || root.style.getPropertyValue('--accent');
+    if (acc && acc.startsWith('#') && acc.length === 7) {
+      const r = parseInt(acc.slice(1,3),16);
+      const g = parseInt(acc.slice(3,5),16);
+      const b = parseInt(acc.slice(5,7),16);
+      root.style.setProperty('--accent-soft', `rgba(${r},${g},${b},0.14)`);
+      root.style.setProperty('--accent-line', `rgba(${r},${g},${b},0.32)`);
+    }
+    /* Dériver fg-1..fg-4 depuis --fg-0 */
+    const fg = patch['--fg-0'] || root.style.getPropertyValue('--fg-0');
+    if (fg && fg.startsWith('#') && fg.length === 7) {
+      const r = parseInt(fg.slice(1,3),16);
+      const g = parseInt(fg.slice(3,5),16);
+      const b = parseInt(fg.slice(5,7),16);
+      root.style.setProperty('--fg-1', `rgba(${r},${g},${b},0.78)`);
+      root.style.setProperty('--fg-2', `rgba(${r},${g},${b},0.55)`);
+      root.style.setProperty('--fg-3', `rgba(${r},${g},${b},0.36)`);
+      root.style.setProperty('--fg-4', `rgba(${r},${g},${b},0.20)`);
+    }
+  }
+
+  /* Appliquer le thème sauvegardé immédiatement */
+  applyTheme(loadTheme());
+
+  /* ── Mode avancé ─────────────────────────────────────────────────────── */
+
+  function isAdvanced() { return localStorage.getItem(LS_ADVANCED_KEY) === '1'; }
+  function setAdvanced(v) { localStorage.setItem(LS_ADVANCED_KEY, v ? '1' : '0'); }
+
+  /* ── Navigation onglets ──────────────────────────────────────────────── */
+
+  let _activeTab = null;
+
+  const iframe = document.getElementById('mc-iframe');
+  const ifacePanel = document.getElementById('mc-panel-interface');
+
+  window.MCPage = {
+    show: function(tabId) {
+      /* Si logs et pas mode avancé, ignorer */
+      if (tabId === 'logs' && !isAdvanced()) return;
+
+      _activeTab = tabId;
+
+      /* Mettre à jour les boutons nav */
+      document.querySelectorAll('.mc-nav-btn').forEach(b => {
+        b.classList.toggle('is-active', b.dataset.tab === tabId);
+      });
+
+      const tab = TABS.find(t => t.id === tabId);
+      if (!tab) return;
+
+      if (tab.href) {
+        /* Charger dans l'iframe */
+        ifacePanel.style.display = 'none';
+        iframe.classList.remove('is-hidden');
+        if (iframe.dataset.src !== tab.href) {
+          iframe.src = tab.href;
+          iframe.dataset.src = tab.href;
+        }
+      } else {
+        /* Panneau Interface natif */
+        iframe.classList.add('is-hidden');
+        ifacePanel.style.display = 'flex';
+        if (!ifacePanel.dataset.built) {
+          buildInterfacePanel(ifacePanel);
+          ifacePanel.dataset.built = '1';
+        }
+      }
+    },
+  };
+
+  /* ── Bouton Logs en mode avancé ──────────────────────────────────────── */
+
+  function refreshLogsBtn() {
+    const end = document.getElementById('mc-topbar-end');
+    if (!end) return;
+    end.innerHTML = '';
+    if (isAdvanced()) {
+      const btn = h('button', {
+        class: 'mc-logs-btn' + (_activeTab === 'logs' ? ' is-active' : ''),
+        text:  'Logs',
+        onclick: () => MCPage.show('logs'),
+      });
+      end.appendChild(btn);
+    }
+  }
+
+  /* ── Panneau Interface ───────────────────────────────────────────────── */
+
+  function buildInterfacePanel(root) {
+    const theme   = loadTheme();
+    const pending = {};
+
+    function section(label) {
+      const s = h('div', { class: 'mci-section' });
+      s.appendChild(h('div', { class: 'mci-section-label', text: label }));
+      return s;
+    }
+
+    /* ── Apparence ── */
+    const secApp = section('APPARENCE');
+
+    THEME_VARS.forEach(v => {
+      const row = h('div', { class: 'mci-row' });
+      row.appendChild(h('label', { class: 'mci-label', text: v.label }));
+      const cur = theme[v.key] !== undefined ? theme[v.key] : v.default;
+
+      if (v.type === 'color') {
+        const wrap = h('div', { class: 'mci-color-wrap' });
+        const inp  = h('input', { type: 'color', class: 'mci-color-input', value: cur });
+        const hex  = h('span',  { class: 'mci-color-hex', text: cur });
+        inp.addEventListener('input', () => {
+          hex.textContent = inp.value;
+          pending[v.key]  = inp.value;
+          const merged = Object.assign({}, loadTheme(), pending);
+          saveTheme(merged);
+          applyTheme(merged);
+        });
+        wrap.appendChild(inp); wrap.appendChild(hex);
+        row.appendChild(wrap);
+      } else {
+        const wrap = h('div', { class: 'mci-range-wrap' });
+        const inp  = h('input', { type: 'range', class: 'mci-range-input',
+          min: String(v.min), max: String(v.max), step: String(v.step), value: String(cur) });
+        const val  = h('span', { class: 'mci-range-val', text: String(cur) });
+        inp.addEventListener('input', () => {
+          val.textContent = inp.value;
+          pending[v.key]  = inp.value;
+          const merged = Object.assign({}, loadTheme(), pending);
+          saveTheme(merged);
+          applyTheme(merged);
+        });
+        wrap.appendChild(inp); wrap.appendChild(val);
+        row.appendChild(wrap);
+      }
+      secApp.appendChild(row);
+    });
+
+    /* Taille texte */
+    const fontRow  = h('div', { class: 'mci-row' });
+    const curFont  = theme['--base-font-size'] || BASE_FONT_DEFAULT;
+    fontRow.appendChild(h('label', { class: 'mci-label', text: 'Taille texte' }));
+    const fontWrap = h('div', { class: 'mci-range-wrap' });
+    const fontInp  = h('input', { type: 'range', class: 'mci-range-input',
+      min: '11', max: '18', step: '1', value: String(curFont) });
+    const fontVal  = h('span', { class: 'mci-range-val', text: curFont + 'px' });
+    fontInp.addEventListener('input', () => {
+      fontVal.textContent = fontInp.value + 'px';
+      pending['--base-font-size'] = Number(fontInp.value);
+      const merged = Object.assign({}, loadTheme(), pending);
+      saveTheme(merged);
+      applyTheme(merged);
+    });
+    fontWrap.appendChild(fontInp); fontWrap.appendChild(fontVal);
+    fontRow.appendChild(fontWrap);
+    secApp.appendChild(fontRow);
+    root.appendChild(secApp);
+
+    /* ── Mode avancé ── */
+    const secAdv = section('MODE AVANCÉ');
+    const advRow = h('div', { class: 'mci-row mci-row--toggle' });
+    const advGrp = h('div', { class: 'mci-toggle-group' });
+    advGrp.appendChild(h('span', { class: 'mci-sublabel', text: 'Expose les logs Jarvis dans la topbar' }));
+
+    const toggle = h('button', {
+      class: 'mci-toggle' + (isAdvanced() ? ' is-on' : ''),
+      'aria-pressed': isAdvanced() ? 'true' : 'false',
+    });
+    const track = h('span', { class: 'mci-toggle-track' });
+    track.appendChild(h('span', { class: 'mci-toggle-thumb' }));
+    toggle.appendChild(track);
+    toggle.addEventListener('click', () => {
+      const next = !isAdvanced();
+      setAdvanced(next);
+      toggle.classList.toggle('is-on', next);
+      toggle.setAttribute('aria-pressed', next ? 'true' : 'false');
+      refreshLogsBtn();
+    });
+
+    advGrp.appendChild(toggle);
+    advRow.appendChild(h('span', { class: 'mci-label', text: 'Mode avancé' }));
+    advRow.appendChild(advGrp);
+    secAdv.appendChild(advRow);
+    root.appendChild(secAdv);
+
+    /* ── Thème export / import / reset ── */
+    const secTheme = section('THÈME');
+    const actRow   = h('div', { class: 'mci-row mci-actions' });
+
+    const exportBtn = h('button', { class: 'mci-btn', text: '↓ Exporter', onclick: () => {
+      const blob = new Blob([JSON.stringify(loadTheme(), null, 2)], { type: 'application/json' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'jarvis-theme.json';
+      a.click();
+      URL.revokeObjectURL(a.href);
+    }});
+
+    const fileInput = h('input', { type: 'file', class: 'mci-file-input', accept: '.json' });
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = e => {
+        try {
+          const imported = JSON.parse(e.target.result);
+          saveTheme(imported);
+          applyTheme(imported);
+          /* Reconstruire le panneau pour refléter les nouvelles valeurs */
+          root.innerHTML = '';
+          root.removeAttribute('data-built');
+          buildInterfacePanel(root);
+          root.dataset.built = '1';
+        } catch (err) {
+          console.error('[MC] Import thème invalide', err);
+        }
+      };
+      reader.readAsText(file);
+    });
+    const importBtn = h('button', { class: 'mci-btn', text: '↑ Importer', onclick: () => fileInput.click() });
+
+    const resetBtn = h('button', { class: 'mci-btn mci-btn--danger', text: 'Réinitialiser', onclick: () => {
+      localStorage.removeItem(LS_THEME_KEY);
+      const r = document.documentElement;
+      THEME_VARS.forEach(v => r.style.removeProperty(v.key));
+      ['--accent-soft','--accent-line','--fg-1','--fg-2','--fg-3','--fg-4','font-size'].forEach(p => r.style.removeProperty(p));
+      root.innerHTML = '';
+      root.removeAttribute('data-built');
+      buildInterfacePanel(root);
+      root.dataset.built = '1';
+    }});
+
+    actRow.appendChild(exportBtn);
+    actRow.appendChild(importBtn);
+    actRow.appendChild(resetBtn);
+    actRow.appendChild(fileInput);
+    secTheme.appendChild(actRow);
+    root.appendChild(secTheme);
+  }
+
+  /* ── Init ────────────────────────────────────────────────────────────── */
+
+  document.addEventListener('DOMContentLoaded', function () {
+    /* Bouton Logs si mode avancé actif */
+    refreshLogsBtn();
+
+    /* Ouvrir l'onglet depuis l'URL hash ou workspace par défaut */
+    const hash = window.location.hash.replace('#', '');
+    const valid = TABS.map(t => t.id);
+    const initial = valid.includes(hash) ? hash : 'workspace';
+    MCPage.show(initial);
+
+    /* Mettre à jour le hash à la nav */
+    const origShow = MCPage.show;
+    MCPage.show = function(tabId) {
+      origShow(tabId);
+      history.replaceState(null, '', '#' + tabId);
+    };
+  });
+
+  /* ── Raccourci : Escape → retour Home ───────────────────────────────── */
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') window.location.href = '/';
+  });
+
+})();

--- a/src/jarvis/interfaces/ui/static/mc.js.bak-1782257126
+++ b/src/jarvis/interfaces/ui/static/mc.js.bak-1782257126
@@ -1,0 +1,334 @@
+/**
+ * mc.js — logique de la page Mission Control (/mc)
+ *
+ * Gère :
+ *  - Navigation par onglets (iframe pour workspace/capacites/config/logs,
+ *    panneau natif pour interface)
+ *  - Panneau Interface : thème CSS vars, export/import, reset, mode avancé
+ *  - Lecture/écriture localStorage pour le thème et le mode avancé
+ *  - Application du thème sauvegardé au boot (avant rendu)
+ */
+
+(function () {
+  'use strict';
+
+  /* ── Config ──────────────────────────────────────────────────────────── */
+
+  const TABS = [
+    { id: 'workspace',     label: 'Workspace',     href: '/dashboard'    },
+    { id: 'capacites',     label: 'Capacités',     href: '/capabilities' },
+    { id: 'configuration', label: 'Configuration', href: '/settings'     },
+    { id: 'interface',     label: 'Interface',     href: null            },
+    { id: 'logs',          label: 'Logs',          href: '/admin'        },
+  ];
+
+  const THEME_VARS = [
+    { key: '--bg-0',             label: 'Fond principal',  type: 'color', default: '#06080D' },
+    { key: '--accent',           label: 'Accent',          type: 'color', default: '#4A9EFF' },
+    { key: '--fg-0',             label: 'Texte principal', type: 'color', default: '#DCE8FF' },
+    { key: '--grain-opacity',    label: 'Grain',           type: 'range', default: 0.035, min: 0,   max: 0.12, step: 0.005 },
+    { key: '--vignette-opacity', label: 'Vignette',        type: 'range', default: 0.55,  min: 0,   max: 1,    step: 0.05  },
+  ];
+
+  const BASE_FONT_DEFAULT = 14;
+  const LS_THEME_KEY      = 'jarvis_theme_v1';
+  const LS_ADVANCED_KEY   = 'jarvis_advanced_mode';
+
+  /* ── Helpers DOM ─────────────────────────────────────────────────────── */
+
+  function h(tag, attrs, children) {
+    const el = document.createElement(tag);
+    if (attrs) Object.entries(attrs).forEach(([k, v]) => {
+      if      (k === 'class')   el.className = v;
+      else if (k === 'text')    el.textContent = v;
+      else if (k === 'onclick') el.addEventListener('click', v);
+      else                      el.setAttribute(k, v);
+    });
+    (children || []).forEach(c => c && el.appendChild(c));
+    return el;
+  }
+
+  /* ── Thème ───────────────────────────────────────────────────────────── */
+
+  function loadTheme() {
+    try { return JSON.parse(localStorage.getItem(LS_THEME_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+
+  function saveTheme(t) { localStorage.setItem(LS_THEME_KEY, JSON.stringify(t)); }
+
+  function applyTheme(patch) {
+    const root = document.documentElement;
+    THEME_VARS.forEach(v => {
+      if (patch[v.key] !== undefined) root.style.setProperty(v.key, patch[v.key]);
+    });
+    if (patch['--base-font-size']) {
+      root.style.setProperty('font-size', patch['--base-font-size'] + 'px');
+    }
+    /* Dériver accent-soft / accent-line depuis --accent */
+    const acc = patch['--accent'] || root.style.getPropertyValue('--accent');
+    if (acc && acc.startsWith('#') && acc.length === 7) {
+      const r = parseInt(acc.slice(1,3),16);
+      const g = parseInt(acc.slice(3,5),16);
+      const b = parseInt(acc.slice(5,7),16);
+      root.style.setProperty('--accent-soft', `rgba(${r},${g},${b},0.14)`);
+      root.style.setProperty('--accent-line', `rgba(${r},${g},${b},0.32)`);
+    }
+    /* Dériver fg-1..fg-4 depuis --fg-0 */
+    const fg = patch['--fg-0'] || root.style.getPropertyValue('--fg-0');
+    if (fg && fg.startsWith('#') && fg.length === 7) {
+      const r = parseInt(fg.slice(1,3),16);
+      const g = parseInt(fg.slice(3,5),16);
+      const b = parseInt(fg.slice(5,7),16);
+      root.style.setProperty('--fg-1', `rgba(${r},${g},${b},0.78)`);
+      root.style.setProperty('--fg-2', `rgba(${r},${g},${b},0.55)`);
+      root.style.setProperty('--fg-3', `rgba(${r},${g},${b},0.36)`);
+      root.style.setProperty('--fg-4', `rgba(${r},${g},${b},0.20)`);
+    }
+  }
+
+  /* Appliquer le thème sauvegardé immédiatement */
+  applyTheme(loadTheme());
+
+  /* ── Mode avancé ─────────────────────────────────────────────────────── */
+
+  function isAdvanced() { return localStorage.getItem(LS_ADVANCED_KEY) === '1'; }
+  function setAdvanced(v) { localStorage.setItem(LS_ADVANCED_KEY, v ? '1' : '0'); }
+
+  /* ── Navigation onglets ──────────────────────────────────────────────── */
+
+  let _activeTab = null;
+
+  const iframe = document.getElementById('mc-iframe');
+  const ifacePanel = document.getElementById('mc-panel-interface');
+
+  window.MCPage = {
+    show: function(tabId) {
+      /* Si logs et pas mode avancé, ignorer */
+      if (tabId === 'logs' && !isAdvanced()) return;
+
+      _activeTab = tabId;
+
+      /* Mettre à jour les boutons nav */
+      document.querySelectorAll('.mc-nav-btn').forEach(b => {
+        b.classList.toggle('is-active', b.dataset.tab === tabId);
+      });
+
+      const tab = TABS.find(t => t.id === tabId);
+      if (!tab) return;
+
+      if (tab.href) {
+        /* Charger dans l'iframe */
+        ifacePanel.style.display = 'none';
+        iframe.classList.remove('is-hidden');
+        if (iframe.dataset.src !== tab.href) {
+          iframe.src = tab.href;
+          iframe.dataset.src = tab.href;
+        }
+      } else {
+        /* Panneau Interface natif */
+        iframe.classList.add('is-hidden');
+        ifacePanel.style.display = 'flex';
+        if (!ifacePanel.dataset.built) {
+          buildInterfacePanel(ifacePanel);
+          ifacePanel.dataset.built = '1';
+        }
+      }
+    },
+  };
+
+  /* ── Bouton Logs en mode avancé ──────────────────────────────────────── */
+
+  function refreshLogsBtn() {
+    const end = document.getElementById('mc-topbar-end');
+    if (!end) return;
+    end.innerHTML = '';
+    if (isAdvanced()) {
+      const btn = h('button', {
+        class: 'mc-logs-btn' + (_activeTab === 'logs' ? ' is-active' : ''),
+        text:  'Logs',
+        onclick: () => MCPage.show('logs'),
+      });
+      end.appendChild(btn);
+    }
+  }
+
+  /* ── Panneau Interface ───────────────────────────────────────────────── */
+
+  function buildInterfacePanel(root) {
+    const theme   = loadTheme();
+    const pending = {};
+
+    function section(label) {
+      const s = h('div', { class: 'mci-section' });
+      s.appendChild(h('div', { class: 'mci-section-label', text: label }));
+      return s;
+    }
+
+    /* ── Apparence ── */
+    const secApp = section('APPARENCE');
+
+    THEME_VARS.forEach(v => {
+      const row = h('div', { class: 'mci-row' });
+      row.appendChild(h('label', { class: 'mci-label', text: v.label }));
+      const cur = theme[v.key] !== undefined ? theme[v.key] : v.default;
+
+      if (v.type === 'color') {
+        const wrap = h('div', { class: 'mci-color-wrap' });
+        const inp  = h('input', { type: 'color', class: 'mci-color-input', value: cur });
+        const hex  = h('span',  { class: 'mci-color-hex', text: cur });
+        inp.addEventListener('input', () => {
+          hex.textContent = inp.value;
+          pending[v.key]  = inp.value;
+          const merged = Object.assign({}, loadTheme(), pending);
+          saveTheme(merged);
+          applyTheme(merged);
+        });
+        wrap.appendChild(inp); wrap.appendChild(hex);
+        row.appendChild(wrap);
+      } else {
+        const wrap = h('div', { class: 'mci-range-wrap' });
+        const inp  = h('input', { type: 'range', class: 'mci-range-input',
+          min: String(v.min), max: String(v.max), step: String(v.step), value: String(cur) });
+        const val  = h('span', { class: 'mci-range-val', text: String(cur) });
+        inp.addEventListener('input', () => {
+          val.textContent = inp.value;
+          pending[v.key]  = inp.value;
+          const merged = Object.assign({}, loadTheme(), pending);
+          saveTheme(merged);
+          applyTheme(merged);
+        });
+        wrap.appendChild(inp); wrap.appendChild(val);
+        row.appendChild(wrap);
+      }
+      secApp.appendChild(row);
+    });
+
+    /* Taille texte */
+    const fontRow  = h('div', { class: 'mci-row' });
+    const curFont  = theme['--base-font-size'] || BASE_FONT_DEFAULT;
+    fontRow.appendChild(h('label', { class: 'mci-label', text: 'Taille texte' }));
+    const fontWrap = h('div', { class: 'mci-range-wrap' });
+    const fontInp  = h('input', { type: 'range', class: 'mci-range-input',
+      min: '11', max: '18', step: '1', value: String(curFont) });
+    const fontVal  = h('span', { class: 'mci-range-val', text: curFont + 'px' });
+    fontInp.addEventListener('input', () => {
+      fontVal.textContent = fontInp.value + 'px';
+      pending['--base-font-size'] = Number(fontInp.value);
+      const merged = Object.assign({}, loadTheme(), pending);
+      saveTheme(merged);
+      applyTheme(merged);
+    });
+    fontWrap.appendChild(fontInp); fontWrap.appendChild(fontVal);
+    fontRow.appendChild(fontWrap);
+    secApp.appendChild(fontRow);
+    root.appendChild(secApp);
+
+    /* ── Mode avancé ── */
+    const secAdv = section('MODE AVANCÉ');
+    const advRow = h('div', { class: 'mci-row mci-row--toggle' });
+    const advGrp = h('div', { class: 'mci-toggle-group' });
+    advGrp.appendChild(h('span', { class: 'mci-sublabel', text: 'Expose les logs Jarvis dans la topbar' }));
+
+    const toggle = h('button', {
+      class: 'mci-toggle' + (isAdvanced() ? ' is-on' : ''),
+      'aria-pressed': isAdvanced() ? 'true' : 'false',
+    });
+    const track = h('span', { class: 'mci-toggle-track' });
+    track.appendChild(h('span', { class: 'mci-toggle-thumb' }));
+    toggle.appendChild(track);
+    toggle.addEventListener('click', () => {
+      const next = !isAdvanced();
+      setAdvanced(next);
+      toggle.classList.toggle('is-on', next);
+      toggle.setAttribute('aria-pressed', next ? 'true' : 'false');
+      refreshLogsBtn();
+    });
+
+    advGrp.appendChild(toggle);
+    advRow.appendChild(h('span', { class: 'mci-label', text: 'Mode avancé' }));
+    advRow.appendChild(advGrp);
+    secAdv.appendChild(advRow);
+    root.appendChild(secAdv);
+
+    /* ── Thème export / import / reset ── */
+    const secTheme = section('THÈME');
+    const actRow   = h('div', { class: 'mci-row mci-actions' });
+
+    const exportBtn = h('button', { class: 'mci-btn', text: '↓ Exporter', onclick: () => {
+      const blob = new Blob([JSON.stringify(loadTheme(), null, 2)], { type: 'application/json' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'jarvis-theme.json';
+      a.click();
+      URL.revokeObjectURL(a.href);
+    }});
+
+    const fileInput = h('input', { type: 'file', class: 'mci-file-input', accept: '.json' });
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = e => {
+        try {
+          const imported = JSON.parse(e.target.result);
+          saveTheme(imported);
+          applyTheme(imported);
+          /* Reconstruire le panneau pour refléter les nouvelles valeurs */
+          root.innerHTML = '';
+          root.removeAttribute('data-built');
+          buildInterfacePanel(root);
+          root.dataset.built = '1';
+        } catch (err) {
+          console.error('[MC] Import thème invalide', err);
+        }
+      };
+      reader.readAsText(file);
+    });
+    const importBtn = h('button', { class: 'mci-btn', text: '↑ Importer', onclick: () => fileInput.click() });
+
+    const resetBtn = h('button', { class: 'mci-btn mci-btn--danger', text: 'Réinitialiser', onclick: () => {
+      localStorage.removeItem(LS_THEME_KEY);
+      const r = document.documentElement;
+      THEME_VARS.forEach(v => r.style.removeProperty(v.key));
+      ['--accent-soft','--accent-line','--fg-1','--fg-2','--fg-3','--fg-4','font-size'].forEach(p => r.style.removeProperty(p));
+      root.innerHTML = '';
+      root.removeAttribute('data-built');
+      buildInterfacePanel(root);
+      root.dataset.built = '1';
+    }});
+
+    actRow.appendChild(exportBtn);
+    actRow.appendChild(importBtn);
+    actRow.appendChild(resetBtn);
+    actRow.appendChild(fileInput);
+    secTheme.appendChild(actRow);
+    root.appendChild(secTheme);
+  }
+
+  /* ── Init ────────────────────────────────────────────────────────────── */
+
+  document.addEventListener('DOMContentLoaded', function () {
+    /* Bouton Logs si mode avancé actif */
+    refreshLogsBtn();
+
+    /* Ouvrir l'onglet depuis l'URL hash ou workspace par défaut */
+    const hash = window.location.hash.replace('#', '');
+    const valid = TABS.map(t => t.id);
+    const initial = valid.includes(hash) ? hash : 'workspace';
+    MCPage.show(initial);
+
+    /* Mettre à jour le hash à la nav */
+    const origShow = MCPage.show;
+    MCPage.show = function(tabId) {
+      origShow(tabId);
+      history.replaceState(null, '', '#' + tabId);
+    };
+  });
+
+  /* ── Raccourci : Escape → retour Home ───────────────────────────────── */
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') window.location.href = '/';
+  });
+
+})();

--- a/src/jarvis/interfaces/ui/static/mc.js.bak-1782259689
+++ b/src/jarvis/interfaces/ui/static/mc.js.bak-1782259689
@@ -1,0 +1,338 @@
+/**
+ * mc.js — logique de la page Mission Control (/mc)
+ *
+ * Gère :
+ *  - Navigation par onglets (iframe pour workspace/capacites/config/logs,
+ *    panneau natif pour interface)
+ *  - Panneau Interface : thème CSS vars, export/import, reset, mode avancé
+ *  - Lecture/écriture localStorage pour le thème et le mode avancé
+ *  - Application du thème sauvegardé au boot (avant rendu)
+ */
+
+(function () {
+  'use strict';
+
+  /* ── Config ──────────────────────────────────────────────────────────── */
+
+  const TABS = [
+    { id: 'workspace',     label: 'Workspace',     href: '/dashboard'    },
+    { id: 'capacites',     label: 'Capacités',     href: '/capabilities' },
+    { id: 'configuration', label: 'Configuration', href: '/settings'     },
+    { id: 'interface',     label: 'Interface',     href: null            },
+    { id: 'logs',          label: 'Logs',          href: '/admin'        },
+  ];
+
+  const THEME_VARS = [
+    { key: '--bg-0',             label: 'Fond principal',  type: 'color', default: '#06080D' },
+    { key: '--accent',           label: 'Accent',          type: 'color', default: '#4A9EFF' },
+    { key: '--fg-0',             label: 'Texte principal', type: 'color', default: '#DCE8FF' },
+    { key: '--grain-opacity',    label: 'Grain',           type: 'range', default: 0.035, min: 0,   max: 0.12, step: 0.005 },
+    { key: '--vignette-opacity', label: 'Vignette',        type: 'range', default: 0.55,  min: 0,   max: 1,    step: 0.05  },
+  ];
+
+  const BASE_FONT_DEFAULT = 14;
+  const LS_THEME_KEY      = 'jarvis_theme_v1';
+  const LS_ADVANCED_KEY   = 'jarvis_advanced_mode';
+
+  /* ── Helpers DOM ─────────────────────────────────────────────────────── */
+
+  function h(tag, attrs, children) {
+    const el = document.createElement(tag);
+    if (attrs) Object.entries(attrs).forEach(([k, v]) => {
+      if      (k === 'class')   el.className = v;
+      else if (k === 'text')    el.textContent = v;
+      else if (k === 'onclick') el.addEventListener('click', v);
+      else                      el.setAttribute(k, v);
+    });
+    (children || []).forEach(c => c && el.appendChild(c));
+    return el;
+  }
+
+  /* ── Thème ───────────────────────────────────────────────────────────── */
+
+  function loadTheme() {
+    try { return JSON.parse(localStorage.getItem(LS_THEME_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+
+  function saveTheme(t) { localStorage.setItem(LS_THEME_KEY, JSON.stringify(t)); }
+
+  function applyTheme(patch) {
+    const root = document.documentElement;
+    THEME_VARS.forEach(v => {
+      if (patch[v.key] !== undefined) root.style.setProperty(v.key, patch[v.key]);
+    });
+    if (patch['--base-font-size']) {
+      root.style.setProperty('font-size', patch['--base-font-size'] + 'px');
+    }
+    /* Dériver accent-soft / accent-line depuis --accent */
+    const acc = patch['--accent'] || root.style.getPropertyValue('--accent');
+    if (acc && acc.startsWith('#') && acc.length === 7) {
+      const r = parseInt(acc.slice(1,3),16);
+      const g = parseInt(acc.slice(3,5),16);
+      const b = parseInt(acc.slice(5,7),16);
+      root.style.setProperty('--accent-soft', `rgba(${r},${g},${b},0.14)`);
+      root.style.setProperty('--accent-line', `rgba(${r},${g},${b},0.32)`);
+    }
+    /* Dériver fg-1..fg-4 depuis --fg-0 */
+    const fg = patch['--fg-0'] || root.style.getPropertyValue('--fg-0');
+    if (fg && fg.startsWith('#') && fg.length === 7) {
+      const r = parseInt(fg.slice(1,3),16);
+      const g = parseInt(fg.slice(3,5),16);
+      const b = parseInt(fg.slice(5,7),16);
+      root.style.setProperty('--fg-1', `rgba(${r},${g},${b},0.78)`);
+      root.style.setProperty('--fg-2', `rgba(${r},${g},${b},0.55)`);
+      root.style.setProperty('--fg-3', `rgba(${r},${g},${b},0.36)`);
+      root.style.setProperty('--fg-4', `rgba(${r},${g},${b},0.20)`);
+    }
+  }
+
+  /* Appliquer le thème sauvegardé immédiatement */
+  applyTheme(loadTheme());
+
+  /* ── Mode avancé ─────────────────────────────────────────────────────── */
+
+  function isAdvanced() { return localStorage.getItem(LS_ADVANCED_KEY) === '1'; }
+  function setAdvanced(v) { localStorage.setItem(LS_ADVANCED_KEY, v ? '1' : '0'); }
+
+  /* ── Navigation onglets ──────────────────────────────────────────────── */
+
+  let _activeTab = null;
+
+  const iframe = document.getElementById('mc-iframe');
+  const ifacePanel = document.getElementById('mc-panel-interface');
+
+  window.MCPage = {
+    show: function(tabId) {
+      /* Si logs et pas mode avancé, ignorer */
+      if (tabId === 'logs' && !isAdvanced()) return;
+
+      _activeTab = tabId;
+
+      /* Mettre à jour les boutons nav */
+      document.querySelectorAll('.mc-nav-btn').forEach(b => {
+        b.classList.toggle('is-active', b.dataset.tab === tabId);
+      });
+
+      const tab = TABS.find(t => t.id === tabId);
+      if (!tab) return;
+
+      if (tab.href) {
+        /* Charger dans l'iframe */
+        ifacePanel.style.display = 'none';
+        iframe.classList.remove('is-hidden');
+        if (iframe.dataset.src !== tab.href) {
+          iframe.src = tab.href;
+          iframe.dataset.src = tab.href;
+        }
+      } else {
+        /* Panneau Interface natif */
+        iframe.classList.add('is-hidden');
+        ifacePanel.style.display = 'flex';
+        if (!ifacePanel.dataset.built) {
+          buildInterfacePanel(ifacePanel);
+          ifacePanel.dataset.built = '1';
+        }
+      }
+    },
+  };
+
+  /* ── Bouton Logs en mode avancé ──────────────────────────────────────── */
+
+  function refreshLogsBtn() {
+    const end = document.getElementById('mc-topbar-end');
+    if (!end) return;
+    end.innerHTML = '';
+    if (isAdvanced()) {
+      const btn = h('button', {
+        class: 'mc-logs-btn' + (_activeTab === 'logs' ? ' is-active' : ''),
+        text:  'Logs',
+        onclick: () => MCPage.show('logs'),
+      });
+      end.appendChild(btn);
+    }
+  }
+
+  /* ── Panneau Interface ───────────────────────────────────────────────── */
+
+  function buildInterfacePanel(root) {
+    const theme   = loadTheme();
+    const pending = {};
+
+    function section(label) {
+      const s = h('div', { class: 'mci-section' });
+      s.appendChild(h('div', { class: 'mci-section-label', text: label }));
+      return s;
+    }
+
+    /* ── Apparence ── */
+    const secApp = section('APPARENCE');
+
+    THEME_VARS.forEach(v => {
+      const row = h('div', { class: 'mci-row' });
+      row.appendChild(h('label', { class: 'mci-label', text: v.label }));
+      const cur = theme[v.key] !== undefined ? theme[v.key] : v.default;
+
+      if (v.type === 'color') {
+        const wrap = h('div', { class: 'mci-color-wrap' });
+        const inp  = h('input', { type: 'color', class: 'mci-color-input', value: cur });
+        const hex  = h('span',  { class: 'mci-color-hex', text: cur });
+        inp.addEventListener('input', () => {
+          hex.textContent = inp.value;
+          pending[v.key]  = inp.value;
+          const merged = Object.assign({}, loadTheme(), pending);
+          saveTheme(merged);
+          applyTheme(merged);
+        });
+        wrap.appendChild(inp); wrap.appendChild(hex);
+        row.appendChild(wrap);
+      } else {
+        const wrap = h('div', { class: 'mci-range-wrap' });
+        const inp  = h('input', { type: 'range', class: 'mci-range-input',
+          min: String(v.min), max: String(v.max), step: String(v.step), value: String(cur) });
+        const val  = h('span', { class: 'mci-range-val', text: String(cur) });
+        inp.addEventListener('input', () => {
+          val.textContent = inp.value;
+          pending[v.key]  = inp.value;
+          const merged = Object.assign({}, loadTheme(), pending);
+          saveTheme(merged);
+          applyTheme(merged);
+        });
+        wrap.appendChild(inp); wrap.appendChild(val);
+        row.appendChild(wrap);
+      }
+      secApp.appendChild(row);
+    });
+
+    /* Taille texte */
+    const fontRow  = h('div', { class: 'mci-row' });
+    const curFont  = theme['--base-font-size'] || BASE_FONT_DEFAULT;
+    fontRow.appendChild(h('label', { class: 'mci-label', text: 'Taille texte' }));
+    const fontWrap = h('div', { class: 'mci-range-wrap' });
+    const fontInp  = h('input', { type: 'range', class: 'mci-range-input',
+      min: '11', max: '18', step: '1', value: String(curFont) });
+    const fontVal  = h('span', { class: 'mci-range-val', text: curFont + 'px' });
+    fontInp.addEventListener('input', () => {
+      fontVal.textContent = fontInp.value + 'px';
+      pending['--base-font-size'] = Number(fontInp.value);
+      const merged = Object.assign({}, loadTheme(), pending);
+      saveTheme(merged);
+      applyTheme(merged);
+    });
+    fontWrap.appendChild(fontInp); fontWrap.appendChild(fontVal);
+    fontRow.appendChild(fontWrap);
+    secApp.appendChild(fontRow);
+    root.appendChild(secApp);
+
+    /* ── Mode avancé ── */
+    const secAdv = section('MODE AVANCÉ');
+    const advRow = h('div', { class: 'mci-row mci-row--toggle' });
+    const advGrp = h('div', { class: 'mci-toggle-group' });
+    advGrp.appendChild(h('span', { class: 'mci-sublabel', text: 'Expose les logs Jarvis dans la topbar' }));
+
+    const toggle = h('button', {
+      class: 'mci-toggle' + (isAdvanced() ? ' is-on' : ''),
+      'aria-pressed': isAdvanced() ? 'true' : 'false',
+    });
+    const track = h('span', { class: 'mci-toggle-track' });
+    track.appendChild(h('span', { class: 'mci-toggle-thumb' }));
+    toggle.appendChild(track);
+    toggle.addEventListener('click', () => {
+      const next = !isAdvanced();
+      setAdvanced(next);
+      toggle.classList.toggle('is-on', next);
+      toggle.setAttribute('aria-pressed', next ? 'true' : 'false');
+      refreshLogsBtn();
+    });
+
+    advGrp.appendChild(toggle);
+    advRow.appendChild(h('span', { class: 'mci-label', text: 'Mode avancé' }));
+    advRow.appendChild(advGrp);
+    secAdv.appendChild(advRow);
+    root.appendChild(secAdv);
+
+    /* ── Thème export / import / reset ── */
+    const secTheme = section('THÈME');
+    const actRow   = h('div', { class: 'mci-row mci-actions' });
+
+    const exportBtn = h('button', { class: 'mci-btn', text: '↓ Exporter', onclick: () => {
+      const blob = new Blob([JSON.stringify(loadTheme(), null, 2)], { type: 'application/json' });
+      const a = document.createElement('a');
+      a.href = URL.createObjectURL(blob);
+      a.download = 'jarvis-theme.json';
+      a.click();
+      URL.revokeObjectURL(a.href);
+    }});
+
+    const fileInput = h('input', { type: 'file', class: 'mci-file-input', accept: '.json' });
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = e => {
+        try {
+          const imported = JSON.parse(e.target.result);
+          saveTheme(imported);
+          applyTheme(imported);
+          /* Reconstruire le panneau pour refléter les nouvelles valeurs */
+          root.innerHTML = '';
+          root.removeAttribute('data-built');
+          buildInterfacePanel(root);
+          root.dataset.built = '1';
+        } catch (err) {
+          console.error('[MC] Import thème invalide', err);
+        }
+      };
+      reader.readAsText(file);
+    });
+    const importBtn = h('button', { class: 'mci-btn', text: '↑ Importer', onclick: () => fileInput.click() });
+
+    const resetBtn = h('button', { class: 'mci-btn mci-btn--danger', text: 'Réinitialiser', onclick: () => {
+      localStorage.removeItem(LS_THEME_KEY);
+      const r = document.documentElement;
+      THEME_VARS.forEach(v => r.style.removeProperty(v.key));
+      ['--accent-soft','--accent-line','--fg-1','--fg-2','--fg-3','--fg-4','font-size'].forEach(p => r.style.removeProperty(p));
+      root.innerHTML = '';
+      root.removeAttribute('data-built');
+      buildInterfacePanel(root);
+      root.dataset.built = '1';
+    }});
+
+    actRow.appendChild(exportBtn);
+    actRow.appendChild(importBtn);
+    actRow.appendChild(resetBtn);
+    actRow.appendChild(fileInput);
+    secTheme.appendChild(actRow);
+    root.appendChild(secTheme);
+  }
+
+  /* ── Init ────────────────────────────────────────────────────────────── */
+
+  document.addEventListener('DOMContentLoaded', function () {
+    /* Effet atmosphère (aurora, vignette, grain) */
+    if (window.Jarvis && typeof Jarvis.mountAtmosphere === 'function') {
+      Jarvis.mountAtmosphere();
+    }
+    /* Bouton Logs si mode avancé actif */
+    refreshLogsBtn();
+
+    /* Ouvrir l'onglet depuis l'URL hash ou workspace par défaut */
+    const hash = window.location.hash.replace('#', '');
+    const valid = TABS.map(t => t.id);
+    const initial = valid.includes(hash) ? hash : 'workspace';
+    MCPage.show(initial);
+
+    /* Mettre à jour le hash à la nav */
+    const origShow = MCPage.show;
+    MCPage.show = function(tabId) {
+      origShow(tabId);
+      history.replaceState(null, '', '#' + tabId);
+    };
+  });
+
+  /* ── Raccourci : Escape → retour Home ───────────────────────────────── */
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') window.location.href = '/';
+  });
+
+})();

--- a/src/jarvis/interfaces/ui/static/mission_control.css
+++ b/src/jarvis/interfaces/ui/static/mission_control.css
@@ -1,0 +1,296 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mission_control.css — Jarvis UI v2
+   À ajouter à _shared.css (à la fin, après les règles .mission-*)
+   ou charger comme feuille séparée après _shared.css.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Overlay ─────────────────────────────────────────────────────────── */
+
+.jmc-overlay {
+  position: fixed; inset: 0; z-index: 9200;
+  background: rgba(6, 8, 13, 0.82);
+  backdrop-filter: blur(12px);
+  display: flex; align-items: center; justify-content: center;
+  animation: jmc-fade-in 0.18s cubic-bezier(0.32,0.72,0,1) both;
+}
+.jmc-overlay.is-hidden { display: none; }
+
+@keyframes jmc-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Panneau central ─────────────────────────────────────────────────── */
+
+.jmc-panel {
+  width: min(820px, 92vw);
+  max-height: 86vh;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2);
+  border-radius: var(--r-4);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 32px 80px rgba(0,0,0,0.55), 0 0 0 0.5px var(--line-1) inset;
+  animation: jmc-panel-in 0.22s cubic-bezier(0.32,0.72,0,1) both;
+}
+
+@keyframes jmc-panel-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+
+.jmc-header {
+  display: flex; align-items: center; gap: 12px;
+  padding: 18px 24px 0;
+  flex-shrink: 0;
+}
+.jmc-header-title {
+  font-family: var(--mono); font-size: 0.625rem;
+  letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--fg-2); flex: 1;
+}
+.jmc-header-hint {
+  display: flex; align-items: center; gap: 4px;
+  font-family: var(--mono); font-size: 0.625rem;
+  color: var(--fg-4);
+}
+.jmc-hkbd {
+  display: inline-flex; gap: 2px; align-items: center;
+  border: 0.5px solid var(--line-2); border-radius: 3px;
+  padding: 1px 5px; font-size: 0.5625rem; color: var(--fg-3);
+}
+.jmc-hdot { opacity: 0.45; }
+.jmc-close {
+  background: none; border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  color: var(--fg-3); font-size: 1rem; line-height: 1;
+  padding: 3px 9px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.jmc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+/* ── Barre d'onglets ─────────────────────────────────────────────────── */
+
+.jmc-tabs {
+  display: flex; gap: 0;
+  padding: 16px 24px 0;
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+  overflow-x: auto; scrollbar-width: none;
+}
+.jmc-tabs::-webkit-scrollbar { display: none; }
+
+.jmc-tab-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 0.6562rem;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 8px 16px 10px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px;
+}
+.jmc-tab-btn:hover { color: var(--fg-1); }
+.jmc-tab-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ── Corps des onglets ───────────────────────────────────────────────── */
+
+.jmc-tab-body {
+  flex: 1; overflow: hidden; min-height: 0;
+  position: relative;
+}
+.jmc-tab-pane {
+  display: none;
+  height: 100%; overflow-y: auto; scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+}
+.jmc-tab-pane.is-active { display: flex; flex-direction: column; }
+
+/* ── Pane Room ───────────────────────────────────────────────────────── */
+
+.jmc-room-pane {
+  padding: 36px 40px 32px;
+  gap: 24px;
+  position: relative;
+}
+.jmc-room-pane::before {
+  content: '';
+  position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(ellipse 60% 50% at 50% 0%, var(--room-glow, transparent), transparent 70%);
+  opacity: 0.35;
+}
+
+.jmc-room-top { display: flex; flex-direction: column; gap: 10px; flex: 1; }
+
+.jmc-room-eyebrow {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.20em; text-transform: uppercase; color: var(--fg-4);
+}
+.jmc-room-chapter { color: var(--accent); }
+.jmc-room-count   { color: var(--fg-4); }
+
+.jmc-room-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(36px, 5vw, 52px); letter-spacing: -0.04em; line-height: 1;
+  color: var(--fg-0);
+}
+.jmc-room-sub {
+  font-family: var(--mono); font-size: 0.5938rem;
+  letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3);
+}
+
+.jmc-room-pages {
+  display: flex; flex-wrap: wrap; gap: 8px 16px;
+  border-top: 0.5px solid var(--line-1); padding-top: 18px;
+}
+.jmc-room-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3);
+  letter-spacing: 0.06em;
+}
+.jmc-pg-num { color: var(--fg-4); font-size: 0.5312rem; }
+.jmc-pg-lbl { color: var(--fg-2); }
+
+.jmc-room-foot {
+  display: flex; justify-content: flex-end;
+  padding-top: 8px; margin-top: auto;
+}
+.jmc-open-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.10em;
+  padding: 8px 20px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.jmc-open-btn:hover {
+  color: var(--fg-0); border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+/* ── Pane Interface ──────────────────────────────────────────────────── */
+
+.jmc-iface-pane {
+  padding: 28px 40px 32px;
+  gap: 0;
+}
+
+.jmc-iface-section {
+  display: flex; flex-direction: column; gap: 14px;
+  padding-bottom: 24px; margin-bottom: 24px;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.jmc-iface-section:last-child { border-bottom: none; margin-bottom: 0; }
+
+.jmc-iface-section-label {
+  font-family: var(--mono); font-size: 0.5625rem;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-4);
+  margin-bottom: 4px;
+}
+
+.jmc-iface-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 32px;
+}
+.jmc-iface-row--toggle {
+  align-items: flex-start; flex-direction: column; gap: 8px;
+}
+
+.jmc-iface-label {
+  font-family: var(--sans); font-size: 0.75rem; color: var(--fg-2);
+  min-width: 130px; flex-shrink: 0;
+}
+.jmc-iface-sublabel {
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.jmc-iface-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.jmc-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.jmc-color-input {
+  width: 36px; height: 28px; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); cursor: pointer; padding: 2px;
+  background: var(--bg-2);
+}
+.jmc-color-hex {
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.jmc-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.jmc-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent);
+  cursor: pointer;
+}
+.jmc-range-val {
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3);
+  min-width: 36px; text-align: right;
+}
+
+/* Boutons actions */
+.jmc-iface-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.08em;
+  padding: 8px 16px; cursor: pointer; display: inline-flex;
+  align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.jmc-iface-btn:hover {
+  color: var(--fg-0); border-color: var(--line-3);
+  background: var(--bg-3);
+}
+.jmc-iface-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.jmc-iface-actions {
+  gap: 10px; flex-wrap: wrap;
+}
+.jmc-file-input { display: none; }
+
+/* Toggle switch */
+.jmc-toggle {
+  background: none; border: none; padding: 0;
+  cursor: pointer; flex-shrink: 0;
+}
+.jmc-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px; transition: background 0.2s, border-color 0.2s;
+  position: relative;
+}
+.jmc-toggle.is-on .jmc-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.jmc-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.jmc-toggle.is-on .jmc-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── Pane Logs ───────────────────────────────────────────────────────── */
+
+.jmc-logs-pane {
+  padding: 20px 24px 0;
+  gap: 12px;
+}
+.jmc-logs-frame {
+  flex: 1; width: 100%; border: none;
+  border-top: 0.5px solid var(--line-1);
+}
+
+/* Bouton Home flottant supprimé — remplacé par le logo Jarvis dans la topbar /mc */

--- a/src/jarvis/interfaces/ui/static/mission_control.css.bak-1782256193
+++ b/src/jarvis/interfaces/ui/static/mission_control.css.bak-1782256193
@@ -1,0 +1,312 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mission_control.css — Jarvis UI v2
+   À ajouter à _shared.css (à la fin, après les règles .mission-*)
+   ou charger comme feuille séparée après _shared.css.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Overlay ─────────────────────────────────────────────────────────── */
+
+.jmc-overlay {
+  position: fixed; inset: 0; z-index: 9200;
+  background: rgba(6, 8, 13, 0.82);
+  backdrop-filter: blur(12px);
+  display: flex; align-items: center; justify-content: center;
+  animation: jmc-fade-in 0.18s cubic-bezier(0.32,0.72,0,1) both;
+}
+.jmc-overlay.is-hidden { display: none; }
+
+@keyframes jmc-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Panneau central ─────────────────────────────────────────────────── */
+
+.jmc-panel {
+  width: min(820px, 92vw);
+  max-height: 86vh;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2);
+  border-radius: var(--r-4);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 32px 80px rgba(0,0,0,0.55), 0 0 0 0.5px var(--line-1) inset;
+  animation: jmc-panel-in 0.22s cubic-bezier(0.32,0.72,0,1) both;
+}
+
+@keyframes jmc-panel-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+
+.jmc-header {
+  display: flex; align-items: center; gap: 12px;
+  padding: 18px 24px 0;
+  flex-shrink: 0;
+}
+.jmc-header-title {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--fg-2); flex: 1;
+}
+.jmc-header-hint {
+  display: flex; align-items: center; gap: 4px;
+  font-family: var(--mono); font-size: 10px;
+  color: var(--fg-4);
+}
+.jmc-hkbd {
+  display: inline-flex; gap: 2px; align-items: center;
+  border: 0.5px solid var(--line-2); border-radius: 3px;
+  padding: 1px 5px; font-size: 9px; color: var(--fg-3);
+}
+.jmc-hdot { opacity: 0.45; }
+.jmc-close {
+  background: none; border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 3px 9px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.jmc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+/* ── Barre d'onglets ─────────────────────────────────────────────────── */
+
+.jmc-tabs {
+  display: flex; gap: 0;
+  padding: 16px 24px 0;
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+  overflow-x: auto; scrollbar-width: none;
+}
+.jmc-tabs::-webkit-scrollbar { display: none; }
+
+.jmc-tab-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 8px 16px 10px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px;
+}
+.jmc-tab-btn:hover { color: var(--fg-1); }
+.jmc-tab-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ── Corps des onglets ───────────────────────────────────────────────── */
+
+.jmc-tab-body {
+  flex: 1; overflow: hidden; min-height: 0;
+  position: relative;
+}
+.jmc-tab-pane {
+  display: none;
+  height: 100%; overflow-y: auto; scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+}
+.jmc-tab-pane.is-active { display: flex; flex-direction: column; }
+
+/* ── Pane Room ───────────────────────────────────────────────────────── */
+
+.jmc-room-pane {
+  padding: 36px 40px 32px;
+  gap: 24px;
+  position: relative;
+}
+.jmc-room-pane::before {
+  content: '';
+  position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(ellipse 60% 50% at 50% 0%, var(--room-glow, transparent), transparent 70%);
+  opacity: 0.35;
+}
+
+.jmc-room-top { display: flex; flex-direction: column; gap: 10px; flex: 1; }
+
+.jmc-room-eyebrow {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.20em; text-transform: uppercase; color: var(--fg-4);
+}
+.jmc-room-chapter { color: var(--accent); }
+.jmc-room-count   { color: var(--fg-4); }
+
+.jmc-room-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(36px, 5vw, 52px); letter-spacing: -0.04em; line-height: 1;
+  color: var(--fg-0);
+}
+.jmc-room-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3);
+}
+
+.jmc-room-pages {
+  display: flex; flex-wrap: wrap; gap: 8px 16px;
+  border-top: 0.5px solid var(--line-1); padding-top: 18px;
+}
+.jmc-room-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.06em;
+}
+.jmc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.jmc-pg-lbl { color: var(--fg-2); }
+
+.jmc-room-foot {
+  display: flex; justify-content: flex-end;
+  padding-top: 8px; margin-top: auto;
+}
+.jmc-open-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.10em;
+  padding: 8px 20px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.jmc-open-btn:hover {
+  color: var(--fg-0); border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+/* ── Pane Interface ──────────────────────────────────────────────────── */
+
+.jmc-iface-pane {
+  padding: 28px 40px 32px;
+  gap: 0;
+}
+
+.jmc-iface-section {
+  display: flex; flex-direction: column; gap: 14px;
+  padding-bottom: 24px; margin-bottom: 24px;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.jmc-iface-section:last-child { border-bottom: none; margin-bottom: 0; }
+
+.jmc-iface-section-label {
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-4);
+  margin-bottom: 4px;
+}
+
+.jmc-iface-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 32px;
+}
+.jmc-iface-row--toggle {
+  align-items: flex-start; flex-direction: column; gap: 8px;
+}
+
+.jmc-iface-label {
+  font-family: var(--sans); font-size: 12px; color: var(--fg-2);
+  min-width: 130px; flex-shrink: 0;
+}
+.jmc-iface-sublabel {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.jmc-iface-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.jmc-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.jmc-color-input {
+  width: 36px; height: 28px; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); cursor: pointer; padding: 2px;
+  background: var(--bg-2);
+}
+.jmc-color-hex {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.jmc-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.jmc-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent);
+  cursor: pointer;
+}
+.jmc-range-val {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  min-width: 36px; text-align: right;
+}
+
+/* Boutons actions */
+.jmc-iface-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  padding: 8px 16px; cursor: pointer; display: inline-flex;
+  align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.jmc-iface-btn:hover {
+  color: var(--fg-0); border-color: var(--line-3);
+  background: var(--bg-3);
+}
+.jmc-iface-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.jmc-iface-actions {
+  gap: 10px; flex-wrap: wrap;
+}
+.jmc-file-input { display: none; }
+
+/* Toggle switch */
+.jmc-toggle {
+  background: none; border: none; padding: 0;
+  cursor: pointer; flex-shrink: 0;
+}
+.jmc-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px; transition: background 0.2s, border-color 0.2s;
+  position: relative;
+}
+.jmc-toggle.is-on .jmc-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.jmc-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.jmc-toggle.is-on .jmc-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── Pane Logs ───────────────────────────────────────────────────────── */
+
+.jmc-logs-pane {
+  padding: 20px 24px 0;
+  gap: 12px;
+}
+.jmc-logs-frame {
+  flex: 1; width: 100%; border: none;
+  border-top: 0.5px solid var(--line-1);
+}
+
+/* ── Bouton Home flottant ────────────────────────────────────────────── */
+
+.jmc-home-btn {
+  position: fixed; bottom: 24px; left: 24px; z-index: 9000;
+  background: var(--bg-2); border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-3);
+  width: 36px; height: 36px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; opacity: 0.55;
+  transition: opacity 0.15s, border-color 0.15s, color 0.15s;
+}
+.jmc-home-btn:hover {
+  opacity: 1; border-color: var(--accent); color: var(--accent);
+}
+
+/* Masqué sur la home (body[data-mode="home"]) */
+body[data-mode="home"] .jmc-home-btn { display: none; }

--- a/src/jarvis/interfaces/ui/static/mission_control.css.bak-1782256749
+++ b/src/jarvis/interfaces/ui/static/mission_control.css.bak-1782256749
@@ -1,0 +1,312 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mission_control.css — Jarvis UI v2
+   À ajouter à _shared.css (à la fin, après les règles .mission-*)
+   ou charger comme feuille séparée après _shared.css.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Overlay ─────────────────────────────────────────────────────────── */
+
+.jmc-overlay {
+  position: fixed; inset: 0; z-index: 9200;
+  background: rgba(6, 8, 13, 0.82);
+  backdrop-filter: blur(12px);
+  display: flex; align-items: center; justify-content: center;
+  animation: jmc-fade-in 0.18s cubic-bezier(0.32,0.72,0,1) both;
+}
+.jmc-overlay.is-hidden { display: none; }
+
+@keyframes jmc-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Panneau central ─────────────────────────────────────────────────── */
+
+.jmc-panel {
+  width: min(820px, 92vw);
+  max-height: 86vh;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2);
+  border-radius: var(--r-4);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 32px 80px rgba(0,0,0,0.55), 0 0 0 0.5px var(--line-1) inset;
+  animation: jmc-panel-in 0.22s cubic-bezier(0.32,0.72,0,1) both;
+}
+
+@keyframes jmc-panel-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+
+.jmc-header {
+  display: flex; align-items: center; gap: 12px;
+  padding: 18px 24px 0;
+  flex-shrink: 0;
+}
+.jmc-header-title {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--fg-2); flex: 1;
+}
+.jmc-header-hint {
+  display: flex; align-items: center; gap: 4px;
+  font-family: var(--mono); font-size: 10px;
+  color: var(--fg-4);
+}
+.jmc-hkbd {
+  display: inline-flex; gap: 2px; align-items: center;
+  border: 0.5px solid var(--line-2); border-radius: 3px;
+  padding: 1px 5px; font-size: 9px; color: var(--fg-3);
+}
+.jmc-hdot { opacity: 0.45; }
+.jmc-close {
+  background: none; border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 3px 9px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.jmc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+/* ── Barre d'onglets ─────────────────────────────────────────────────── */
+
+.jmc-tabs {
+  display: flex; gap: 0;
+  padding: 16px 24px 0;
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+  overflow-x: auto; scrollbar-width: none;
+}
+.jmc-tabs::-webkit-scrollbar { display: none; }
+
+.jmc-tab-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 8px 16px 10px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px;
+}
+.jmc-tab-btn:hover { color: var(--fg-1); }
+.jmc-tab-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ── Corps des onglets ───────────────────────────────────────────────── */
+
+.jmc-tab-body {
+  flex: 1; overflow: hidden; min-height: 0;
+  position: relative;
+}
+.jmc-tab-pane {
+  display: none;
+  height: 100%; overflow-y: auto; scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+}
+.jmc-tab-pane.is-active { display: flex; flex-direction: column; }
+
+/* ── Pane Room ───────────────────────────────────────────────────────── */
+
+.jmc-room-pane {
+  padding: 36px 40px 32px;
+  gap: 24px;
+  position: relative;
+}
+.jmc-room-pane::before {
+  content: '';
+  position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(ellipse 60% 50% at 50% 0%, var(--room-glow, transparent), transparent 70%);
+  opacity: 0.35;
+}
+
+.jmc-room-top { display: flex; flex-direction: column; gap: 10px; flex: 1; }
+
+.jmc-room-eyebrow {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.20em; text-transform: uppercase; color: var(--fg-4);
+}
+.jmc-room-chapter { color: var(--accent); }
+.jmc-room-count   { color: var(--fg-4); }
+
+.jmc-room-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(36px, 5vw, 52px); letter-spacing: -0.04em; line-height: 1;
+  color: var(--fg-0);
+}
+.jmc-room-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3);
+}
+
+.jmc-room-pages {
+  display: flex; flex-wrap: wrap; gap: 8px 16px;
+  border-top: 0.5px solid var(--line-1); padding-top: 18px;
+}
+.jmc-room-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.06em;
+}
+.jmc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.jmc-pg-lbl { color: var(--fg-2); }
+
+.jmc-room-foot {
+  display: flex; justify-content: flex-end;
+  padding-top: 8px; margin-top: auto;
+}
+.jmc-open-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.10em;
+  padding: 8px 20px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.jmc-open-btn:hover {
+  color: var(--fg-0); border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+/* ── Pane Interface ──────────────────────────────────────────────────── */
+
+.jmc-iface-pane {
+  padding: 28px 40px 32px;
+  gap: 0;
+}
+
+.jmc-iface-section {
+  display: flex; flex-direction: column; gap: 14px;
+  padding-bottom: 24px; margin-bottom: 24px;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.jmc-iface-section:last-child { border-bottom: none; margin-bottom: 0; }
+
+.jmc-iface-section-label {
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-4);
+  margin-bottom: 4px;
+}
+
+.jmc-iface-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 32px;
+}
+.jmc-iface-row--toggle {
+  align-items: flex-start; flex-direction: column; gap: 8px;
+}
+
+.jmc-iface-label {
+  font-family: var(--sans); font-size: 12px; color: var(--fg-2);
+  min-width: 130px; flex-shrink: 0;
+}
+.jmc-iface-sublabel {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.jmc-iface-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.jmc-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.jmc-color-input {
+  width: 36px; height: 28px; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); cursor: pointer; padding: 2px;
+  background: var(--bg-2);
+}
+.jmc-color-hex {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.jmc-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.jmc-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent);
+  cursor: pointer;
+}
+.jmc-range-val {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  min-width: 36px; text-align: right;
+}
+
+/* Boutons actions */
+.jmc-iface-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  padding: 8px 16px; cursor: pointer; display: inline-flex;
+  align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.jmc-iface-btn:hover {
+  color: var(--fg-0); border-color: var(--line-3);
+  background: var(--bg-3);
+}
+.jmc-iface-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.jmc-iface-actions {
+  gap: 10px; flex-wrap: wrap;
+}
+.jmc-file-input { display: none; }
+
+/* Toggle switch */
+.jmc-toggle {
+  background: none; border: none; padding: 0;
+  cursor: pointer; flex-shrink: 0;
+}
+.jmc-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px; transition: background 0.2s, border-color 0.2s;
+  position: relative;
+}
+.jmc-toggle.is-on .jmc-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.jmc-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.jmc-toggle.is-on .jmc-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── Pane Logs ───────────────────────────────────────────────────────── */
+
+.jmc-logs-pane {
+  padding: 20px 24px 0;
+  gap: 12px;
+}
+.jmc-logs-frame {
+  flex: 1; width: 100%; border: none;
+  border-top: 0.5px solid var(--line-1);
+}
+
+/* ── Bouton Home flottant ────────────────────────────────────────────── */
+
+.jmc-home-btn {
+  position: fixed; bottom: 24px; left: 24px; z-index: 9000;
+  background: var(--bg-1); border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-3);
+  width: 36px; height: 36px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; opacity: 0.55;
+  transition: opacity 0.15s, border-color 0.15s, color 0.15s;
+}
+.jmc-home-btn:hover {
+  opacity: 1; border-color: var(--accent); color: var(--accent);
+}
+
+/* Masqué sur la home (body[data-mode="home"]) */
+body[data-mode="home"] .jmc-home-btn { display: none; }

--- a/src/jarvis/interfaces/ui/static/mission_control.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/mission_control.css.bak-1782259625
@@ -1,0 +1,296 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   mission_control.css — Jarvis UI v2
+   À ajouter à _shared.css (à la fin, après les règles .mission-*)
+   ou charger comme feuille séparée après _shared.css.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* ── Overlay ─────────────────────────────────────────────────────────── */
+
+.jmc-overlay {
+  position: fixed; inset: 0; z-index: 9200;
+  background: rgba(6, 8, 13, 0.82);
+  backdrop-filter: blur(12px);
+  display: flex; align-items: center; justify-content: center;
+  animation: jmc-fade-in 0.18s cubic-bezier(0.32,0.72,0,1) both;
+}
+.jmc-overlay.is-hidden { display: none; }
+
+@keyframes jmc-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* ── Panneau central ─────────────────────────────────────────────────── */
+
+.jmc-panel {
+  width: min(820px, 92vw);
+  max-height: 86vh;
+  background: var(--bg-1);
+  border: 0.5px solid var(--line-2);
+  border-radius: var(--r-4);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 32px 80px rgba(0,0,0,0.55), 0 0 0 0.5px var(--line-1) inset;
+  animation: jmc-panel-in 0.22s cubic-bezier(0.32,0.72,0,1) both;
+}
+
+@keyframes jmc-panel-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* ── Header ──────────────────────────────────────────────────────────── */
+
+.jmc-header {
+  display: flex; align-items: center; gap: 12px;
+  padding: 18px 24px 0;
+  flex-shrink: 0;
+}
+.jmc-header-title {
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.22em; text-transform: uppercase;
+  color: var(--fg-2); flex: 1;
+}
+.jmc-header-hint {
+  display: flex; align-items: center; gap: 4px;
+  font-family: var(--mono); font-size: 10px;
+  color: var(--fg-4);
+}
+.jmc-hkbd {
+  display: inline-flex; gap: 2px; align-items: center;
+  border: 0.5px solid var(--line-2); border-radius: 3px;
+  padding: 1px 5px; font-size: 9px; color: var(--fg-3);
+}
+.jmc-hdot { opacity: 0.45; }
+.jmc-close {
+  background: none; border: 0.5px solid var(--line-2); border-radius: var(--r-2);
+  color: var(--fg-3); font-size: 16px; line-height: 1;
+  padding: 3px 9px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.jmc-close:hover { color: var(--fg-0); border-color: var(--line-3); }
+
+/* ── Barre d'onglets ─────────────────────────────────────────────────── */
+
+.jmc-tabs {
+  display: flex; gap: 0;
+  padding: 16px 24px 0;
+  border-bottom: 0.5px solid var(--line-1);
+  flex-shrink: 0;
+  overflow-x: auto; scrollbar-width: none;
+}
+.jmc-tabs::-webkit-scrollbar { display: none; }
+
+.jmc-tab-btn {
+  background: none; border: none; border-bottom: 1.5px solid transparent;
+  color: var(--fg-3); font-family: var(--mono); font-size: 10.5px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 8px 16px 10px; cursor: pointer; white-space: nowrap;
+  transition: color 0.15s, border-color 0.15s;
+  margin-bottom: -0.5px;
+}
+.jmc-tab-btn:hover { color: var(--fg-1); }
+.jmc-tab-btn.is-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ── Corps des onglets ───────────────────────────────────────────────── */
+
+.jmc-tab-body {
+  flex: 1; overflow: hidden; min-height: 0;
+  position: relative;
+}
+.jmc-tab-pane {
+  display: none;
+  height: 100%; overflow-y: auto; scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+}
+.jmc-tab-pane.is-active { display: flex; flex-direction: column; }
+
+/* ── Pane Room ───────────────────────────────────────────────────────── */
+
+.jmc-room-pane {
+  padding: 36px 40px 32px;
+  gap: 24px;
+  position: relative;
+}
+.jmc-room-pane::before {
+  content: '';
+  position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(ellipse 60% 50% at 50% 0%, var(--room-glow, transparent), transparent 70%);
+  opacity: 0.35;
+}
+
+.jmc-room-top { display: flex; flex-direction: column; gap: 10px; flex: 1; }
+
+.jmc-room-eyebrow {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.20em; text-transform: uppercase; color: var(--fg-4);
+}
+.jmc-room-chapter { color: var(--accent); }
+.jmc-room-count   { color: var(--fg-4); }
+
+.jmc-room-title {
+  font-family: var(--serif); font-weight: 300;
+  font-size: clamp(36px, 5vw, 52px); letter-spacing: -0.04em; line-height: 1;
+  color: var(--fg-0);
+}
+.jmc-room-sub {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3);
+}
+
+.jmc-room-pages {
+  display: flex; flex-wrap: wrap; gap: 8px 16px;
+  border-top: 0.5px solid var(--line-1); padding-top: 18px;
+}
+.jmc-room-page {
+  display: inline-flex; align-items: baseline; gap: 5px;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.06em;
+}
+.jmc-pg-num { color: var(--fg-4); font-size: 8.5px; }
+.jmc-pg-lbl { color: var(--fg-2); }
+
+.jmc-room-foot {
+  display: flex; justify-content: flex-end;
+  padding-top: 8px; margin-top: auto;
+}
+.jmc-open-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.10em;
+  padding: 8px 20px; cursor: pointer;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.jmc-open-btn:hover {
+  color: var(--fg-0); border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+/* ── Pane Interface ──────────────────────────────────────────────────── */
+
+.jmc-iface-pane {
+  padding: 28px 40px 32px;
+  gap: 0;
+}
+
+.jmc-iface-section {
+  display: flex; flex-direction: column; gap: 14px;
+  padding-bottom: 24px; margin-bottom: 24px;
+  border-bottom: 0.5px solid var(--line-1);
+}
+.jmc-iface-section:last-child { border-bottom: none; margin-bottom: 0; }
+
+.jmc-iface-section-label {
+  font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.22em; text-transform: uppercase; color: var(--fg-4);
+  margin-bottom: 4px;
+}
+
+.jmc-iface-row {
+  display: flex; align-items: center; gap: 16px;
+  min-height: 32px;
+}
+.jmc-iface-row--toggle {
+  align-items: flex-start; flex-direction: column; gap: 8px;
+}
+
+.jmc-iface-label {
+  font-family: var(--sans); font-size: 12px; color: var(--fg-2);
+  min-width: 130px; flex-shrink: 0;
+}
+.jmc-iface-sublabel {
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.jmc-iface-toggle-group {
+  display: flex; align-items: center; gap: 12px;
+}
+
+/* Color picker */
+.jmc-color-wrap {
+  display: flex; align-items: center; gap: 10px;
+}
+.jmc-color-input {
+  width: 36px; height: 28px; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); cursor: pointer; padding: 2px;
+  background: var(--bg-2);
+}
+.jmc-color-hex {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  letter-spacing: 0.06em;
+}
+
+/* Range slider */
+.jmc-range-wrap {
+  display: flex; align-items: center; gap: 10px; flex: 1;
+}
+.jmc-range-input {
+  flex: 1; height: 3px; accent-color: var(--accent);
+  cursor: pointer;
+}
+.jmc-range-val {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3);
+  min-width: 36px; text-align: right;
+}
+
+/* Boutons actions */
+.jmc-iface-btn {
+  background: none; border: 0.5px solid var(--line-2);
+  border-radius: var(--r-2); color: var(--fg-2);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  padding: 8px 16px; cursor: pointer; display: inline-flex;
+  align-items: center; gap: 6px;
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.jmc-iface-btn:hover {
+  color: var(--fg-0); border-color: var(--line-3);
+  background: var(--bg-3);
+}
+.jmc-iface-btn--danger:hover { border-color: var(--red); color: var(--red); }
+
+.jmc-iface-actions {
+  gap: 10px; flex-wrap: wrap;
+}
+.jmc-file-input { display: none; }
+
+/* Toggle switch */
+.jmc-toggle {
+  background: none; border: none; padding: 0;
+  cursor: pointer; flex-shrink: 0;
+}
+.jmc-toggle-track {
+  display: flex; align-items: center;
+  width: 36px; height: 20px; border-radius: 10px;
+  background: var(--bg-3); border: 0.5px solid var(--line-2);
+  padding: 2px; transition: background 0.2s, border-color 0.2s;
+  position: relative;
+}
+.jmc-toggle.is-on .jmc-toggle-track {
+  background: var(--accent-soft); border-color: var(--accent-line);
+}
+.jmc-toggle-thumb {
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--fg-3);
+  transition: transform 0.2s cubic-bezier(0.32,0.72,0,1), background 0.2s;
+  flex-shrink: 0;
+}
+.jmc-toggle.is-on .jmc-toggle-thumb {
+  transform: translateX(16px); background: var(--accent);
+}
+
+/* ── Pane Logs ───────────────────────────────────────────────────────── */
+
+.jmc-logs-pane {
+  padding: 20px 24px 0;
+  gap: 12px;
+}
+.jmc-logs-frame {
+  flex: 1; width: 100%; border: none;
+  border-top: 0.5px solid var(--line-1);
+}
+
+/* Bouton Home flottant supprimé — remplacé par le logo Jarvis dans la topbar /mc */

--- a/src/jarvis/interfaces/ui/static/mission_control.js
+++ b/src/jarvis/interfaces/ui/static/mission_control.js
@@ -1,0 +1,67 @@
+/**
+ * mission_control.js — Jarvis UI v2 (slim)
+ *
+ * Responsabilités :
+ *  1. Appliquer le thème sauvegardé (localStorage) au boot sur toutes les pages
+ *  2. Injecter le bouton Home flottant sur les pages hors home
+ *  3. Rediriger openMissionControl() vers /mc
+ *
+ * PAS de logique overlay, PAS de panneau Interface ici.
+ * Tout ça est dans mc.js (page /mc).
+ */
+
+(function () {
+  'use strict';
+
+  const LS_THEME_KEY = 'jarvis_theme_v1';
+
+  const THEME_VARS = [
+    '--bg-0', '--bg-2', '--accent', '--fg-0',
+    '--grain-opacity', '--vignette-opacity',
+  ];
+
+  /* ── Appliquer le thème sauvegardé ───────────────────────────────────── */
+
+  function loadTheme() {
+    try { return JSON.parse(localStorage.getItem(LS_THEME_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+
+  function applyTheme(theme) {
+    const root = document.documentElement;
+    THEME_VARS.forEach(k => {
+      if (theme[k] !== undefined) root.style.setProperty(k, theme[k]);
+    });
+    if (theme['--base-font-size']) {
+      root.style.setProperty('font-size', theme['--base-font-size'] + 'px');
+    }
+    if (theme['--accent'] && theme['--accent'].startsWith('#') && theme['--accent'].length === 7) {
+      const r = parseInt(theme['--accent'].slice(1,3),16);
+      const g = parseInt(theme['--accent'].slice(3,5),16);
+      const b = parseInt(theme['--accent'].slice(5,7),16);
+      root.style.setProperty('--accent-soft', `rgba(${r},${g},${b},0.14)`);
+      root.style.setProperty('--accent-line', `rgba(${r},${g},${b},0.32)`);
+    }
+    if (theme['--fg-0'] && theme['--fg-0'].startsWith('#') && theme['--fg-0'].length === 7) {
+      const r = parseInt(theme['--fg-0'].slice(1,3),16);
+      const g = parseInt(theme['--fg-0'].slice(3,5),16);
+      const b = parseInt(theme['--fg-0'].slice(5,7),16);
+      root.style.setProperty('--fg-1', `rgba(${r},${g},${b},0.78)`);
+      root.style.setProperty('--fg-2', `rgba(${r},${g},${b},0.55)`);
+      root.style.setProperty('--fg-3', `rgba(${r},${g},${b},0.36)`);
+      root.style.setProperty('--fg-4', `rgba(${r},${g},${b},0.20)`);
+    }
+  }
+
+  applyTheme(loadTheme());
+
+  /* ── Rediriger openMissionControl vers /mc ───────────────────────────── */
+
+  if (window.Jarvis) {
+    Jarvis.openMissionControl  = function () { window.location.href = '/mc'; };
+    Jarvis.closeMissionControl = function () {};
+  }
+
+  /* Bouton Home supprimé — le logo Jarvis dans la topbar /mc joue ce rôle */
+
+})();

--- a/src/jarvis/interfaces/ui/static/mission_control.js
+++ b/src/jarvis/interfaces/ui/static/mission_control.js
@@ -55,6 +55,16 @@
 
   applyTheme(loadTheme());
 
+  /* Injecter la couleur accent pour l'orbe (lu par sphereStyle.js) */
+  (function () {
+    try {
+      const t = JSON.parse(localStorage.getItem('jarvis_theme_v1') || '{}');
+      if (t['--accent'] && /^#[0-9a-fA-F]{6}$/.test(t['--accent'])) {
+        window.JARVIS_ACCENT_COLOR = t['--accent'];
+      }
+    } catch (e) {}
+  })();
+
   /* ── Rediriger openMissionControl vers /mc ───────────────────────────── */
 
   if (window.Jarvis) {

--- a/src/jarvis/interfaces/ui/static/mission_control.js.bak-1782256436
+++ b/src/jarvis/interfaces/ui/static/mission_control.js.bak-1782256436
@@ -1,0 +1,85 @@
+/**
+ * mission_control.js — Jarvis UI v2 (slim)
+ *
+ * Responsabilités :
+ *  1. Appliquer le thème sauvegardé (localStorage) au boot sur toutes les pages
+ *  2. Injecter le bouton Home flottant sur les pages hors home
+ *  3. Rediriger openMissionControl() vers /mc
+ *
+ * PAS de logique overlay, PAS de panneau Interface ici.
+ * Tout ça est dans mc.js (page /mc).
+ */
+
+(function () {
+  'use strict';
+
+  const LS_THEME_KEY = 'jarvis_theme_v1';
+
+  const THEME_VARS = [
+    '--bg-0', '--bg-2', '--accent', '--fg-0',
+    '--grain-opacity', '--vignette-opacity',
+  ];
+
+  /* ── Appliquer le thème sauvegardé ───────────────────────────────────── */
+
+  function loadTheme() {
+    try { return JSON.parse(localStorage.getItem(LS_THEME_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+
+  function applyTheme(theme) {
+    const root = document.documentElement;
+    THEME_VARS.forEach(k => {
+      if (theme[k] !== undefined) root.style.setProperty(k, theme[k]);
+    });
+    if (theme['--base-font-size']) {
+      root.style.setProperty('font-size', theme['--base-font-size'] + 'px');
+    }
+    if (theme['--accent'] && theme['--accent'].startsWith('#') && theme['--accent'].length === 7) {
+      const r = parseInt(theme['--accent'].slice(1,3),16);
+      const g = parseInt(theme['--accent'].slice(3,5),16);
+      const b = parseInt(theme['--accent'].slice(5,7),16);
+      root.style.setProperty('--accent-soft', `rgba(${r},${g},${b},0.14)`);
+      root.style.setProperty('--accent-line', `rgba(${r},${g},${b},0.32)`);
+    }
+    if (theme['--fg-0'] && theme['--fg-0'].startsWith('#') && theme['--fg-0'].length === 7) {
+      const r = parseInt(theme['--fg-0'].slice(1,3),16);
+      const g = parseInt(theme['--fg-0'].slice(3,5),16);
+      const b = parseInt(theme['--fg-0'].slice(5,7),16);
+      root.style.setProperty('--fg-1', `rgba(${r},${g},${b},0.78)`);
+      root.style.setProperty('--fg-2', `rgba(${r},${g},${b},0.55)`);
+      root.style.setProperty('--fg-3', `rgba(${r},${g},${b},0.36)`);
+      root.style.setProperty('--fg-4', `rgba(${r},${g},${b},0.20)`);
+    }
+  }
+
+  applyTheme(loadTheme());
+
+  /* ── Rediriger openMissionControl vers /mc ───────────────────────────── */
+
+  if (window.Jarvis) {
+    Jarvis.openMissionControl  = function () { window.location.href = '/mc'; };
+    Jarvis.closeMissionControl = function () {};
+  }
+
+  /* ── Bouton Home flottant ────────────────────────────────────────────── */
+
+  function mountHomeButton() {
+    if (document.getElementById('jmc-home-btn')) return;
+    if (window.location.pathname === '/' || window.location.pathname === '') return;
+    const btn = document.createElement('button');
+    btn.id = 'jmc-home-btn';
+    btn.className = 'jmc-home-btn';
+    btn.title = 'Retour Home';
+    btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12L12 3l9 9"/><path d="M9 21V12h6v9"/></svg>';
+    btn.addEventListener('click', () => { window.location.href = '/'; });
+    document.body.appendChild(btn);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', mountHomeButton);
+  } else {
+    mountHomeButton();
+  }
+
+})();

--- a/src/jarvis/interfaces/ui/static/mission_control.js.bak-1782256749
+++ b/src/jarvis/interfaces/ui/static/mission_control.js.bak-1782256749
@@ -1,0 +1,86 @@
+/**
+ * mission_control.js — Jarvis UI v2 (slim)
+ *
+ * Responsabilités :
+ *  1. Appliquer le thème sauvegardé (localStorage) au boot sur toutes les pages
+ *  2. Injecter le bouton Home flottant sur les pages hors home
+ *  3. Rediriger openMissionControl() vers /mc
+ *
+ * PAS de logique overlay, PAS de panneau Interface ici.
+ * Tout ça est dans mc.js (page /mc).
+ */
+
+(function () {
+  'use strict';
+
+  const LS_THEME_KEY = 'jarvis_theme_v1';
+
+  const THEME_VARS = [
+    '--bg-0', '--bg-2', '--accent', '--fg-0',
+    '--grain-opacity', '--vignette-opacity',
+  ];
+
+  /* ── Appliquer le thème sauvegardé ───────────────────────────────────── */
+
+  function loadTheme() {
+    try { return JSON.parse(localStorage.getItem(LS_THEME_KEY) || '{}'); }
+    catch (e) { return {}; }
+  }
+
+  function applyTheme(theme) {
+    const root = document.documentElement;
+    THEME_VARS.forEach(k => {
+      if (theme[k] !== undefined) root.style.setProperty(k, theme[k]);
+    });
+    if (theme['--base-font-size']) {
+      root.style.setProperty('font-size', theme['--base-font-size'] + 'px');
+    }
+    if (theme['--accent'] && theme['--accent'].startsWith('#') && theme['--accent'].length === 7) {
+      const r = parseInt(theme['--accent'].slice(1,3),16);
+      const g = parseInt(theme['--accent'].slice(3,5),16);
+      const b = parseInt(theme['--accent'].slice(5,7),16);
+      root.style.setProperty('--accent-soft', `rgba(${r},${g},${b},0.14)`);
+      root.style.setProperty('--accent-line', `rgba(${r},${g},${b},0.32)`);
+    }
+    if (theme['--fg-0'] && theme['--fg-0'].startsWith('#') && theme['--fg-0'].length === 7) {
+      const r = parseInt(theme['--fg-0'].slice(1,3),16);
+      const g = parseInt(theme['--fg-0'].slice(3,5),16);
+      const b = parseInt(theme['--fg-0'].slice(5,7),16);
+      root.style.setProperty('--fg-1', `rgba(${r},${g},${b},0.78)`);
+      root.style.setProperty('--fg-2', `rgba(${r},${g},${b},0.55)`);
+      root.style.setProperty('--fg-3', `rgba(${r},${g},${b},0.36)`);
+      root.style.setProperty('--fg-4', `rgba(${r},${g},${b},0.20)`);
+    }
+  }
+
+  applyTheme(loadTheme());
+
+  /* ── Rediriger openMissionControl vers /mc ───────────────────────────── */
+
+  if (window.Jarvis) {
+    Jarvis.openMissionControl  = function () { window.location.href = '/mc'; };
+    Jarvis.closeMissionControl = function () {};
+  }
+
+  /* ── Bouton Home flottant ────────────────────────────────────────────── */
+
+  function mountHomeButton() {
+    if (document.getElementById('jmc-home-btn')) return;
+    if (window.location.pathname === '/' || window.location.pathname === '') return;
+    if (document.body && document.body.dataset.mode === 'home') return;
+    const btn = document.createElement('button');
+    btn.id = 'jmc-home-btn';
+    btn.className = 'jmc-home-btn';
+    btn.title = 'Retour Home';
+    btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12L12 3l9 9"/><path d="M9 21V12h6v9"/></svg>';
+    btn.addEventListener('click', () => { window.location.href = '/'; });
+    document.body.appendChild(btn);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', mountHomeButton);
+  } else {
+    mountHomeButton();
+  }
+
+})();

--- a/src/jarvis/interfaces/ui/static/routines.html
+++ b/src/jarvis/interfaces/ui/static/routines.html
@@ -528,5 +528,16 @@
 
   loadAll();
 </script>
+<style>
+.jmc-home-btn-standalone{position:fixed;bottom:24px;left:24px;z-index:9000;
+background:rgba(15,20,31,0.9);border:0.5px solid rgba(220,232,255,0.10);
+border-radius:8px;color:rgba(220,232,255,0.5);width:36px;height:36px;
+display:flex;align-items:center;justify-content:center;
+text-decoration:none;opacity:.55;transition:opacity .15s,border-color .15s,color .15s;}
+.jmc-home-btn-standalone:hover{opacity:1;border-color:#4A9EFF;color:#4A9EFF;}
+</style>
+<a href="/" class="jmc-home-btn-standalone" title="Retour Home">
+<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12L12 3l9 9"/><path d="M9 21V12h6v9"/></svg>
+</a>
 </body>
 </html>

--- a/src/jarvis/interfaces/ui/static/routines.html.bak-1782249020
+++ b/src/jarvis/interfaces/ui/static/routines.html.bak-1782249020
@@ -1,0 +1,532 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jarvis — Routines</title>
+  <link rel="icon" type="image/png" href="/favicon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Syne:wght@700;800&family=DM+Sans:ital,wght@0,400;0,500;0,600&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:    #06080D;
+      --b1:    #4A9EFF;
+      --b2:    rgba(74,158,255,0.55);
+      --b3:    rgba(74,158,255,0.18);
+      --b4:    rgba(74,158,255,0.08);
+      --text:  #DCE8FF;
+      --dim:   rgba(170,195,230,0.55);
+      --muted: rgba(100,130,175,0.40);
+      --green: #36D399;
+      --amber: #FBBF24;
+      --red:   #F87171;
+      --panel: rgba(5,8,22,0.78);
+      --glass: rgba(8,13,32,0.72);
+    }
+
+    html, body {
+      width: 100%; height: 100%;
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'DM Sans', sans-serif;
+      font-size: 13px;
+      overflow: hidden;
+    }
+
+    body::before {
+      content: '';
+      position: fixed; inset: 0; z-index: 0; pointer-events: none;
+      opacity: 0.028;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+      background-size: 160px;
+    }
+
+    ::-webkit-scrollbar { width: 3px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--b3); border-radius: 99px; }
+    * { scrollbar-width: thin; scrollbar-color: var(--b3) transparent; }
+
+    /* ── Header ─────────────────────────────────────────────── */
+    header {
+      position: relative; z-index: 10;
+      display: flex; align-items: center; gap: 16px;
+      padding: 0 28px;
+      height: 56px;
+      background: rgba(4,6,16,0.92);
+      border-bottom: 1px solid var(--b3);
+      backdrop-filter: blur(24px);
+    }
+
+    .brand {
+      font: 800 14px/1 'Syne', sans-serif;
+      letter-spacing: 0.18em; text-transform: uppercase;
+      color: #fff;
+      text-shadow: 0 0 28px rgba(74,158,255,0.45);
+    }
+    .brand em { font-style: normal; color: var(--b1); }
+
+    .hd-rule { flex: 0 0 1px; height: 20px; background: var(--b3); }
+
+    header a {
+      font: 500 10px/1 'DM Mono', monospace;
+      letter-spacing: 0.22em; text-transform: uppercase;
+      color: var(--muted); text-decoration: none;
+      transition: color .15s;
+    }
+    header a:hover { color: var(--b1); }
+    header a.active { color: var(--b1); }
+
+    .hd-spacer { flex: 1; }
+
+    .hd-refresh {
+      display: flex; align-items: center; gap: 6px;
+      font: 500 10px/1 'DM Mono', monospace;
+      letter-spacing: 0.16em; text-transform: uppercase;
+      color: var(--muted);
+      background: var(--b4);
+      border: 1px solid var(--b3);
+      border-radius: 99px;
+      padding: 6px 14px;
+      cursor: pointer;
+      transition: color .15s, border-color .15s;
+    }
+    .hd-refresh:hover { color: var(--b1); border-color: var(--b2); }
+
+    /* ── Layout ─────────────────────────────────────────────── */
+    .layout {
+      display: grid;
+      grid-template-columns: 220px 1fr;
+      grid-template-rows: 1fr;
+      height: calc(100vh - 56px);
+      position: relative; z-index: 1;
+    }
+
+    /* ── Sidebar ────────────────────────────────────────────── */
+    #sidebar {
+      border-right: 1px solid var(--b3);
+      background: var(--panel);
+      backdrop-filter: blur(20px);
+      display: flex; flex-direction: column; overflow: hidden;
+    }
+
+    .col-hd {
+      padding: 18px 18px 14px;
+      flex-shrink: 0;
+    }
+    .col-label {
+      font: 700 10px/1 'Syne', sans-serif;
+      letter-spacing: 0.24em; text-transform: uppercase;
+      color: var(--b1);
+    }
+    .col-rule {
+      height: 1px; background: var(--b3);
+      margin: 10px 18px 0; flex-shrink: 0;
+    }
+
+    #routine-list {
+      flex: 1; overflow-y: auto;
+      padding: 8px 10px 10px;
+      display: flex; flex-direction: column; gap: 3px;
+    }
+
+    .routine-item {
+      padding: 10px 12px;
+      border-radius: 10px;
+      border: 1px solid transparent;
+      cursor: pointer;
+      transition: background .15s, border-color .15s;
+    }
+    .routine-item:hover {
+      background: var(--b4);
+      border-color: var(--b3);
+    }
+    .routine-item.active {
+      background: rgba(45,125,210,0.10);
+      border-color: rgba(74,158,255,0.32);
+    }
+    .ri-name {
+      font: 500 12px/1 'DM Mono', monospace;
+      color: var(--text);
+      margin-bottom: 4px;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .ri-trigger {
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--muted);
+    }
+
+    .sidebar-empty {
+      flex: 1; display: flex; flex-direction: column;
+      align-items: center; justify-content: center; gap: 8px;
+      padding: 20px;
+    }
+    .sidebar-empty p {
+      font: 400 10px/1.5 'DM Mono', monospace;
+      letter-spacing: 0.12em; text-transform: uppercase;
+      color: var(--muted); text-align: center;
+    }
+
+    /* ── Main pane ──────────────────────────────────────────── */
+    #pane {
+      display: flex; flex-direction: column;
+      overflow: hidden;
+      background: rgba(3,5,14,0.55);
+    }
+
+    .pane-toolbar {
+      flex-shrink: 0;
+      display: flex; align-items: center; gap: 12px;
+      padding: 14px 24px 12px;
+      border-bottom: 1px solid var(--b3);
+      background: rgba(4,6,18,0.60);
+    }
+
+    .pane-title {
+      font: 700 12px/1 'Syne', sans-serif;
+      letter-spacing: 0.18em; text-transform: uppercase;
+      color: var(--b1);
+      flex: 1;
+    }
+
+    .pane-ts {
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--muted);
+    }
+
+    #runs-list {
+      flex: 1; overflow-y: auto;
+      padding: 16px 20px 20px;
+      display: flex; flex-direction: column; gap: 8px;
+    }
+
+    /* ── Run card ───────────────────────────────────────────── */
+    .run-card {
+      background: var(--glass);
+      border: 1px solid var(--b3);
+      border-radius: 12px;
+      overflow: hidden;
+      transition: border-color .15s;
+    }
+    .run-card:hover { border-color: var(--b2); }
+
+    .run-summary {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 16px;
+      cursor: pointer;
+      user-select: none;
+    }
+
+    .run-expand {
+      font: 400 11px/1 'DM Mono', monospace;
+      color: var(--muted);
+      transition: transform .2s;
+      flex-shrink: 0;
+    }
+    .run-card.open .run-expand { transform: rotate(90deg); }
+
+    .run-name {
+      font: 500 12px/1 'DM Mono', monospace;
+      color: var(--text);
+      flex: 1;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+
+    .run-id {
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--muted);
+    }
+
+    /* Status badge */
+    .badge {
+      display: inline-flex; align-items: center; gap: 4px;
+      font: 500 9px/1 'DM Mono', monospace;
+      letter-spacing: 0.10em; text-transform: uppercase;
+      padding: 3px 9px;
+      border-radius: 99px; border: 1px solid;
+      flex-shrink: 0;
+    }
+    .badge::before {
+      content: '';
+      width: 4px; height: 4px; border-radius: 50%;
+      background: currentColor; flex-shrink: 0;
+    }
+    .badge.success  { color: var(--green); border-color: rgba(54,211,153,0.28); background: rgba(54,211,153,0.06); }
+    .badge.failed   { color: var(--red);   border-color: rgba(248,113,113,0.28); background: rgba(248,113,113,0.06); }
+    .badge.running  { color: var(--b1);    border-color: rgba(74,158,255,0.28);  background: rgba(74,158,255,0.06); }
+    .badge.pending  { color: var(--dim);   border-color: var(--b3);              background: var(--b4); }
+    .badge.skipped  { color: var(--muted); border-color: rgba(100,130,175,0.20); background: transparent; }
+
+    .run-meta {
+      display: flex; flex-direction: column; gap: 2px; align-items: flex-end;
+    }
+    .run-time {
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--muted);
+    }
+    .run-cost {
+      font: 500 10px/1 'DM Mono', monospace;
+      color: var(--dim);
+    }
+
+    /* ── Audit log ──────────────────────────────────────────── */
+    .audit-log {
+      display: none;
+      border-top: 1px solid var(--b3);
+      padding: 12px 16px 14px;
+      flex-direction: column; gap: 6px;
+    }
+    .run-card.open .audit-log { display: flex; }
+
+    .audit-hd {
+      font: 700 9px/1 'Syne', sans-serif;
+      letter-spacing: 0.22em; text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 6px;
+    }
+
+    .audit-step {
+      display: grid;
+      grid-template-columns: 80px 1fr;
+      gap: 8px;
+      align-items: start;
+      padding: 6px 0;
+      border-bottom: 1px solid rgba(74,158,255,0.06);
+    }
+    .audit-step:last-child { border-bottom: none; }
+
+    .step-event {
+      font: 500 10px/1 'DM Mono', monospace;
+      color: var(--b2);
+      white-space: nowrap;
+    }
+    .step-detail {
+      font: 400 11px/1.5 'DM Sans', sans-serif;
+      color: var(--dim);
+      word-break: break-word;
+    }
+    .step-ts {
+      font: 400 9px/1 'DM Mono', monospace;
+      color: var(--muted);
+      grid-column: 1 / -1;
+      margin-bottom: 2px;
+    }
+
+    .audit-empty {
+      font: 400 10px/1 'DM Mono', monospace;
+      color: var(--muted);
+      padding: 4px 0;
+    }
+
+    /* ── Summary row under audit ─────────────────────────────── */
+    .run-summary-text {
+      font: 400 11px/1.5 'DM Sans', sans-serif;
+      color: var(--dim);
+      padding: 8px 0 0;
+      border-top: 1px solid var(--b3);
+      margin-top: 6px;
+    }
+
+    /* ── Empty / disabled ───────────────────────────────────── */
+    .empty-state {
+      flex: 1; display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      gap: 12px; padding: 40px;
+    }
+    .empty-icon { font-size: 32px; opacity: .12; }
+    .empty-title {
+      font: 700 10px/1 'Syne', sans-serif;
+      letter-spacing: 0.24em; text-transform: uppercase;
+      color: var(--muted);
+    }
+    .empty-sub {
+      font: 400 11px/1.6 'DM Sans', sans-serif;
+      color: var(--muted); text-align: center; max-width: 300px;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <span class="brand">JARVIS <em>OS</em></span>
+  <span class="hd-rule"></span>
+  <a href="/admin.html">Admin</a>
+  <a href="/settings.html">Réglages</a>
+  <a href="/budget.html">Budget</a>
+  <a href="/routines.html" class="active">Routines</a>
+  <span class="hd-spacer"></span>
+  <button class="hd-refresh" onclick="loadAll()">↺ Actualiser</button>
+</header>
+
+<div class="layout">
+  <div id="sidebar">
+    <div class="col-hd">
+      <div class="col-label">Routines</div>
+    </div>
+    <div class="col-rule"></div>
+    <div id="routine-list">
+      <div class="sidebar-empty"><p>Chargement…</p></div>
+    </div>
+  </div>
+
+  <div id="pane">
+    <div class="pane-toolbar">
+      <div class="pane-title" id="pane-title">Journal des décisions</div>
+      <div class="pane-ts" id="pane-ts"></div>
+    </div>
+    <div id="runs-list">
+      <div class="empty-state">
+        <div class="empty-icon">⧗</div>
+        <div class="empty-title">Chargement…</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  let _routines = [];
+  let _filter = null;
+
+  function fmtDate(iso) {
+    if (!iso) return '—';
+    const d = new Date(iso);
+    return d.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit' })
+      + ' ' + d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  }
+
+  function fmtDuration(start, end) {
+    if (!start || !end) return null;
+    const ms = new Date(end) - new Date(start);
+    if (ms < 1000) return `${ms} ms`;
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)} s`;
+    return `${Math.floor(ms / 60000)} m ${Math.round((ms % 60000) / 1000)} s`;
+  }
+
+  function fmtCost(usd) {
+    if (usd == null) return null;
+    return `$${Number(usd).toFixed(5)}`;
+  }
+
+  function statusBadge(s) {
+    const labels = { success: 'Succès', failed: 'Échec', running: 'En cours', pending: 'En attente', skipped: 'Ignoré' };
+    return `<span class="badge ${s || 'pending'}">${labels[s] || s}</span>`;
+  }
+
+  async function loadAll() {
+    const [routinesRes, runsRes] = await Promise.all([
+      fetch('/api/routines'),
+      fetch(`/api/routines/runs?limit=100${_filter ? '&routine=' + encodeURIComponent(_filter) : ''}`)
+    ]);
+
+    const routinesData = await routinesRes.json();
+    const runsData = await runsRes.json();
+
+    if (!routinesData.enabled || !runsData.enabled) {
+      renderDisabled();
+      return;
+    }
+
+    _routines = routinesData.routines || [];
+    renderSidebar(_routines);
+    renderRuns(runsData.runs || []);
+
+    const ts = new Date().toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+    document.getElementById('pane-ts').textContent = `${(runsData.runs || []).length} run(s) · mis à jour ${ts}`;
+  }
+
+  function renderDisabled() {
+    document.getElementById('routine-list').innerHTML = `
+      <div class="sidebar-empty"><p>Désactivé</p></div>`;
+    document.getElementById('runs-list').innerHTML = `
+      <div class="empty-state">
+        <div class="empty-icon">⚙</div>
+        <div class="empty-title">Routines désactivées</div>
+        <div class="empty-sub">Activez <code>ROUTINES_ENABLED=true</code> dans votre .env pour activer le moteur de routines.</div>
+      </div>`;
+  }
+
+  function renderSidebar(routines) {
+    const list = document.getElementById('routine-list');
+    if (routines.length === 0) {
+      list.innerHTML = `<div class="sidebar-empty"><p>Aucune routine enregistrée</p></div>`;
+      return;
+    }
+    list.innerHTML = [
+      `<div class="routine-item${_filter === null ? ' active' : ''}" onclick="setFilter(null)">
+        <div class="ri-name">Toutes les routines</div>
+        <div class="ri-trigger">${routines.length} routine(s)</div>
+       </div>`
+    ].concat(routines.map(r => `
+      <div class="routine-item${_filter === r.name ? ' active' : ''}" onclick="setFilter(${JSON.stringify(r.name)})">
+        <div class="ri-name">${r.name}</div>
+        <div class="ri-trigger">${r.trigger}${r.cron_expr ? ' · ' + r.cron_expr : ''}${r.interval_seconds ? ' · ' + r.interval_seconds + 's' : ''}</div>
+      </div>`
+    )).join('');
+  }
+
+  function setFilter(name) {
+    _filter = name;
+    document.getElementById('pane-title').textContent = name ? name : 'Journal des décisions';
+    loadAll();
+  }
+
+  function renderRuns(runs) {
+    const list = document.getElementById('runs-list');
+    if (runs.length === 0) {
+      list.innerHTML = `
+        <div class="empty-state">
+          <div class="empty-icon">📋</div>
+          <div class="empty-title">Aucun run enregistré</div>
+          <div class="empty-sub">Les exécutions de routines apparaîtront ici avec leur journal d'audit.</div>
+        </div>`;
+      return;
+    }
+
+    list.innerHTML = runs.map((r, i) => {
+      const dur = fmtDuration(r.started_at, r.finished_at);
+      const cost = fmtCost(r.cost_usd);
+      const steps = r.audit_log || [];
+
+      const stepsHtml = steps.length === 0
+        ? `<div class="audit-empty">Aucune étape d'audit enregistrée.</div>`
+        : steps.map(s => `
+          <div class="audit-step">
+            <div class="step-ts">${fmtDate(s.ts)}</div>
+            <div class="step-event">${s.event}</div>
+            <div class="step-detail">${s.detail || '—'}</div>
+          </div>`).join('');
+
+      const summaryHtml = r.result_summary
+        ? `<div class="run-summary-text">↳ ${r.result_summary}</div>`
+        : '';
+
+      return `
+        <div class="run-card" id="run-${i}">
+          <div class="run-summary" onclick="toggleRun(${i})">
+            <span class="run-expand">▶</span>
+            <span class="run-name">${r.routine_name}</span>
+            ${statusBadge(r.status)}
+            <div class="run-meta">
+              <span class="run-time">${fmtDate(r.started_at)}${dur ? ' · ' + dur : ''}</span>
+              ${cost ? `<span class="run-cost">${cost}</span>` : ''}
+            </div>
+            <span class="run-id">${r.id}</span>
+          </div>
+          <div class="audit-log">
+            <div class="audit-hd">Journal d'audit</div>
+            ${stepsHtml}
+            ${summaryHtml}
+          </div>
+        </div>`;
+    }).join('');
+  }
+
+  function toggleRun(i) {
+    document.getElementById(`run-${i}`).classList.toggle('open');
+  }
+
+  loadAll();
+</script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/settings.css
+++ b/src/jarvis/interfaces/ui/static/settings.css
@@ -9,7 +9,7 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   appearance: none; display: flex; align-items: center; justify-content: space-between;
   gap: 10px; min-width: 200px;
   background: var(--bg-2); border: 1px solid var(--line-2); border-radius: 6px;
-  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  color: var(--fg-1); font-family: var(--mono); font-size: 0.7188rem;
   padding: 7px 10px; cursor: pointer;
   transition: border-color .15s;
 }
@@ -29,7 +29,7 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 
 .csel-item {
   padding: 7px 10px; border-radius: 5px;
-  font-family: var(--mono); font-size: 11.5px; color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.7188rem; color: var(--fg-2);
   cursor: pointer; transition: background .1s, color .1s;
 }
 .csel-item:hover  { background: var(--accent-soft); color: var(--fg-1); }
@@ -42,8 +42,8 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   padding: 14px 0; border-bottom: 0.5px solid var(--line-1);
 }
 .setting-row:last-child { border-bottom: 0; }
-.setting-label { font-size: 13px; color: var(--fg-1); line-height: 1.3; }
-.setting-sub   { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 3px; letter-spacing: 0.06em; }
+.setting-label { font-size: 0.8125rem; color: var(--fg-1); line-height: 1.3; }
+.setting-sub   { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); margin-top: 3px; letter-spacing: 0.06em; }
 
 /* ── Key rows (API keys, masked) ── */
 .key-row {
@@ -51,9 +51,9 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   align-items: center; gap: 14px;
   padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
 }
-.key-name { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; color: var(--fg-2); }
+.key-name { font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.08em; color: var(--fg-2); }
 .key-val  {
-  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-3);
   letter-spacing: 0.04em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .key-actions { display: flex; gap: 6px; }
@@ -64,8 +64,8 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   align-items: center; gap: 16px;
   padding: 13px 0; border-bottom: 0.5px solid var(--line-1);
 }
-.model-name { font-size: 13px; color: var(--fg-0); }
-.model-sub  { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 3px; }
+.model-name { font-size: 0.8125rem; color: var(--fg-0); }
+.model-sub  { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); margin-top: 3px; }
 
 /* ── Conso dashboard ── */
 .conso-evolution h2,
@@ -91,32 +91,32 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 }
 .conso-tile .l {
   font-family: var(--mono);
-  font-size: 9.5px; letter-spacing: 0.24em; text-transform: uppercase;
+  font-size: 0.5938rem; letter-spacing: 0.24em; text-transform: uppercase;
   color: var(--fg-3); margin-bottom: 14px;
 }
 .conso-tile .v {
-  font-family: var(--serif); font-weight: 300; font-size: 38px;
+  font-family: var(--serif); font-weight: 300; font-size: 2.375rem;
   letter-spacing: -0.035em; line-height: 1; color: var(--fg-0);
   display: flex; align-items: baseline; gap: 2px;
 }
-.conso-tile.primary .v { font-size: 44px; }
+.conso-tile.primary .v { font-size: 2.75rem; }
 .conso-tile .v .dec { font-family: var(--serif); font-weight: 300; }
 .conso-tile .v .unit {
-  font-family: var(--mono); font-size: 18px; color: var(--fg-2);
+  font-family: var(--mono); font-size: 1.125rem; color: var(--fg-2);
   letter-spacing: 0; margin-left: 2px;
 }
 .conso-tile .v .rel {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.16em;
   color: var(--green); text-transform: uppercase;
   margin-left: 8px; align-self: flex-end; padding-bottom: 4px;
 }
 .conso-tile .v.gold { color: var(--gold); }
 .conso-tile .d {
   margin-top: 10px; font-family: var(--mono);
-  font-size: 10px; letter-spacing: 0.06em; color: var(--fg-3);
+  font-size: 0.625rem; letter-spacing: 0.06em; color: var(--fg-3);
 }
 .conso-tile .d.sub {
-  font-family: var(--sans); font-size: 11.5px;
+  font-family: var(--sans); font-size: 0.7188rem;
   letter-spacing: 0; color: var(--fg-3);
 }
 .conso-budget-bar {
@@ -128,7 +128,7 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   background: var(--accent); box-shadow: 0 0 6px var(--accent);
 }
 .conso-tile-flag {
-  margin-top: 10px; font-family: var(--mono); font-size: 10px;
+  margin-top: 10px; font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.18em; text-transform: lowercase; color: var(--gold);
   display: inline-flex; align-items: center; gap: 6px;
 }
@@ -142,11 +142,11 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 .conso-evolution { padding: 24px 26px; margin-bottom: 18px; }
 .conso-evolution .card-hd { border-bottom: 0; padding-bottom: 18px; margin-bottom: 0; }
 .conso-evolution .card-hd h2 {
-  font-family: var(--serif); font-weight: 300; font-size: 22px;
+  font-family: var(--serif); font-weight: 300; font-size: 1.375rem;
   letter-spacing: -0.025em; color: var(--fg-0);
 }
 .conso-evolution .card-hd .sub {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.1em;
   color: var(--fg-3); display: block; margin-top: 3px;
 }
 .conso-range { display: flex; gap: 8px; }
@@ -155,20 +155,20 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   background: var(--bg-3); border: 0.5px solid var(--line-1); border-radius: 6px;
 }
 .conso-range-group button {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.08em;
   padding: 4px 8px; border-radius: 4px; color: var(--fg-3);
   background: none; border: none; cursor: pointer;
   transition: background .15s, color .15s;
 }
 .conso-range-group button.on,
 .conso-range-group button[data-on="true"] {
-  background: rgba(220,232,255,0.06); color: var(--fg-0);
+  background: rgba(var(--c-fg), 0.06); color: var(--fg-0);
 }
 .conso-area-wrap { width: 100%; height: 280px; overflow: hidden; }
 .conso-area-wrap svg { width: 100%; height: 100%; display: block; }
 .conso-axis {
   display: flex; justify-content: space-between;
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.12em;
   color: var(--fg-3); padding: 4px 4px 0;
 }
 .conso-legend {
@@ -178,12 +178,12 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 }
 .conso-legend-item {
   display: inline-flex; align-items: center; gap: 8px;
-  font-family: var(--sans); font-size: 12.5px; color: var(--fg-1);
+  font-family: var(--sans); font-size: 0.7812rem; color: var(--fg-1);
 }
 .conso-legend-item .sw {
   width: 8px; height: 8px; border-radius: 2px; display: inline-block;
 }
-.conso-legend-item .val { color: var(--fg-3); font-family: var(--mono); font-size: 11px; }
+.conso-legend-item .val { color: var(--fg-3); font-family: var(--mono); font-size: 0.6875rem; }
 
 /* Two-column rows */
 .conso-row-2 {
@@ -192,11 +192,11 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 }
 .conso-row-2 > .card { margin-bottom: 0; padding: 20px 22px; }
 .conso-row-2 .card-hd h2 {
-  font-family: var(--serif); font-weight: 300; font-size: 22px;
+  font-family: var(--serif); font-weight: 300; font-size: 1.375rem;
   letter-spacing: -0.025em; color: var(--fg-0);
 }
 .conso-row-2 .card-hd .sub {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.1em;
   color: var(--fg-3); display: block; margin-top: 3px;
 }
 
@@ -208,9 +208,9 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 }
 .conso-usage-row:last-child { border-bottom: 0; }
 .conso-usage-sw { width: 10px; height: 10px; border-radius: 3px; margin-top: 5px; }
-.conso-usage-body .nm { font-size: 13px; font-weight: 500; color: var(--fg-0); }
+.conso-usage-body .nm { font-size: 0.8125rem; font-weight: 500; color: var(--fg-0); }
 .conso-usage-body .ctx {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.06em;
   color: var(--fg-3); margin-top: 2px;
 }
 .conso-usage-bar {
@@ -220,11 +220,11 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 .conso-usage-bar > i { display: block; height: 100%; border-radius: 1px; }
 .conso-usage-vals { text-align: right; }
 .conso-usage-vals .val {
-  font-family: var(--serif); font-weight: 300; font-size: 18px;
+  font-family: var(--serif); font-weight: 300; font-size: 1.125rem;
   letter-spacing: -0.02em; color: var(--fg-0);
 }
 .conso-usage-vals .pct {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.04em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.04em;
   color: var(--fg-3); margin-top: 4px;
 }
 
@@ -238,19 +238,19 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 .conso-providers-row {
   display: grid; grid-template-columns: 12px 1fr auto;
   gap: 10px; align-items: center;
-  font-family: var(--sans); font-size: 13px;
+  font-family: var(--sans); font-size: 0.8125rem;
 }
 .conso-providers-row .sw { width: 10px; height: 10px; border-radius: 3px; }
 .conso-providers-row .nm { color: var(--fg-1); }
 .conso-providers-row .val {
-  font-family: var(--mono); font-size: 12px; color: var(--fg-2); letter-spacing: 0.04em;
+  font-family: var(--mono); font-size: 0.75rem; color: var(--fg-2); letter-spacing: 0.04em;
 }
 
 /* Heatmap 24h */
 .conso-heat { border-top: 0.5px solid var(--line-1); padding-top: 14px; margin-top: 4px; }
 .conso-heat-head {
   display: flex; justify-content: space-between;
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.18em;
   text-transform: uppercase; color: var(--fg-3); margin-bottom: 10px;
 }
 .conso-heat-row {
@@ -259,7 +259,7 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 .conso-heat-row i { display: block; height: 22px; border-radius: 2px; }
 .conso-heat-foot {
   display: flex; justify-content: space-between;
-  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  font-family: var(--mono); font-size: 0.5938rem; color: var(--fg-3);
   letter-spacing: 0.06em; margin-top: 8px;
 }
 
@@ -270,14 +270,14 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
 }
 .conso-mod-row:last-child { border-bottom: 0; }
-.conso-mod-row .nm { font-family: var(--mono); font-size: 12.5px; color: var(--fg-0); }
+.conso-mod-row .nm { font-family: var(--mono); font-size: 0.7812rem; color: var(--fg-0); }
 .conso-mod-bar { height: 3px; background: var(--bg-3); border-radius: 2px; overflow: hidden; }
 .conso-mod-bar > i {
   display: block; height: 100%;
   background: var(--accent); box-shadow: 0 0 6px var(--accent);
 }
 .conso-mod-vals { display: flex; gap: 14px; align-items: baseline; }
-.conso-mod-vals .meta { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+.conso-mod-vals .meta { font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-3); }
 .conso-mod-vals .meta.accent { color: var(--accent); }
 
 /* Par skill */
@@ -287,9 +287,9 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
 }
 .conso-skill-row:last-child { border-bottom: 0; }
-.conso-skill-row .nm { font-size: 13px; color: var(--fg-0); }
+.conso-skill-row .nm { font-size: 0.8125rem; color: var(--fg-0); }
 .conso-empty {
-  font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em;
+  font-family: var(--mono); font-size: 0.6875rem; letter-spacing: 0.1em;
   color: var(--fg-3); padding: 24px 0; text-align: center;
 }
 
@@ -309,9 +309,9 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   border-radius: 12px; padding: 16px 18px;
   display: flex; flex-direction: column; gap: 8px;
 }
-.perf-label { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--fg-3); }
-.perf-val   { font-family: var(--serif); font-weight: 300; font-size: 28px; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
-.perf-unit  { font-size: 13px; letter-spacing: 0; opacity: .55; margin-left: 3px; }
+.perf-label { font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.2em; text-transform: uppercase; color: var(--fg-3); }
+.perf-val   { font-family: var(--serif); font-weight: 300; font-size: 1.75rem; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
+.perf-unit  { font-size: 0.8125rem; letter-spacing: 0; opacity: .55; margin-left: 3px; }
 .perf-bar-wrap { height: 2px; background: var(--bg-3); border-radius: 2px; overflow: hidden; }
 .perf-bar-fill { height: 100%; border-radius: 2px; background: var(--accent); transition: width .4s; }
 
@@ -319,7 +319,7 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 .log-viewer {
   background: var(--bg-1); border: 0.5px solid var(--line-1);
   border-radius: 12px; padding: 16px;
-  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-2);
   line-height: 1.6; max-height: 320px; overflow-y: auto;
 }
 .log-entry { display: block; padding: 1px 0; }
@@ -335,23 +335,23 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 
 .about2-name {
   font-family: var(--serif); font-weight: 300;
-  font-size: 42px; letter-spacing: -0.04em;
+  font-size: 2.625rem; letter-spacing: -0.04em;
   color: var(--fg-0); line-height: 1;
 }
 
 .about2-sub-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 
 .about2-badge {
-  font-family: var(--mono); font-size: 9.5px;
+  font-family: var(--mono); font-size: 0.5938rem;
   letter-spacing: 0.14em; text-transform: uppercase;
   color: var(--accent);
-  background: rgba(74, 158, 255, 0.10);
-  border: 1px solid rgba(74, 158, 255, 0.22);
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.22);
   border-radius: 6px; padding: 3px 9px; flex-shrink: 0;
 }
 
 .about2-tagline {
-  font-family: var(--mono); font-size: 11px;
+  font-family: var(--mono); font-size: 0.6875rem;
   letter-spacing: 0.04em; color: var(--fg-3);
 }
 
@@ -363,14 +363,14 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 }
 
 .about2-dt {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.16em;
   text-transform: uppercase; color: var(--fg-4);
   padding: 10px 0; border-bottom: 1px solid var(--line-1);
 }
 .about2-dt:last-of-type { border-bottom: none; }
 
 .about2-dd {
-  font-family: var(--serif); font-weight: 300; font-size: 14px;
+  font-family: var(--serif); font-weight: 300; font-size: 0.875rem;
   color: var(--fg-1); padding: 10px 0; margin: 0;
   border-bottom: 1px solid var(--line-1);
 }
@@ -378,7 +378,7 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 
 .about2-copy {
   padding: 20px 0 20px; margin: 0;
-  font-family: var(--mono); font-size: 10px;
+  font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.10em; color: var(--fg-4);
 }
 
@@ -386,18 +386,18 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 
 .about2-update-btn {
   align-self: flex-start;
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.12em;
   text-transform: uppercase; color: var(--fg-0);
   padding: 8px 16px;
-  background: rgba(220, 232, 255, 0.05);
+  background: rgba(var(--c-fg), 0.05);
   border: 0.5px solid var(--line-3); border-radius: 8px;
   cursor: pointer; transition: background .15s, border-color .15s, opacity .15s;
 }
-.about2-update-btn:hover { background: rgba(220, 232, 255, 0.09); border-color: var(--line-4); }
+.about2-update-btn:hover { background: rgba(var(--c-fg), 0.09); border-color: var(--line-4); }
 .about2-update-btn:disabled { opacity: .45; cursor: default; }
 
 .about2-update-status {
-  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em;
+  font-family: var(--mono); font-size: 0.6562rem; letter-spacing: 0.08em;
   color: var(--fg-3); min-height: 16px;
 }
 .about2-update-status.ok  { color: var(--green); }
@@ -405,31 +405,31 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 
 /* ── Danger zone ── */
 .danger-zone {
-  border: 0.5px solid rgba(229,72,77,.22); border-radius: 12px;
+  border: 0.5px solid rgba(var(--c-red), .22); border-radius: 12px;
   padding: 18px; display: flex; flex-direction: column; gap: 12px;
 }
 .danger-title {
-  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.2em;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.2em;
   text-transform: uppercase; color: var(--red); opacity: .7;
 }
 .danger-row { display: flex; align-items: center; justify-content: space-between; gap: 14px; }
-.danger-label { font-size: 13px; color: var(--fg-1); }
-.danger-sub   { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 3px; }
+.danger-label { font-size: 0.8125rem; color: var(--fg-1); }
+.danger-sub   { font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); margin-top: 3px; }
 .btn-danger {
-  appearance: none; background: rgba(229,72,77,.1);
-  border: 0.5px solid rgba(229,72,77,.4); border-radius: 8px;
-  color: var(--red); font-family: var(--mono); font-size: 10px;
+  appearance: none; background: rgba(var(--c-red), .1);
+  border: 0.5px solid rgba(var(--c-red), .4); border-radius: 8px;
+  color: var(--red); font-family: var(--mono); font-size: 0.625rem;
   letter-spacing: 0.12em; text-transform: uppercase;
   padding: 7px 12px; cursor: pointer; white-space: nowrap;
   transition: background .15s;
 }
-.btn-danger:hover { background: rgba(229,72,77,.2); }
+.btn-danger:hover { background: rgba(var(--c-red), .2); }
 
 /* ── Action buttons (shared with dashboard) ── */
 .m-btn {
   appearance: none; background: transparent;
   border: 0.5px solid var(--line-2); border-radius: 6px;
-  color: var(--fg-2); font-family: var(--mono); font-size: 9.5px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 0.5938rem;
   letter-spacing: 0.1em; text-transform: uppercase;
   padding: 5px 9px; cursor: pointer;
   transition: all .15s; white-space: nowrap;
@@ -438,22 +438,22 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 .m-btn.ghost {
   border-color: transparent; color: var(--fg-3);
 }
-.m-btn.ghost:hover { color: var(--red); border-color: rgba(229,72,77,.3); }
+.m-btn.ghost:hover { color: var(--red); border-color: rgba(var(--c-red), .3); }
 
 /* ── Ollama ── */
 .ollama-offline-row {
   display: flex; align-items: center; gap: 8px;
-  font-family: var(--mono); font-size: 11px; color: var(--fg-3); padding: 12px 0 4px;
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-3); padding: 12px 0 4px;
 }
 .ollama-dot {
   width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
   background: var(--red, #e5484d);
 }
 .ollama-hint {
-  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); padding: 4px 0 10px;
+  font-family: var(--mono); font-size: 0.6562rem; color: var(--fg-3); padding: 4px 0 10px;
 }
 .ollama-lib-sep {
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  font-family: var(--mono); font-size: 0.625rem; letter-spacing: 0.08em;
   text-transform: uppercase; color: var(--fg-3);
   padding: 18px 0 10px; border-top: 0.5px solid var(--line-1); margin-top: 6px;
 }
@@ -464,15 +464,15 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
 }
 .ollama-model-card:last-child { border-bottom: 0; }
 .ollama-model-name {
-  font-size: 13px; color: var(--fg-1); display: flex; align-items: center; gap: 7px;
+  font-size: 0.8125rem; color: var(--fg-1); display: flex; align-items: center; gap: 7px;
 }
 .ollama-tag {
-  font-family: var(--mono); font-size: 9px; letter-spacing: 0.05em;
+  font-family: var(--mono); font-size: 0.5625rem; letter-spacing: 0.05em;
   color: var(--accent); background: var(--accent-soft, rgba(98,126,234,.12));
   border-radius: 3px; padding: 2px 5px; flex-shrink: 0;
 }
 .ollama-model-size {
-  font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 2px;
+  font-family: var(--mono); font-size: 0.625rem; color: var(--fg-3); margin-top: 2px;
 }
 
 /* Pull modal */
@@ -488,10 +488,10 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   box-shadow: 0 24px 60px rgba(0,0,0,.5);
 }
 .ollama-pull-eyebrow {
-  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em;
+  font-family: var(--mono); font-size: 0.5938rem; letter-spacing: 0.1em;
   text-transform: uppercase; color: var(--fg-3);
 }
-.ollama-pull-model-name { font-size: 15px; font-weight: 500; color: var(--fg-1); }
+.ollama-pull-model-name { font-size: 0.9375rem; font-weight: 500; color: var(--fg-1); }
 .ollama-pull-bar {
   height: 4px; background: var(--line-2); border-radius: 2px; overflow: hidden;
 }
@@ -509,5 +509,5 @@ body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
   animation: ollama-slide 1.4s ease-in-out infinite;
 }
 .ollama-pull-status {
-  font-family: var(--mono); font-size: 11px; color: var(--fg-3); min-height: 16px;
+  font-family: var(--mono); font-size: 0.6875rem; color: var(--fg-3); min-height: 16px;
 }

--- a/src/jarvis/interfaces/ui/static/settings.css.bak-1782254922
+++ b/src/jarvis/interfaces/ui/static/settings.css.bak-1782254922
@@ -1,0 +1,513 @@
+/* settings.css — Configuration (Réglages) v2 */
+
+body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
+
+/* ── Custom select ── */
+.csel-wrap { position: relative; display: inline-flex; }
+
+.csel-btn {
+  appearance: none; display: flex; align-items: center; justify-content: space-between;
+  gap: 10px; min-width: 200px;
+  background: var(--bg-2); border: 1px solid var(--line-2); border-radius: 6px;
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 10px; cursor: pointer;
+  transition: border-color .15s;
+}
+.csel-btn:hover,
+.csel-wrap.open .csel-btn { border-color: var(--accent-line); }
+
+.csel-chevron { color: var(--fg-3); flex-shrink: 0; display: flex; align-items: center; transition: transform .15s; }
+.csel-wrap.open .csel-chevron { transform: rotate(180deg); }
+
+.csel-dropdown {
+  display: none; position: absolute; top: calc(100% + 4px); left: 0;
+  min-width: 100%; z-index: 1000;
+  background: var(--bg-2); border: 1px solid var(--line-2); border-radius: 8px;
+  padding: 4px; box-shadow: 0 12px 32px rgba(0,0,0,.5);
+}
+.csel-wrap.open .csel-dropdown { display: block; }
+
+.csel-item {
+  padding: 7px 10px; border-radius: 5px;
+  font-family: var(--mono); font-size: 11.5px; color: var(--fg-2);
+  cursor: pointer; transition: background .1s, color .1s;
+}
+.csel-item:hover  { background: var(--accent-soft); color: var(--fg-1); }
+.csel-item.active { color: var(--accent); }
+
+/* ── Setting rows ── */
+.setting-row {
+  display: grid; grid-template-columns: 1fr auto;
+  align-items: center; gap: 18px;
+  padding: 14px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.setting-row:last-child { border-bottom: 0; }
+.setting-label { font-size: 13px; color: var(--fg-1); line-height: 1.3; }
+.setting-sub   { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 3px; letter-spacing: 0.06em; }
+
+/* ── Key rows (API keys, masked) ── */
+.key-row {
+  display: grid; grid-template-columns: 160px 1fr auto;
+  align-items: center; gap: 14px;
+  padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.key-name { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; color: var(--fg-2); }
+.key-val  {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+  letter-spacing: 0.04em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.key-actions { display: flex; gap: 6px; }
+
+/* ── Model select ── */
+.model-row {
+  display: grid; grid-template-columns: 1fr auto;
+  align-items: center; gap: 16px;
+  padding: 13px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.model-name { font-size: 13px; color: var(--fg-0); }
+.model-sub  { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 3px; }
+
+/* ── Conso dashboard ── */
+.conso-evolution h2,
+.conso-row-2 h2 {
+  margin: 0; padding: 0; font-size: inherit; font-weight: inherit;
+}
+
+.conso-hero {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  gap: 14px;
+  margin-bottom: 18px;
+}
+.conso-tile {
+  position: relative;
+  padding: 18px 20px;
+  border: 0.5px solid var(--line-2);
+  border-radius: 14px;
+  background: rgba(10,14,22,0.35);
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+}
+.conso-tile .l {
+  font-family: var(--mono);
+  font-size: 9.5px; letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-3); margin-bottom: 14px;
+}
+.conso-tile .v {
+  font-family: var(--serif); font-weight: 300; font-size: 38px;
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0);
+  display: flex; align-items: baseline; gap: 2px;
+}
+.conso-tile.primary .v { font-size: 44px; }
+.conso-tile .v .dec { font-family: var(--serif); font-weight: 300; }
+.conso-tile .v .unit {
+  font-family: var(--mono); font-size: 18px; color: var(--fg-2);
+  letter-spacing: 0; margin-left: 2px;
+}
+.conso-tile .v .rel {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em;
+  color: var(--green); text-transform: uppercase;
+  margin-left: 8px; align-self: flex-end; padding-bottom: 4px;
+}
+.conso-tile .v.gold { color: var(--gold); }
+.conso-tile .d {
+  margin-top: 10px; font-family: var(--mono);
+  font-size: 10px; letter-spacing: 0.06em; color: var(--fg-3);
+}
+.conso-tile .d.sub {
+  font-family: var(--sans); font-size: 11.5px;
+  letter-spacing: 0; color: var(--fg-3);
+}
+.conso-budget-bar {
+  margin-top: 10px; height: 2px;
+  background: var(--bg-3); border-radius: 1px; overflow: hidden;
+}
+.conso-budget-bar > i {
+  display: block; height: 100%;
+  background: var(--accent); box-shadow: 0 0 6px var(--accent);
+}
+.conso-tile-flag {
+  margin-top: 10px; font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: lowercase; color: var(--gold);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.conso-tile-flag .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--gold); display: inline-block;
+}
+.conso-spark { display: block; width: 100%; margin-top: auto; padding-top: 6px; }
+
+/* Evolution chart card */
+.conso-evolution { padding: 24px 26px; margin-bottom: 18px; }
+.conso-evolution .card-hd { border-bottom: 0; padding-bottom: 18px; margin-bottom: 0; }
+.conso-evolution .card-hd h2 {
+  font-family: var(--serif); font-weight: 300; font-size: 22px;
+  letter-spacing: -0.025em; color: var(--fg-0);
+}
+.conso-evolution .card-hd .sub {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
+  color: var(--fg-3); display: block; margin-top: 3px;
+}
+.conso-range { display: flex; gap: 8px; }
+.conso-range-group {
+  display: inline-flex; gap: 4px; padding: 3px;
+  background: var(--bg-3); border: 0.5px solid var(--line-1); border-radius: 6px;
+}
+.conso-range-group button {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  padding: 4px 8px; border-radius: 4px; color: var(--fg-3);
+  background: none; border: none; cursor: pointer;
+  transition: background .15s, color .15s;
+}
+.conso-range-group button.on,
+.conso-range-group button[data-on="true"] {
+  background: rgba(220,232,255,0.06); color: var(--fg-0);
+}
+.conso-area-wrap { width: 100%; height: 280px; overflow: hidden; }
+.conso-area-wrap svg { width: 100%; height: 100%; display: block; }
+.conso-axis {
+  display: flex; justify-content: space-between;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+  color: var(--fg-3); padding: 4px 4px 0;
+}
+.conso-legend {
+  border-top: 0.5px solid var(--line-1);
+  padding-top: 14px; margin-top: 14px;
+  display: flex; gap: 14px;
+}
+.conso-legend-item {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--sans); font-size: 12.5px; color: var(--fg-1);
+}
+.conso-legend-item .sw {
+  width: 8px; height: 8px; border-radius: 2px; display: inline-block;
+}
+.conso-legend-item .val { color: var(--fg-3); font-family: var(--mono); font-size: 11px; }
+
+/* Two-column rows */
+.conso-row-2 {
+  display: grid; grid-template-columns: 1.4fr 1fr;
+  gap: 14px; margin-bottom: 18px;
+}
+.conso-row-2 > .card { margin-bottom: 0; padding: 20px 22px; }
+.conso-row-2 .card-hd h2 {
+  font-family: var(--serif); font-weight: 300; font-size: 22px;
+  letter-spacing: -0.025em; color: var(--fg-0);
+}
+.conso-row-2 .card-hd .sub {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
+  color: var(--fg-3); display: block; margin-top: 3px;
+}
+
+/* Usage by type */
+.conso-usage-row {
+  display: grid; grid-template-columns: 14px 1fr 90px;
+  gap: 14px; align-items: start;
+  padding: 14px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.conso-usage-row:last-child { border-bottom: 0; }
+.conso-usage-sw { width: 10px; height: 10px; border-radius: 3px; margin-top: 5px; }
+.conso-usage-body .nm { font-size: 13px; font-weight: 500; color: var(--fg-0); }
+.conso-usage-body .ctx {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em;
+  color: var(--fg-3); margin-top: 2px;
+}
+.conso-usage-bar {
+  margin-top: 10px; height: 2px;
+  background: var(--bg-3); border-radius: 1px; overflow: hidden;
+}
+.conso-usage-bar > i { display: block; height: 100%; border-radius: 1px; }
+.conso-usage-vals { text-align: right; }
+.conso-usage-vals .val {
+  font-family: var(--serif); font-weight: 300; font-size: 18px;
+  letter-spacing: -0.02em; color: var(--fg-0);
+}
+.conso-usage-vals .pct {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.04em;
+  color: var(--fg-3); margin-top: 4px;
+}
+
+/* Provider donut */
+.conso-providers-grid {
+  display: grid; grid-template-columns: 160px 1fr;
+  gap: 22px; align-items: center; padding: 6px 0 18px;
+}
+.conso-donut { display: block; width: 160px; height: 160px; }
+.conso-providers-legend { display: flex; flex-direction: column; gap: 12px; }
+.conso-providers-row {
+  display: grid; grid-template-columns: 12px 1fr auto;
+  gap: 10px; align-items: center;
+  font-family: var(--sans); font-size: 13px;
+}
+.conso-providers-row .sw { width: 10px; height: 10px; border-radius: 3px; }
+.conso-providers-row .nm { color: var(--fg-1); }
+.conso-providers-row .val {
+  font-family: var(--mono); font-size: 12px; color: var(--fg-2); letter-spacing: 0.04em;
+}
+
+/* Heatmap 24h */
+.conso-heat { border-top: 0.5px solid var(--line-1); padding-top: 14px; margin-top: 4px; }
+.conso-heat-head {
+  display: flex; justify-content: space-between;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--fg-3); margin-bottom: 10px;
+}
+.conso-heat-row {
+  display: grid; grid-template-columns: repeat(24, 1fr); gap: 3px;
+}
+.conso-heat-row i { display: block; height: 22px; border-radius: 2px; }
+.conso-heat-foot {
+  display: flex; justify-content: space-between;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.06em; margin-top: 8px;
+}
+
+/* Par modèle */
+.conso-mod-row {
+  display: grid; grid-template-columns: 1.4fr 1fr auto;
+  align-items: center; gap: 18px;
+  padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.conso-mod-row:last-child { border-bottom: 0; }
+.conso-mod-row .nm { font-family: var(--mono); font-size: 12.5px; color: var(--fg-0); }
+.conso-mod-bar { height: 3px; background: var(--bg-3); border-radius: 2px; overflow: hidden; }
+.conso-mod-bar > i {
+  display: block; height: 100%;
+  background: var(--accent); box-shadow: 0 0 6px var(--accent);
+}
+.conso-mod-vals { display: flex; gap: 14px; align-items: baseline; }
+.conso-mod-vals .meta { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+.conso-mod-vals .meta.accent { color: var(--accent); }
+
+/* Par skill */
+.conso-skill-row {
+  display: grid; grid-template-columns: 1fr auto auto;
+  align-items: center; gap: 18px;
+  padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.conso-skill-row:last-child { border-bottom: 0; }
+.conso-skill-row .nm { font-size: 13px; color: var(--fg-0); }
+.conso-empty {
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em;
+  color: var(--fg-3); padding: 24px 0; text-align: center;
+}
+
+@media (max-width: 1280px) {
+  .conso-hero { grid-template-columns: 1fr 1fr; }
+  .conso-row-2 { grid-template-columns: 1fr; }
+}
+
+/* ── Système perf ── */
+.perf-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+.perf-tile {
+  background: var(--bg-1); border: 0.5px solid var(--line-1);
+  border-radius: 12px; padding: 16px 18px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.perf-label { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--fg-3); }
+.perf-val   { font-family: var(--serif); font-weight: 300; font-size: 28px; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
+.perf-unit  { font-size: 13px; letter-spacing: 0; opacity: .55; margin-left: 3px; }
+.perf-bar-wrap { height: 2px; background: var(--bg-3); border-radius: 2px; overflow: hidden; }
+.perf-bar-fill { height: 100%; border-radius: 2px; background: var(--accent); transition: width .4s; }
+
+/* ── Log viewer ── */
+.log-viewer {
+  background: var(--bg-1); border: 0.5px solid var(--line-1);
+  border-radius: 12px; padding: 16px;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  line-height: 1.6; max-height: 320px; overflow-y: auto;
+}
+.log-entry { display: block; padding: 1px 0; }
+.log-entry.error { color: var(--red); }
+.log-entry.warn  { color: var(--amber); }
+
+/* ── À propos ── */
+.about2 { display: flex; flex-direction: column; max-width: 560px; }
+
+.about2-hdr { padding: 24px 0 28px; }
+
+.about2-name-wrap { display: flex; flex-direction: column; gap: 9px; }
+
+.about2-name {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 42px; letter-spacing: -0.04em;
+  color: var(--fg-0); line-height: 1;
+}
+
+.about2-sub-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+
+.about2-badge {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--accent);
+  background: rgba(74, 158, 255, 0.10);
+  border: 1px solid rgba(74, 158, 255, 0.22);
+  border-radius: 6px; padding: 3px 9px; flex-shrink: 0;
+}
+
+.about2-tagline {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-3);
+}
+
+.about2-sep { height: 1px; background: var(--line-1); }
+
+.about2-meta {
+  display: grid; grid-template-columns: 90px 1fr;
+  padding: 4px 0;
+}
+
+.about2-dt {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--fg-4);
+  padding: 10px 0; border-bottom: 1px solid var(--line-1);
+}
+.about2-dt:last-of-type { border-bottom: none; }
+
+.about2-dd {
+  font-family: var(--serif); font-weight: 300; font-size: 14px;
+  color: var(--fg-1); padding: 10px 0; margin: 0;
+  border-bottom: 1px solid var(--line-1);
+}
+.about2-dd:last-child { border-bottom: none; }
+
+.about2-copy {
+  padding: 20px 0 20px; margin: 0;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.10em; color: var(--fg-4);
+}
+
+.about2-update-wrap { display: flex; flex-direction: column; gap: 10px; }
+
+.about2-update-btn {
+  align-self: flex-start;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--fg-0);
+  padding: 8px 16px;
+  background: rgba(220, 232, 255, 0.05);
+  border: 0.5px solid var(--line-3); border-radius: 8px;
+  cursor: pointer; transition: background .15s, border-color .15s, opacity .15s;
+}
+.about2-update-btn:hover { background: rgba(220, 232, 255, 0.09); border-color: var(--line-4); }
+.about2-update-btn:disabled { opacity: .45; cursor: default; }
+
+.about2-update-status {
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em;
+  color: var(--fg-3); min-height: 16px;
+}
+.about2-update-status.ok  { color: var(--green); }
+.about2-update-status.err { color: var(--red); }
+
+/* ── Danger zone ── */
+.danger-zone {
+  border: 0.5px solid rgba(229,72,77,.22); border-radius: 12px;
+  padding: 18px; display: flex; flex-direction: column; gap: 12px;
+}
+.danger-title {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--red); opacity: .7;
+}
+.danger-row { display: flex; align-items: center; justify-content: space-between; gap: 14px; }
+.danger-label { font-size: 13px; color: var(--fg-1); }
+.danger-sub   { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 3px; }
+.btn-danger {
+  appearance: none; background: rgba(229,72,77,.1);
+  border: 0.5px solid rgba(229,72,77,.4); border-radius: 8px;
+  color: var(--red); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 7px 12px; cursor: pointer; white-space: nowrap;
+  transition: background .15s;
+}
+.btn-danger:hover { background: rgba(229,72,77,.2); }
+
+/* ── Action buttons (shared with dashboard) ── */
+.m-btn {
+  appearance: none; background: transparent;
+  border: 0.5px solid var(--line-2); border-radius: 6px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 5px 9px; cursor: pointer;
+  transition: all .15s; white-space: nowrap;
+}
+.m-btn:hover { border-color: var(--accent-line); color: var(--accent); }
+.m-btn.ghost {
+  border-color: transparent; color: var(--fg-3);
+}
+.m-btn.ghost:hover { color: var(--red); border-color: rgba(229,72,77,.3); }
+
+/* ── Ollama ── */
+.ollama-offline-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3); padding: 12px 0 4px;
+}
+.ollama-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--red, #e5484d);
+}
+.ollama-hint {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); padding: 4px 0 10px;
+}
+.ollama-lib-sep {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--fg-3);
+  padding: 18px 0 10px; border-top: 0.5px solid var(--line-1); margin-top: 6px;
+}
+.ollama-model-grid { display: flex; flex-direction: column; }
+.ollama-model-card {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.ollama-model-card:last-child { border-bottom: 0; }
+.ollama-model-name {
+  font-size: 13px; color: var(--fg-1); display: flex; align-items: center; gap: 7px;
+}
+.ollama-tag {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.05em;
+  color: var(--accent); background: var(--accent-soft, rgba(98,126,234,.12));
+  border-radius: 3px; padding: 2px 5px; flex-shrink: 0;
+}
+.ollama-model-size {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 2px;
+}
+
+/* Pull modal */
+.ollama-pull-overlay {
+  position: fixed; inset: 0; z-index: 9999;
+  background: rgba(0,0,0,.72); backdrop-filter: blur(6px);
+  display: flex; align-items: center; justify-content: center;
+}
+.ollama-pull-dialog {
+  background: var(--bg-1); border: 1px solid var(--line-2);
+  border-radius: 14px; padding: 28px 32px; width: 360px; max-width: 90vw;
+  display: flex; flex-direction: column; gap: 12px;
+  box-shadow: 0 24px 60px rgba(0,0,0,.5);
+}
+.ollama-pull-eyebrow {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--fg-3);
+}
+.ollama-pull-model-name { font-size: 15px; font-weight: 500; color: var(--fg-1); }
+.ollama-pull-bar {
+  height: 4px; background: var(--line-2); border-radius: 2px; overflow: hidden;
+}
+.ollama-pull-fill {
+  height: 100%; width: 0%; background: var(--accent, #627eea);
+  border-radius: 2px; transition: width .4s ease;
+}
+@keyframes ollama-slide {
+  0%   { transform: translateX(-100%); }
+  50%  { transform: translateX(0%);    }
+  100% { transform: translateX(100%);  }
+}
+.ollama-pull-fill.indeterminate {
+  width: 40% !important;
+  animation: ollama-slide 1.4s ease-in-out infinite;
+}
+.ollama-pull-status {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3); min-height: 16px;
+}

--- a/src/jarvis/interfaces/ui/static/settings.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/settings.css.bak-1782259625
@@ -1,0 +1,513 @@
+/* settings.css — Configuration (Réglages) v2 */
+
+body[data-mode="config"] { overflow-y: auto; overflow-x: hidden; }
+
+/* ── Custom select ── */
+.csel-wrap { position: relative; display: inline-flex; }
+
+.csel-btn {
+  appearance: none; display: flex; align-items: center; justify-content: space-between;
+  gap: 10px; min-width: 200px;
+  background: var(--bg-2); border: 1px solid var(--line-2); border-radius: 6px;
+  color: var(--fg-1); font-family: var(--mono); font-size: 11.5px;
+  padding: 7px 10px; cursor: pointer;
+  transition: border-color .15s;
+}
+.csel-btn:hover,
+.csel-wrap.open .csel-btn { border-color: var(--accent-line); }
+
+.csel-chevron { color: var(--fg-3); flex-shrink: 0; display: flex; align-items: center; transition: transform .15s; }
+.csel-wrap.open .csel-chevron { transform: rotate(180deg); }
+
+.csel-dropdown {
+  display: none; position: absolute; top: calc(100% + 4px); left: 0;
+  min-width: 100%; z-index: 1000;
+  background: var(--bg-2); border: 1px solid var(--line-2); border-radius: 8px;
+  padding: 4px; box-shadow: 0 12px 32px rgba(0,0,0,.5);
+}
+.csel-wrap.open .csel-dropdown { display: block; }
+
+.csel-item {
+  padding: 7px 10px; border-radius: 5px;
+  font-family: var(--mono); font-size: 11.5px; color: var(--fg-2);
+  cursor: pointer; transition: background .1s, color .1s;
+}
+.csel-item:hover  { background: var(--accent-soft); color: var(--fg-1); }
+.csel-item.active { color: var(--accent); }
+
+/* ── Setting rows ── */
+.setting-row {
+  display: grid; grid-template-columns: 1fr auto;
+  align-items: center; gap: 18px;
+  padding: 14px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.setting-row:last-child { border-bottom: 0; }
+.setting-label { font-size: 13px; color: var(--fg-1); line-height: 1.3; }
+.setting-sub   { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 3px; letter-spacing: 0.06em; }
+
+/* ── Key rows (API keys, masked) ── */
+.key-row {
+  display: grid; grid-template-columns: 160px 1fr auto;
+  align-items: center; gap: 14px;
+  padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.key-name { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; color: var(--fg-2); }
+.key-val  {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+  letter-spacing: 0.04em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.key-actions { display: flex; gap: 6px; }
+
+/* ── Model select ── */
+.model-row {
+  display: grid; grid-template-columns: 1fr auto;
+  align-items: center; gap: 16px;
+  padding: 13px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.model-name { font-size: 13px; color: var(--fg-0); }
+.model-sub  { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 3px; }
+
+/* ── Conso dashboard ── */
+.conso-evolution h2,
+.conso-row-2 h2 {
+  margin: 0; padding: 0; font-size: inherit; font-weight: inherit;
+}
+
+.conso-hero {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  gap: 14px;
+  margin-bottom: 18px;
+}
+.conso-tile {
+  position: relative;
+  padding: 18px 20px;
+  border: 0.5px solid var(--line-2);
+  border-radius: 14px;
+  background: rgba(10,14,22,0.35);
+  min-height: 138px;
+  display: flex;
+  flex-direction: column;
+}
+.conso-tile .l {
+  font-family: var(--mono);
+  font-size: 9.5px; letter-spacing: 0.24em; text-transform: uppercase;
+  color: var(--fg-3); margin-bottom: 14px;
+}
+.conso-tile .v {
+  font-family: var(--serif); font-weight: 300; font-size: 38px;
+  letter-spacing: -0.035em; line-height: 1; color: var(--fg-0);
+  display: flex; align-items: baseline; gap: 2px;
+}
+.conso-tile.primary .v { font-size: 44px; }
+.conso-tile .v .dec { font-family: var(--serif); font-weight: 300; }
+.conso-tile .v .unit {
+  font-family: var(--mono); font-size: 18px; color: var(--fg-2);
+  letter-spacing: 0; margin-left: 2px;
+}
+.conso-tile .v .rel {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em;
+  color: var(--green); text-transform: uppercase;
+  margin-left: 8px; align-self: flex-end; padding-bottom: 4px;
+}
+.conso-tile .v.gold { color: var(--gold); }
+.conso-tile .d {
+  margin-top: 10px; font-family: var(--mono);
+  font-size: 10px; letter-spacing: 0.06em; color: var(--fg-3);
+}
+.conso-tile .d.sub {
+  font-family: var(--sans); font-size: 11.5px;
+  letter-spacing: 0; color: var(--fg-3);
+}
+.conso-budget-bar {
+  margin-top: 10px; height: 2px;
+  background: var(--bg-3); border-radius: 1px; overflow: hidden;
+}
+.conso-budget-bar > i {
+  display: block; height: 100%;
+  background: var(--accent); box-shadow: 0 0 6px var(--accent);
+}
+.conso-tile-flag {
+  margin-top: 10px; font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.18em; text-transform: lowercase; color: var(--gold);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.conso-tile-flag .dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--gold); display: inline-block;
+}
+.conso-spark { display: block; width: 100%; margin-top: auto; padding-top: 6px; }
+
+/* Evolution chart card */
+.conso-evolution { padding: 24px 26px; margin-bottom: 18px; }
+.conso-evolution .card-hd { border-bottom: 0; padding-bottom: 18px; margin-bottom: 0; }
+.conso-evolution .card-hd h2 {
+  font-family: var(--serif); font-weight: 300; font-size: 22px;
+  letter-spacing: -0.025em; color: var(--fg-0);
+}
+.conso-evolution .card-hd .sub {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
+  color: var(--fg-3); display: block; margin-top: 3px;
+}
+.conso-range { display: flex; gap: 8px; }
+.conso-range-group {
+  display: inline-flex; gap: 4px; padding: 3px;
+  background: var(--bg-3); border: 0.5px solid var(--line-1); border-radius: 6px;
+}
+.conso-range-group button {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  padding: 4px 8px; border-radius: 4px; color: var(--fg-3);
+  background: none; border: none; cursor: pointer;
+  transition: background .15s, color .15s;
+}
+.conso-range-group button.on,
+.conso-range-group button[data-on="true"] {
+  background: rgba(var(--c-fg), 0.06); color: var(--fg-0);
+}
+.conso-area-wrap { width: 100%; height: 280px; overflow: hidden; }
+.conso-area-wrap svg { width: 100%; height: 100%; display: block; }
+.conso-axis {
+  display: flex; justify-content: space-between;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+  color: var(--fg-3); padding: 4px 4px 0;
+}
+.conso-legend {
+  border-top: 0.5px solid var(--line-1);
+  padding-top: 14px; margin-top: 14px;
+  display: flex; gap: 14px;
+}
+.conso-legend-item {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--sans); font-size: 12.5px; color: var(--fg-1);
+}
+.conso-legend-item .sw {
+  width: 8px; height: 8px; border-radius: 2px; display: inline-block;
+}
+.conso-legend-item .val { color: var(--fg-3); font-family: var(--mono); font-size: 11px; }
+
+/* Two-column rows */
+.conso-row-2 {
+  display: grid; grid-template-columns: 1.4fr 1fr;
+  gap: 14px; margin-bottom: 18px;
+}
+.conso-row-2 > .card { margin-bottom: 0; padding: 20px 22px; }
+.conso-row-2 .card-hd h2 {
+  font-family: var(--serif); font-weight: 300; font-size: 22px;
+  letter-spacing: -0.025em; color: var(--fg-0);
+}
+.conso-row-2 .card-hd .sub {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em;
+  color: var(--fg-3); display: block; margin-top: 3px;
+}
+
+/* Usage by type */
+.conso-usage-row {
+  display: grid; grid-template-columns: 14px 1fr 90px;
+  gap: 14px; align-items: start;
+  padding: 14px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.conso-usage-row:last-child { border-bottom: 0; }
+.conso-usage-sw { width: 10px; height: 10px; border-radius: 3px; margin-top: 5px; }
+.conso-usage-body .nm { font-size: 13px; font-weight: 500; color: var(--fg-0); }
+.conso-usage-body .ctx {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em;
+  color: var(--fg-3); margin-top: 2px;
+}
+.conso-usage-bar {
+  margin-top: 10px; height: 2px;
+  background: var(--bg-3); border-radius: 1px; overflow: hidden;
+}
+.conso-usage-bar > i { display: block; height: 100%; border-radius: 1px; }
+.conso-usage-vals { text-align: right; }
+.conso-usage-vals .val {
+  font-family: var(--serif); font-weight: 300; font-size: 18px;
+  letter-spacing: -0.02em; color: var(--fg-0);
+}
+.conso-usage-vals .pct {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.04em;
+  color: var(--fg-3); margin-top: 4px;
+}
+
+/* Provider donut */
+.conso-providers-grid {
+  display: grid; grid-template-columns: 160px 1fr;
+  gap: 22px; align-items: center; padding: 6px 0 18px;
+}
+.conso-donut { display: block; width: 160px; height: 160px; }
+.conso-providers-legend { display: flex; flex-direction: column; gap: 12px; }
+.conso-providers-row {
+  display: grid; grid-template-columns: 12px 1fr auto;
+  gap: 10px; align-items: center;
+  font-family: var(--sans); font-size: 13px;
+}
+.conso-providers-row .sw { width: 10px; height: 10px; border-radius: 3px; }
+.conso-providers-row .nm { color: var(--fg-1); }
+.conso-providers-row .val {
+  font-family: var(--mono); font-size: 12px; color: var(--fg-2); letter-spacing: 0.04em;
+}
+
+/* Heatmap 24h */
+.conso-heat { border-top: 0.5px solid var(--line-1); padding-top: 14px; margin-top: 4px; }
+.conso-heat-head {
+  display: flex; justify-content: space-between;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--fg-3); margin-bottom: 10px;
+}
+.conso-heat-row {
+  display: grid; grid-template-columns: repeat(24, 1fr); gap: 3px;
+}
+.conso-heat-row i { display: block; height: 22px; border-radius: 2px; }
+.conso-heat-foot {
+  display: flex; justify-content: space-between;
+  font-family: var(--mono); font-size: 9.5px; color: var(--fg-3);
+  letter-spacing: 0.06em; margin-top: 8px;
+}
+
+/* Par modèle */
+.conso-mod-row {
+  display: grid; grid-template-columns: 1.4fr 1fr auto;
+  align-items: center; gap: 18px;
+  padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.conso-mod-row:last-child { border-bottom: 0; }
+.conso-mod-row .nm { font-family: var(--mono); font-size: 12.5px; color: var(--fg-0); }
+.conso-mod-bar { height: 3px; background: var(--bg-3); border-radius: 2px; overflow: hidden; }
+.conso-mod-bar > i {
+  display: block; height: 100%;
+  background: var(--accent); box-shadow: 0 0 6px var(--accent);
+}
+.conso-mod-vals { display: flex; gap: 14px; align-items: baseline; }
+.conso-mod-vals .meta { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+.conso-mod-vals .meta.accent { color: var(--accent); }
+
+/* Par skill */
+.conso-skill-row {
+  display: grid; grid-template-columns: 1fr auto auto;
+  align-items: center; gap: 18px;
+  padding: 12px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.conso-skill-row:last-child { border-bottom: 0; }
+.conso-skill-row .nm { font-size: 13px; color: var(--fg-0); }
+.conso-empty {
+  font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em;
+  color: var(--fg-3); padding: 24px 0; text-align: center;
+}
+
+@media (max-width: 1280px) {
+  .conso-hero { grid-template-columns: 1fr 1fr; }
+  .conso-row-2 { grid-template-columns: 1fr; }
+}
+
+/* ── Système perf ── */
+.perf-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+.perf-tile {
+  background: var(--bg-1); border: 0.5px solid var(--line-1);
+  border-radius: 12px; padding: 16px 18px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.perf-label { font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.2em; text-transform: uppercase; color: var(--fg-3); }
+.perf-val   { font-family: var(--serif); font-weight: 300; font-size: 28px; letter-spacing: -0.04em; color: var(--fg-0); line-height: 1; }
+.perf-unit  { font-size: 13px; letter-spacing: 0; opacity: .55; margin-left: 3px; }
+.perf-bar-wrap { height: 2px; background: var(--bg-3); border-radius: 2px; overflow: hidden; }
+.perf-bar-fill { height: 100%; border-radius: 2px; background: var(--accent); transition: width .4s; }
+
+/* ── Log viewer ── */
+.log-viewer {
+  background: var(--bg-1); border: 0.5px solid var(--line-1);
+  border-radius: 12px; padding: 16px;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  line-height: 1.6; max-height: 320px; overflow-y: auto;
+}
+.log-entry { display: block; padding: 1px 0; }
+.log-entry.error { color: var(--red); }
+.log-entry.warn  { color: var(--amber); }
+
+/* ── À propos ── */
+.about2 { display: flex; flex-direction: column; max-width: 560px; }
+
+.about2-hdr { padding: 24px 0 28px; }
+
+.about2-name-wrap { display: flex; flex-direction: column; gap: 9px; }
+
+.about2-name {
+  font-family: var(--serif); font-weight: 300;
+  font-size: 42px; letter-spacing: -0.04em;
+  color: var(--fg-0); line-height: 1;
+}
+
+.about2-sub-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+
+.about2-badge {
+  font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--accent);
+  background: rgba(var(--c-accent), 0.10);
+  border: 1px solid rgba(var(--c-accent), 0.22);
+  border-radius: 6px; padding: 3px 9px; flex-shrink: 0;
+}
+
+.about2-tagline {
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.04em; color: var(--fg-3);
+}
+
+.about2-sep { height: 1px; background: var(--line-1); }
+
+.about2-meta {
+  display: grid; grid-template-columns: 90px 1fr;
+  padding: 4px 0;
+}
+
+.about2-dt {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em;
+  text-transform: uppercase; color: var(--fg-4);
+  padding: 10px 0; border-bottom: 1px solid var(--line-1);
+}
+.about2-dt:last-of-type { border-bottom: none; }
+
+.about2-dd {
+  font-family: var(--serif); font-weight: 300; font-size: 14px;
+  color: var(--fg-1); padding: 10px 0; margin: 0;
+  border-bottom: 1px solid var(--line-1);
+}
+.about2-dd:last-child { border-bottom: none; }
+
+.about2-copy {
+  padding: 20px 0 20px; margin: 0;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.10em; color: var(--fg-4);
+}
+
+.about2-update-wrap { display: flex; flex-direction: column; gap: 10px; }
+
+.about2-update-btn {
+  align-self: flex-start;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--fg-0);
+  padding: 8px 16px;
+  background: rgba(var(--c-fg), 0.05);
+  border: 0.5px solid var(--line-3); border-radius: 8px;
+  cursor: pointer; transition: background .15s, border-color .15s, opacity .15s;
+}
+.about2-update-btn:hover { background: rgba(var(--c-fg), 0.09); border-color: var(--line-4); }
+.about2-update-btn:disabled { opacity: .45; cursor: default; }
+
+.about2-update-status {
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em;
+  color: var(--fg-3); min-height: 16px;
+}
+.about2-update-status.ok  { color: var(--green); }
+.about2-update-status.err { color: var(--red); }
+
+/* ── Danger zone ── */
+.danger-zone {
+  border: 0.5px solid rgba(var(--c-red), .22); border-radius: 12px;
+  padding: 18px; display: flex; flex-direction: column; gap: 12px;
+}
+.danger-title {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.2em;
+  text-transform: uppercase; color: var(--red); opacity: .7;
+}
+.danger-row { display: flex; align-items: center; justify-content: space-between; gap: 14px; }
+.danger-label { font-size: 13px; color: var(--fg-1); }
+.danger-sub   { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 3px; }
+.btn-danger {
+  appearance: none; background: rgba(var(--c-red), .1);
+  border: 0.5px solid rgba(var(--c-red), .4); border-radius: 8px;
+  color: var(--red); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  padding: 7px 12px; cursor: pointer; white-space: nowrap;
+  transition: background .15s;
+}
+.btn-danger:hover { background: rgba(var(--c-red), .2); }
+
+/* ── Action buttons (shared with dashboard) ── */
+.m-btn {
+  appearance: none; background: transparent;
+  border: 0.5px solid var(--line-2); border-radius: 6px;
+  color: var(--fg-2); font-family: var(--mono); font-size: 9.5px;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  padding: 5px 9px; cursor: pointer;
+  transition: all .15s; white-space: nowrap;
+}
+.m-btn:hover { border-color: var(--accent-line); color: var(--accent); }
+.m-btn.ghost {
+  border-color: transparent; color: var(--fg-3);
+}
+.m-btn.ghost:hover { color: var(--red); border-color: rgba(var(--c-red), .3); }
+
+/* ── Ollama ── */
+.ollama-offline-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3); padding: 12px 0 4px;
+}
+.ollama-dot {
+  width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0;
+  background: var(--red, #e5484d);
+}
+.ollama-hint {
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-3); padding: 4px 0 10px;
+}
+.ollama-lib-sep {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em;
+  text-transform: uppercase; color: var(--fg-3);
+  padding: 18px 0 10px; border-top: 0.5px solid var(--line-1); margin-top: 6px;
+}
+.ollama-model-grid { display: flex; flex-direction: column; }
+.ollama-model-card {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 0; border-bottom: 0.5px solid var(--line-1);
+}
+.ollama-model-card:last-child { border-bottom: 0; }
+.ollama-model-name {
+  font-size: 13px; color: var(--fg-1); display: flex; align-items: center; gap: 7px;
+}
+.ollama-tag {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.05em;
+  color: var(--accent); background: var(--accent-soft, rgba(98,126,234,.12));
+  border-radius: 3px; padding: 2px 5px; flex-shrink: 0;
+}
+.ollama-model-size {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 2px;
+}
+
+/* Pull modal */
+.ollama-pull-overlay {
+  position: fixed; inset: 0; z-index: 9999;
+  background: rgba(0,0,0,.72); backdrop-filter: blur(6px);
+  display: flex; align-items: center; justify-content: center;
+}
+.ollama-pull-dialog {
+  background: var(--bg-1); border: 1px solid var(--line-2);
+  border-radius: 14px; padding: 28px 32px; width: 360px; max-width: 90vw;
+  display: flex; flex-direction: column; gap: 12px;
+  box-shadow: 0 24px 60px rgba(0,0,0,.5);
+}
+.ollama-pull-eyebrow {
+  font-family: var(--mono); font-size: 9.5px; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--fg-3);
+}
+.ollama-pull-model-name { font-size: 15px; font-weight: 500; color: var(--fg-1); }
+.ollama-pull-bar {
+  height: 4px; background: var(--line-2); border-radius: 2px; overflow: hidden;
+}
+.ollama-pull-fill {
+  height: 100%; width: 0%; background: var(--accent, #627eea);
+  border-radius: 2px; transition: width .4s ease;
+}
+@keyframes ollama-slide {
+  0%   { transform: translateX(-100%); }
+  50%  { transform: translateX(0%);    }
+  100% { transform: translateX(100%);  }
+}
+.ollama-pull-fill.indeterminate {
+  width: 40% !important;
+  animation: ollama-slide 1.4s ease-in-out infinite;
+}
+.ollama-pull-status {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3); min-height: 16px;
+}

--- a/src/jarvis/interfaces/ui/static/settings.html
+++ b/src/jarvis/interfaces/ui/static/settings.html
@@ -9,11 +9,13 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
 <link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/mission_control.css" />
 <link rel="stylesheet" href="/settings.css" />
 </head>
 <body data-mode="config">
 <div id="page-root"></div>
 <script src="/_shared.js"></script>
+<script src="/mission_control.js"></script>
 <script src="/settings-charts.js"></script>
 <script src="/settings.js"></script>
 </body>

--- a/src/jarvis/interfaces/ui/static/settings.html.bak-1782249020
+++ b/src/jarvis/interfaces/ui/static/settings.html.bak-1782249020
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis · Réglages</title>
+<link rel="icon" type="image/png" href="/favicon.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="/_shared.css" />
+<link rel="stylesheet" href="/settings.css" />
+</head>
+<body data-mode="config">
+<div id="page-root"></div>
+<script src="/_shared.js"></script>
+<script src="/settings-charts.js"></script>
+<script src="/settings.js"></script>
+</body>
+</html>

--- a/src/jarvis/interfaces/ui/static/setup.css
+++ b/src/jarvis/interfaces/ui/static/setup.css
@@ -25,7 +25,7 @@
   gap: 11px;
   font-family: var(--serif);
   font-weight: 500;
-  font-size: 18px;
+  font-size: 1.125rem;
   letter-spacing: 0.18em;
   color: var(--fg-0);
 }
@@ -42,7 +42,7 @@
   margin-top: 8px;
   color: var(--fg-3);
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 0.625rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
 }
@@ -72,10 +72,10 @@
   overflow-y: auto;
   padding-right: 4px;
   scrollbar-width: thin;
-  scrollbar-color: rgba(220, 232, 255, 0.08) transparent;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
 }
 .setup-main::-webkit-scrollbar { width: 6px; }
-.setup-main::-webkit-scrollbar-thumb { background: rgba(220, 232, 255, 0.08); border-radius: 3px; }
+.setup-main::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
 
 .setup-card {
   background: var(--bg-1);
@@ -110,7 +110,7 @@
 .setup-hd-eyebrow {
   margin-bottom: 8px;
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 0.625rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--accent);
@@ -119,7 +119,7 @@
   margin: 0;
   font-family: var(--serif);
   font-weight: 400;
-  font-size: 23px;
+  font-size: 1.4375rem;
   letter-spacing: -0.025em;
   color: var(--fg-0);
 }
@@ -128,7 +128,7 @@
   color: var(--fg-2);
   margin: 10px 0 0;
   line-height: 1.55;
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 
 /* ───────── Fields ───────── */
@@ -140,7 +140,7 @@
 .setup-field label {
   color: var(--fg-2);
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 0.625rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
 }
@@ -153,7 +153,7 @@
   color: var(--fg-0);
   padding: 9px 12px;
   font-family: var(--sans);
-  font-size: 13.5px;
+  font-size: 0.8438rem;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 .setup-field input::placeholder { color: var(--fg-4); }
@@ -166,7 +166,7 @@
 .setup-field input[type="file"] {
   padding: 8px 12px;
   color: var(--fg-2);
-  font-size: 12.5px;
+  font-size: 0.7812rem;
 }
 
 /* ───────── Dropdown custom (remplace <select> natif) ───────── */
@@ -183,7 +183,7 @@
   color: var(--fg-0);
   padding: 9px 12px;
   font-family: var(--sans);
-  font-size: 13.5px;
+  font-size: 0.8438rem;
   text-align: left;
   cursor: pointer;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
@@ -195,7 +195,7 @@
 }
 .setup-select-chev {
   color: var(--fg-3);
-  font-size: 11px;
+  font-size: 0.6875rem;
   transition: transform 0.15s ease, color 0.15s ease;
 }
 .setup-select.open .setup-select-chev { transform: rotate(180deg); color: var(--accent); }
@@ -229,13 +229,13 @@
   padding: 9px 12px;
   border-radius: 7px;
   color: var(--fg-1);
-  font-size: 13px;
+  font-size: 0.8125rem;
   cursor: pointer;
   transition: background 0.12s ease, color 0.12s ease;
 }
 .setup-select-opt:hover { background: var(--accent-soft); color: var(--fg-0); }
 .setup-select-opt.is-sel { color: var(--accent); }
-.setup-select-opt.is-sel::after { content: "✓"; font-size: 11px; }
+.setup-select-opt.is-sel::after { content: "✓"; font-size: 0.6875rem; }
 
 /* ───────── Sélecteur de fichier custom ───────── */
 .setup-file {
@@ -253,7 +253,7 @@
   color: var(--fg-1);
   padding: 9px 16px;
   font-family: var(--sans);
-  font-size: 12.5px;
+  font-size: 0.7812rem;
   font-weight: 500;
   transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
 }
@@ -265,7 +265,7 @@
 .setup-file-name {
   color: var(--fg-3);
   font-family: var(--mono);
-  font-size: 11.5px;
+  font-size: 0.7188rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -279,7 +279,7 @@
   background: rgba(6, 8, 13, 0.4);
   color: var(--fg-2);
   font-family: var(--mono);
-  font-size: 12.5px;
+  font-size: 0.7812rem;
   word-break: break-all;
 }
 
@@ -294,7 +294,7 @@
   border-radius: 10px;
   background: var(--bg-2);
   color: var(--fg-1);
-  font-size: 13px;
+  font-size: 0.8125rem;
   cursor: pointer;
   transition: border-color 0.15s ease, background 0.15s ease;
 }
@@ -320,12 +320,12 @@
   border: 1px solid var(--line-1);
   border-radius: 9px;
   background: var(--bg-2);
-  font-size: 13px;
+  font-size: 0.8125rem;
   color: var(--fg-1);
 }
 .setup-status-row span:last-child {
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 0.625rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
@@ -357,7 +357,7 @@
   color: #001127;
   font-family: var(--sans);
   font-weight: 600;
-  font-size: 13px;
+  font-size: 0.8125rem;
   transition: filter 0.15s ease, transform 0.05s ease;
 }
 .setup-footer .m-btn:hover { filter: brightness(1.08); }
@@ -388,16 +388,16 @@
   place-items: center;
   border-radius: 50%;
   background: var(--green-soft);
-  border: 1px solid rgba(54, 211, 153, 0.4);
+  border: 1px solid rgba(var(--c-green), 0.4);
   color: var(--green);
-  font-size: 26px;
+  font-size: 1.625rem;
   box-shadow: 0 0 30px -6px var(--green);
 }
 .setup-done h2 {
   margin: 0 0 10px;
   font-family: var(--serif);
   font-weight: 400;
-  font-size: 25px;
+  font-size: 1.5625rem;
   letter-spacing: -0.02em;
   color: var(--fg-0);
 }
@@ -405,7 +405,7 @@
   color: var(--fg-2);
   margin: 0 0 16px;
   line-height: 1.55;
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 .setup-done-url {
   display: inline-block;
@@ -416,14 +416,14 @@
   background: var(--accent-soft);
   color: var(--accent);
   font-family: var(--mono);
-  font-size: 13px;
+  font-size: 0.8125rem;
   text-decoration: none;
   transition: box-shadow 0.15s ease;
 }
 .setup-done-url:hover { box-shadow: 0 0 20px -4px var(--accent); }
 .setup-done-cmd {
   font-family: var(--mono);
-  font-size: 11.5px;
+  font-size: 0.7188rem;
   color: var(--fg-3);
   letter-spacing: 0.02em;
 }

--- a/src/jarvis/interfaces/ui/static/setup.css.bak-1782254922
+++ b/src/jarvis/interfaces/ui/static/setup.css.bak-1782254922
@@ -1,0 +1,435 @@
+/* ─────────────────────────────────────────────────────────────────────
+   Setup wizard — aligné sur le design system JARVIS (_shared.css)
+   Header + footer fixes, seule la carte défile (le body est overflow:hidden).
+   ───────────────────────────────────────────────────────────────────── */
+
+.setup-shell {
+  position: relative;
+  z-index: 3;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 26px 28px 22px;
+}
+
+/* ───────── Header / brand ───────── */
+.setup-header { margin-bottom: 16px; }
+
+.setup-brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 18px;
+  letter-spacing: 0.18em;
+  color: var(--fg-0);
+}
+.setup-brand::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 9px var(--green);
+}
+
+.setup-sub {
+  margin-top: 8px;
+  color: var(--fg-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+/* ───────── Step indicator ───────── */
+.setup-steps {
+  display: flex;
+  gap: 7px;
+  margin-top: 16px;
+}
+.setup-step-dot {
+  flex: 1;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--line-2);
+  transition: background 0.25s ease, box-shadow 0.25s ease;
+}
+.setup-step-dot.active {
+  background: var(--accent);
+  box-shadow: 0 0 10px -1px var(--accent);
+}
+.setup-step-dot.done { background: var(--green); }
+
+/* ───────── Card (seule zone scrollable) ───────── */
+.setup-main {
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(220, 232, 255, 0.08) transparent;
+}
+.setup-main::-webkit-scrollbar { width: 6px; }
+.setup-main::-webkit-scrollbar-thumb { background: rgba(220, 232, 255, 0.08); border-radius: 3px; }
+
+.setup-card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 16px;
+  padding: 22px 26px;
+  position: relative;
+  animation: setupIn 0.4s cubic-bezier(0.2, 0.8, 0.25, 1) both;
+}
+@keyframes setupIn {
+  from { opacity: 0; transform: translateY(10px); filter: blur(5px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ───────── Card header (eyebrow + title + lead) ───────── */
+.setup-hd {
+  position: relative;
+  margin-bottom: 18px;
+  padding-bottom: 13px;
+  border-bottom: 1px solid var(--line-1);
+}
+.setup-hd::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -1px;
+  width: 34px;
+  height: 1px;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.setup-hd-eyebrow {
+  margin-bottom: 8px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.setup-hd-title {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 23px;
+  letter-spacing: -0.025em;
+  color: var(--fg-0);
+}
+
+.setup-lead {
+  color: var(--fg-2);
+  margin: 10px 0 0;
+  line-height: 1.55;
+  font-size: 13px;
+}
+
+/* ───────── Fields ───────── */
+.setup-field {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 13px;
+}
+.setup-field label {
+  color: var(--fg-2);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.setup-field input,
+.setup-field select {
+  width: 100%;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--fg-0);
+  padding: 9px 12px;
+  font-family: var(--sans);
+  font-size: 13.5px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.setup-field input::placeholder { color: var(--fg-4); }
+.setup-field input:focus,
+.setup-field select:focus {
+  outline: none;
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.setup-field input[type="file"] {
+  padding: 8px 12px;
+  color: var(--fg-2);
+  font-size: 12.5px;
+}
+
+/* ───────── Dropdown custom (remplace <select> natif) ───────── */
+.setup-select { position: relative; }
+.setup-select-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--fg-0);
+  padding: 9px 12px;
+  font-family: var(--sans);
+  font-size: 13.5px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.setup-select-btn:hover { border-color: var(--line-3); }
+.setup-select.open .setup-select-btn {
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.setup-select-chev {
+  color: var(--fg-3);
+  font-size: 11px;
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+.setup-select.open .setup-select-chev { transform: rotate(180deg); color: var(--accent); }
+.setup-select-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  display: none;
+  padding: 5px;
+  background: var(--bg-3);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  box-shadow: 0 16px 40px -12px rgba(0, 0, 0, 0.7);
+}
+.setup-select.open .setup-select-menu {
+  display: block;
+  animation: setupMenu 0.14s ease both;
+}
+@keyframes setupMenu {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.setup-select-opt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 12px;
+  border-radius: 7px;
+  color: var(--fg-1);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.setup-select-opt:hover { background: var(--accent-soft); color: var(--fg-0); }
+.setup-select-opt.is-sel { color: var(--accent); }
+.setup-select-opt.is-sel::after { content: "✓"; font-size: 11px; }
+
+/* ───────── Sélecteur de fichier custom ───────── */
+.setup-file {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.setup-file-btn {
+  appearance: none;
+  cursor: pointer;
+  flex: none;
+  background: var(--bg-3);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--fg-1);
+  padding: 9px 16px;
+  font-family: var(--sans);
+  font-size: 12.5px;
+  font-weight: 500;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+.setup-file-btn:hover {
+  border-color: var(--accent-line);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.setup-file-name {
+  color: var(--fg-3);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Champ en lecture seule (ex : Voice ID, non modifiable à l'onboarding) */
+.setup-readonly {
+  padding: 9px 12px;
+  border: 1px dashed var(--line-2);
+  border-radius: 8px;
+  background: rgba(6, 8, 13, 0.4);
+  color: var(--fg-2);
+  font-family: var(--mono);
+  font-size: 12.5px;
+  word-break: break-all;
+}
+
+/* ───────── Checkbox rows ───────── */
+.setup-check {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin-bottom: 8px;
+  padding: 10px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 10px;
+  background: var(--bg-2);
+  color: var(--fg-1);
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.setup-check:hover { border-color: var(--line-3); }
+.setup-check input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+/* ───────── Prereq status rows ───────── */
+.setup-status-list {
+  display: grid;
+  gap: 7px;
+  margin-top: 4px;
+}
+.setup-status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 9px;
+  background: var(--bg-2);
+  font-size: 13px;
+  color: var(--fg-1);
+}
+.setup-status-row span:last-child {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.setup-status-ok { color: var(--green); }
+.setup-status-warn { color: var(--gold); }
+.setup-status-err { color: var(--red); }
+
+.setup-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+/* ───────── Footer buttons ───────── */
+.setup-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+}
+.setup-footer .m-btn {
+  appearance: none;
+  cursor: pointer;
+  min-width: 132px;
+  padding: 11px 22px;
+  border: 0;
+  border-radius: 9px;
+  background: var(--accent);
+  color: #001127;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 13px;
+  transition: filter 0.15s ease, transform 0.05s ease;
+}
+.setup-footer .m-btn:hover { filter: brightness(1.08); }
+.setup-footer .m-btn:active { transform: translateY(1px); }
+.setup-footer .m-btn:disabled { opacity: 0.5; cursor: default; }
+.setup-footer .m-btn--ghost {
+  background: transparent;
+  color: var(--fg-2);
+  border: 1px solid var(--line-2);
+  font-weight: 500;
+}
+.setup-footer .m-btn--ghost:hover {
+  background: var(--bg-2);
+  color: var(--fg-0);
+  filter: none;
+}
+
+/* ───────── Finish screen ───────── */
+.setup-done {
+  text-align: center;
+  padding: 10px 0 4px;
+}
+.setup-done-badge {
+  width: 54px;
+  height: 54px;
+  margin: 0 auto 18px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--green-soft);
+  border: 1px solid rgba(54, 211, 153, 0.4);
+  color: var(--green);
+  font-size: 26px;
+  box-shadow: 0 0 30px -6px var(--green);
+}
+.setup-done h2 {
+  margin: 0 0 10px;
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 25px;
+  letter-spacing: -0.02em;
+  color: var(--fg-0);
+}
+.setup-done p {
+  color: var(--fg-2);
+  margin: 0 0 16px;
+  line-height: 1.55;
+  font-size: 13px;
+}
+.setup-done-url {
+  display: inline-block;
+  margin: 4px 0 16px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--accent-line);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 13px;
+  text-decoration: none;
+  transition: box-shadow 0.15s ease;
+}
+.setup-done-url:hover { box-shadow: 0 0 20px -4px var(--accent); }
+.setup-done-cmd {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--fg-3);
+  letter-spacing: 0.02em;
+}
+
+@media (max-width: 640px) {
+  .setup-grid-2 { grid-template-columns: 1fr; }
+  .setup-shell { padding: 20px 16px 16px; }
+  .setup-card { padding: 20px 18px; }
+}

--- a/src/jarvis/interfaces/ui/static/setup.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/setup.css.bak-1782259625
@@ -1,0 +1,435 @@
+/* ─────────────────────────────────────────────────────────────────────
+   Setup wizard — aligné sur le design system JARVIS (_shared.css)
+   Header + footer fixes, seule la carte défile (le body est overflow:hidden).
+   ───────────────────────────────────────────────────────────────────── */
+
+.setup-shell {
+  position: relative;
+  z-index: 3;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 26px 28px 22px;
+}
+
+/* ───────── Header / brand ───────── */
+.setup-header { margin-bottom: 16px; }
+
+.setup-brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  font-family: var(--serif);
+  font-weight: 500;
+  font-size: 18px;
+  letter-spacing: 0.18em;
+  color: var(--fg-0);
+}
+.setup-brand::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 9px var(--green);
+}
+
+.setup-sub {
+  margin-top: 8px;
+  color: var(--fg-3);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+/* ───────── Step indicator ───────── */
+.setup-steps {
+  display: flex;
+  gap: 7px;
+  margin-top: 16px;
+}
+.setup-step-dot {
+  flex: 1;
+  height: 3px;
+  border-radius: 999px;
+  background: var(--line-2);
+  transition: background 0.25s ease, box-shadow 0.25s ease;
+}
+.setup-step-dot.active {
+  background: var(--accent);
+  box-shadow: 0 0 10px -1px var(--accent);
+}
+.setup-step-dot.done { background: var(--green); }
+
+/* ───────── Card (seule zone scrollable) ───────── */
+.setup-main {
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--c-fg), 0.08) transparent;
+}
+.setup-main::-webkit-scrollbar { width: 6px; }
+.setup-main::-webkit-scrollbar-thumb { background: rgba(var(--c-fg), 0.08); border-radius: 3px; }
+
+.setup-card {
+  background: var(--bg-1);
+  border: 1px solid var(--line-1);
+  border-radius: 16px;
+  padding: 22px 26px;
+  position: relative;
+  animation: setupIn 0.4s cubic-bezier(0.2, 0.8, 0.25, 1) both;
+}
+@keyframes setupIn {
+  from { opacity: 0; transform: translateY(10px); filter: blur(5px); }
+  to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+}
+
+/* ───────── Card header (eyebrow + title + lead) ───────── */
+.setup-hd {
+  position: relative;
+  margin-bottom: 18px;
+  padding-bottom: 13px;
+  border-bottom: 1px solid var(--line-1);
+}
+.setup-hd::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -1px;
+  width: 34px;
+  height: 1px;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+.setup-hd-eyebrow {
+  margin-bottom: 8px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.setup-hd-title {
+  margin: 0;
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 23px;
+  letter-spacing: -0.025em;
+  color: var(--fg-0);
+}
+
+.setup-lead {
+  color: var(--fg-2);
+  margin: 10px 0 0;
+  line-height: 1.55;
+  font-size: 13px;
+}
+
+/* ───────── Fields ───────── */
+.setup-field {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 13px;
+}
+.setup-field label {
+  color: var(--fg-2);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.setup-field input,
+.setup-field select {
+  width: 100%;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--fg-0);
+  padding: 9px 12px;
+  font-family: var(--sans);
+  font-size: 13.5px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.setup-field input::placeholder { color: var(--fg-4); }
+.setup-field input:focus,
+.setup-field select:focus {
+  outline: none;
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.setup-field input[type="file"] {
+  padding: 8px 12px;
+  color: var(--fg-2);
+  font-size: 12.5px;
+}
+
+/* ───────── Dropdown custom (remplace <select> natif) ───────── */
+.setup-select { position: relative; }
+.setup-select-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--fg-0);
+  padding: 9px 12px;
+  font-family: var(--sans);
+  font-size: 13.5px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.setup-select-btn:hover { border-color: var(--line-3); }
+.setup-select.open .setup-select-btn {
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.setup-select-chev {
+  color: var(--fg-3);
+  font-size: 11px;
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+.setup-select.open .setup-select-chev { transform: rotate(180deg); color: var(--accent); }
+.setup-select-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 30;
+  display: none;
+  padding: 5px;
+  background: var(--bg-3);
+  border: 1px solid var(--line-2);
+  border-radius: 10px;
+  max-height: 240px;
+  overflow-y: auto;
+  box-shadow: 0 16px 40px -12px rgba(0, 0, 0, 0.7);
+}
+.setup-select.open .setup-select-menu {
+  display: block;
+  animation: setupMenu 0.14s ease both;
+}
+@keyframes setupMenu {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.setup-select-opt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 9px 12px;
+  border-radius: 7px;
+  color: var(--fg-1);
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.setup-select-opt:hover { background: var(--accent-soft); color: var(--fg-0); }
+.setup-select-opt.is-sel { color: var(--accent); }
+.setup-select-opt.is-sel::after { content: "✓"; font-size: 11px; }
+
+/* ───────── Sélecteur de fichier custom ───────── */
+.setup-file {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.setup-file-btn {
+  appearance: none;
+  cursor: pointer;
+  flex: none;
+  background: var(--bg-3);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  color: var(--fg-1);
+  padding: 9px 16px;
+  font-family: var(--sans);
+  font-size: 12.5px;
+  font-weight: 500;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+.setup-file-btn:hover {
+  border-color: var(--accent-line);
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.setup-file-name {
+  color: var(--fg-3);
+  font-family: var(--mono);
+  font-size: 11.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Champ en lecture seule (ex : Voice ID, non modifiable à l'onboarding) */
+.setup-readonly {
+  padding: 9px 12px;
+  border: 1px dashed var(--line-2);
+  border-radius: 8px;
+  background: rgba(6, 8, 13, 0.4);
+  color: var(--fg-2);
+  font-family: var(--mono);
+  font-size: 12.5px;
+  word-break: break-all;
+}
+
+/* ───────── Checkbox rows ───────── */
+.setup-check {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin-bottom: 8px;
+  padding: 10px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 10px;
+  background: var(--bg-2);
+  color: var(--fg-1);
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease;
+}
+.setup-check:hover { border-color: var(--line-3); }
+.setup-check input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+/* ───────── Prereq status rows ───────── */
+.setup-status-list {
+  display: grid;
+  gap: 7px;
+  margin-top: 4px;
+}
+.setup-status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border: 1px solid var(--line-1);
+  border-radius: 9px;
+  background: var(--bg-2);
+  font-size: 13px;
+  color: var(--fg-1);
+}
+.setup-status-row span:last-child {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.setup-status-ok { color: var(--green); }
+.setup-status-warn { color: var(--gold); }
+.setup-status-err { color: var(--red); }
+
+.setup-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+/* ───────── Footer buttons ───────── */
+.setup-footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 16px;
+}
+.setup-footer .m-btn {
+  appearance: none;
+  cursor: pointer;
+  min-width: 132px;
+  padding: 11px 22px;
+  border: 0;
+  border-radius: 9px;
+  background: var(--accent);
+  color: #001127;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 13px;
+  transition: filter 0.15s ease, transform 0.05s ease;
+}
+.setup-footer .m-btn:hover { filter: brightness(1.08); }
+.setup-footer .m-btn:active { transform: translateY(1px); }
+.setup-footer .m-btn:disabled { opacity: 0.5; cursor: default; }
+.setup-footer .m-btn--ghost {
+  background: transparent;
+  color: var(--fg-2);
+  border: 1px solid var(--line-2);
+  font-weight: 500;
+}
+.setup-footer .m-btn--ghost:hover {
+  background: var(--bg-2);
+  color: var(--fg-0);
+  filter: none;
+}
+
+/* ───────── Finish screen ───────── */
+.setup-done {
+  text-align: center;
+  padding: 10px 0 4px;
+}
+.setup-done-badge {
+  width: 54px;
+  height: 54px;
+  margin: 0 auto 18px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--green-soft);
+  border: 1px solid rgba(var(--c-green), 0.4);
+  color: var(--green);
+  font-size: 26px;
+  box-shadow: 0 0 30px -6px var(--green);
+}
+.setup-done h2 {
+  margin: 0 0 10px;
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 25px;
+  letter-spacing: -0.02em;
+  color: var(--fg-0);
+}
+.setup-done p {
+  color: var(--fg-2);
+  margin: 0 0 16px;
+  line-height: 1.55;
+  font-size: 13px;
+}
+.setup-done-url {
+  display: inline-block;
+  margin: 4px 0 16px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--accent-line);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 13px;
+  text-decoration: none;
+  transition: box-shadow 0.15s ease;
+}
+.setup-done-url:hover { box-shadow: 0 0 20px -4px var(--accent); }
+.setup-done-cmd {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--fg-3);
+  letter-spacing: 0.02em;
+}
+
+@media (max-width: 640px) {
+  .setup-grid-2 { grid-template-columns: 1fr; }
+  .setup-shell { padding: 20px 16px 16px; }
+  .setup-card { padding: 20px 18px; }
+}

--- a/src/jarvis/interfaces/ui/static/voice_livekit.js.bak-1782207354
+++ b/src/jarvis/interfaces/ui/static/voice_livekit.js.bak-1782207354
@@ -1,0 +1,206 @@
+"use strict";
+
+// ── Label voice-status ────────────────────────────────────────────────────────
+function showVoiceStatus(text, duration = 0) {
+  const el = document.getElementById("voice-status");
+  if (!el) return;
+  el.textContent = text;
+  el.classList.toggle("visible", text.length > 0);
+  if (duration > 0 && text.length > 0) {
+    setTimeout(() => {
+      if (el.textContent === text) el.classList.remove("visible");
+    }, duration);
+  }
+}
+
+// ── JarvisLiveKitClient ───────────────────────────────────────────────────────
+class JarvisLiveKitClient {
+  constructor() {
+    this._room       = null;
+    this._connected  = false;
+    this._isSpeaking = false;
+    this._agentBubble = null;
+    this._btn        = document.getElementById("perm-microphone");
+
+    // Interface window.jarvis (identique à l'ancien voice.js)
+    window.jarvis = {
+      get isSpeaking() { return window._voiceClient?._isSpeaking ?? false; },
+      stopAudio: () => {},        // LiveKit gère l'audio nativement
+      setState:  (s) => window._voiceClient?._setSphereState(s),
+      appendJarvisMessage: (text) => window._voiceClient?._appendAgentText(text),
+      appendUserMessage:   (text) => { if (text) addMsg("vous", text); },
+    };
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  async _start() {
+    // Partager la session texte courante avec l'agent vocal
+    const sessionId = typeof window._jarvisSessionId === "function" ? window._jarvisSessionId() : null;
+    const tokenUrl = sessionId
+      ? `/api/voice/token?session_id=${encodeURIComponent(sessionId)}`
+      : "/api/voice/token";
+
+    let tokenData;
+    try {
+      tokenData = await fetch(tokenUrl).then((r) => r.json());
+    } catch (e) {
+      console.error("[LiveKit] Impossible de récupérer le token:", e);
+      throw e;
+    }
+    const { token, url } = tokenData;
+    console.log("[LiveKit] Token OK, connexion à", url);
+
+    const { Room, RoomEvent, Track } = LivekitClient;
+
+    this._room = new Room({ adaptiveStream: true, reconnectPolicy: { maxRetries: 5 } });
+
+    this._room.on(RoomEvent.Connected, () => {
+      this._setState("listening");
+      showVoiceStatus("Jarvis en ligne");
+      setTimeout(() => showVoiceStatus(""), 2000);
+    });
+
+    this._room.on(RoomEvent.Disconnected, () => {
+      this._setState("idle");
+      this._isSpeaking = false;
+      this._setSphereState("IDLE");
+      showVoiceStatus("");
+    });
+
+    // Audio de l'agent → attacher à un <audio> invisible
+    this._room.on(RoomEvent.TrackSubscribed, (track, _pub, _participant) => {
+      if (track.kind === Track.Kind.Audio) {
+        const el = track.attach();
+        el.dataset.livekit = "1";
+        el.autoplay = true;
+        document.body.appendChild(el);
+      }
+    });
+
+    this._room.on(RoomEvent.TrackUnsubscribed, (track) => {
+      track.detach().forEach((el) => el.remove());
+    });
+
+    // États sphère via activité des speakers
+    this._room.on(RoomEvent.ActiveSpeakersChanged, (speakers) => {
+      const agentSpeaking = speakers.some((s) => s.isAgent);
+      const userSpeaking  = speakers.some((s) => !s.isAgent);
+
+      if (userSpeaking) {
+        this._setSphereState("LISTENING");
+        showVoiceStatus("...");
+      } else if (agentSpeaking) {
+        this._isSpeaking = true;
+        this._setSphereState("SPEAKING");
+        showVoiceStatus("");
+      } else {
+        this._isSpeaking = false;
+        this._setSphereState("IDLE");
+        showVoiceStatus("");
+      }
+    });
+
+    // État THINKING via metadata de l'agent
+    this._room.on(RoomEvent.ParticipantMetadataChanged, (metadata, participant) => {
+      if (!participant?.isAgent) return;
+      try {
+        const data = JSON.parse(metadata || "{}");
+        if (data.state === "thinking") {
+          this._setSphereState("THINKING");
+          showVoiceStatus("Jarvis réfléchit...");
+        }
+      } catch (_) {}
+    });
+
+    // Transcriptions
+    this._room.on(RoomEvent.TranscriptionReceived, (segments, participant) => {
+      for (const seg of segments) {
+        if (!seg.final) continue;
+        if (participant?.isAgent) {
+          this._appendAgentText(seg.text);
+        } else {
+          if (seg.text.trim()) addMsg("vous", seg.text);
+        }
+      }
+    });
+
+    console.log("[LiveKit] Connexion à la room...");
+    await this._room.connect(url, token, { audio: false, video: false });
+    console.log("[LiveKit] Room connectée, activation du micro...");
+
+    // Publier le micro local explicitement
+    try {
+      await this._room.localParticipant.setMicrophoneEnabled(true);
+      console.log("[LiveKit] Micro activé.");
+    } catch (e) {
+      console.error("[LiveKit] Erreur activation micro:", e);
+      // On continue — la room est connectée, Jarvis peut quand même parler
+    }
+
+    this._connected = true;
+  }
+
+  _stop() {
+    this._room?.disconnect();
+    this._room      = null;
+    this._connected = false;
+    this._isSpeaking = false;
+    this._agentBubble = null;
+
+    // Supprimer les éléments audio LiveKit
+    document.querySelectorAll("audio[data-livekit]").forEach((el) => el.remove());
+
+    this._setState("idle");
+    this._setSphereState("IDLE");
+    showVoiceStatus("");
+
+    if (window._perms) window._perms.microphone = false;
+    document.getElementById("perm-microphone")?.classList.remove("active");
+  }
+
+  // ── Texte agent (streaming ou bloc) ──────────────────────────────────────
+
+  _appendAgentText(text) {
+    if (!text?.trim()) return;
+    if (!this._agentBubble) {
+      this._agentBubble = addMsg("jarvis", "", true);
+    }
+    this._agentBubble.textContent += text + " ";
+    const chat = document.getElementById("chat");
+    if (chat) chat.scrollTop = chat.scrollHeight;
+    // Finaliser la bulle si le texte se termine par une ponctuation de fin
+    if (/[.!?]$/.test(text.trim())) {
+      this._agentBubble?.classList.remove("streaming");
+      if (typeof checkForMindmap === "function") checkForMindmap(this._agentBubble);
+      this._agentBubble = null;
+    }
+  }
+
+  // ── État sphère ───────────────────────────────────────────────────────────
+
+  _setSphereState(state) {
+    if (typeof sphereState !== "undefined") sphereState = state;
+    // Pont vers l'orbe de la home (home.js expose __jarvisSetOrbState).
+    // États LiveKit en MAJ (LISTENING/SPEAKING/THINKING/IDLE) -> minuscules.
+    if (typeof window.__jarvisSetOrbState === "function") {
+      window.__jarvisSetOrbState(String(state).toLowerCase());
+    }
+  }
+
+  // ── État bouton micro ─────────────────────────────────────────────────────
+
+  _setState(state) {
+    if (!this._btn) return;
+    this._btn.dataset.state = state;
+    this._btn.classList.toggle("active", state !== "idle" && state !== "error");
+  }
+
+  stopAudio() {
+    // LiveKit gère l'interruption nativement via barge-in
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  window._voiceClient = new JarvisLiveKitClient();
+});

--- a/src/jarvis/interfaces/ui/static/wakeup.css
+++ b/src/jarvis/interfaces/ui/static/wakeup.css
@@ -21,16 +21,16 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: rgba(74, 158, 255, 0.4);
+  background: rgba(var(--c-accent), 0.4);
   animation: pulse-slow 3s ease-in-out infinite;
 }
 
 #sleep-indicator-label {
   font-family: 'DM Mono', monospace;
-  font-size: 9px;
+  font-size: 0.5625rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
-  color: rgba(220, 232, 255, 0.15);
+  color: rgba(var(--c-fg), 0.15);
 }
 
 @keyframes pulse-slow {
@@ -105,7 +105,7 @@
 
 #scan-status-text {
   font-family: 'DM Mono', monospace;
-  font-size: 11px;
+  font-size: 0.6875rem;
   letter-spacing: 0.25em;
   text-transform: uppercase;
   color: #4A9EFF;
@@ -114,9 +114,9 @@
 
 #scan-system-text {
   font-family: 'DM Mono', monospace;
-  font-size: 9px;
+  font-size: 0.5625rem;
   letter-spacing: 0.15em;
-  color: rgba(220, 232, 255, 0.2);
+  color: rgba(var(--c-fg), 0.2);
 }
 
 @keyframes blink-text {
@@ -136,29 +136,29 @@
 .scan-corner-tl {
   top: calc(50% - min(320px, 27vw) - 4px);
   left: calc(50% - min(320px, 27vw) - 4px);
-  border-top: 2px solid rgba(74, 158, 255, 0.85);
-  border-left: 2px solid rgba(74, 158, 255, 0.85);
+  border-top: 2px solid rgba(var(--c-accent), 0.85);
+  border-left: 2px solid rgba(var(--c-accent), 0.85);
 }
 
 .scan-corner-tr {
   top: calc(50% - min(320px, 27vw) - 4px);
   right: calc(50% - min(320px, 27vw) - 4px);
-  border-top: 2px solid rgba(74, 158, 255, 0.85);
-  border-right: 2px solid rgba(74, 158, 255, 0.85);
+  border-top: 2px solid rgba(var(--c-accent), 0.85);
+  border-right: 2px solid rgba(var(--c-accent), 0.85);
 }
 
 .scan-corner-bl {
   bottom: calc(50% - min(320px, 27vw) - 4px);
   left: calc(50% - min(320px, 27vw) - 4px);
-  border-bottom: 2px solid rgba(74, 158, 255, 0.85);
-  border-left: 2px solid rgba(74, 158, 255, 0.85);
+  border-bottom: 2px solid rgba(var(--c-accent), 0.85);
+  border-left: 2px solid rgba(var(--c-accent), 0.85);
 }
 
 .scan-corner-br {
   bottom: calc(50% - min(320px, 27vw) - 4px);
   right: calc(50% - min(320px, 27vw) - 4px);
-  border-bottom: 2px solid rgba(74, 158, 255, 0.85);
-  border-right: 2px solid rgba(74, 158, 255, 0.85);
+  border-bottom: 2px solid rgba(var(--c-accent), 0.85);
+  border-right: 2px solid rgba(var(--c-accent), 0.85);
 }
 
 /* ── Scan line — spans the visible video width ───────────────────────────── */
@@ -170,12 +170,12 @@
   height: 2px;
   background: linear-gradient(90deg,
     transparent 0%,
-    rgba(74, 158, 255, 0.3) 15%,
-    rgba(74, 158, 255, 0.9) 50%,
-    rgba(74, 158, 255, 0.3) 85%,
+    rgba(var(--c-accent), 0.3) 15%,
+    rgba(var(--c-accent), 0.9) 50%,
+    rgba(var(--c-accent), 0.3) 85%,
     transparent 100%
   );
-  box-shadow: 0 0 18px rgba(74, 158, 255, 0.55), 0 0 4px #fff;
+  box-shadow: 0 0 18px rgba(var(--c-accent), 0.55), 0 0 4px #fff;
   animation: scan-move 1.8s ease-in-out infinite;
 }
 
@@ -195,9 +195,9 @@
 .scan-datapoint {
   position: absolute;
   font-family: 'DM Mono', monospace;
-  font-size: 8px;
+  font-size: 0.5rem;
   letter-spacing: 0.12em;
-  color: rgba(74, 158, 255, 0.45);
+  color: rgba(var(--c-accent), 0.45);
   white-space: nowrap;
   animation: float-data 3s ease-in-out infinite;
 }
@@ -216,7 +216,7 @@
   transform: translateX(-50%);
   width: min(480px, 40vw);
   height: 2px;
-  background: rgba(74, 158, 255, 0.1);
+  background: rgba(var(--c-accent), 0.1);
   border-radius: 99px;
   overflow: hidden;
 }
@@ -226,7 +226,7 @@
   width: 0%;
   background: linear-gradient(90deg, #2D7DD2, #4A9EFF);
   border-radius: 99px;
-  box-shadow: 0 0 8px rgba(74, 158, 255, 0.5);
+  box-shadow: 0 0 8px rgba(var(--c-accent), 0.5);
 }
 
 /* ── Footer ──────────────────────────────────────────────────────────────── */
@@ -244,16 +244,16 @@
 #scan-percentage {
   font-family: 'Syne', sans-serif;
   font-weight: 700;
-  font-size: 18px;
+  font-size: 1.125rem;
   color: #4A9EFF;
   min-width: 44px;
 }
 
 #scan-label {
   font-family: 'DM Mono', monospace;
-  font-size: 9px;
+  font-size: 0.5625rem;
   letter-spacing: 0.15em;
-  color: rgba(220, 232, 255, 0.35);
+  color: rgba(var(--c-fg), 0.35);
 }
 
 /* ── Result overlay ──────────────────────────────────────────────────────── */
@@ -272,13 +272,13 @@
 }
 
 #scan-result-icon {
-  font-size: 64px;
+  font-size: 4rem;
   line-height: 1;
 }
 
 #scan-result-text {
   font-family: 'DM Mono', monospace;
-  font-size: 14px;
+  font-size: 0.875rem;
   letter-spacing: 0.2em;
   text-transform: uppercase;
 }
@@ -286,7 +286,7 @@
 #scan-result-name {
   font-family: 'Syne', sans-serif;
   font-weight: 700;
-  font-size: 26px;
+  font-size: 1.625rem;
   letter-spacing: 0.1em;
 }
 

--- a/src/jarvis/interfaces/ui/static/wakeup.css.bak-1782254922
+++ b/src/jarvis/interfaces/ui/static/wakeup.css.bak-1782254922
@@ -1,0 +1,298 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   Jarvis Wake Up — styles
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ── Sleep indicator ─────────────────────────────────────────────────────── */
+
+#sleep-indicator {
+  display: none;
+  position: fixed;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 100;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+}
+
+#sleep-indicator-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(74, 158, 255, 0.4);
+  animation: pulse-slow 3s ease-in-out infinite;
+}
+
+#sleep-indicator-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(220, 232, 255, 0.15);
+}
+
+@keyframes pulse-slow {
+  0%, 100% { opacity: 0.3; transform: scale(1); }
+  50%       { opacity: 0.8; transform: scale(1.3); }
+}
+
+/* ── Scan overlay ────────────────────────────────────────────────────────── */
+
+#scan-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  pointer-events: none;
+}
+
+/* Dark backdrop — fills the screen around the video window */
+#scan-bg {
+  position: absolute;
+  inset: 0;
+  background: rgba(6, 8, 13, 0.94);
+}
+
+/* Webcam feed — moderate centered window, radial mask fades edges into dark bg */
+#scan-webcam-feed {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(640px, 54vw);
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  transform: translate(-50%, -50%) scaleX(-1);
+  filter: brightness(0.78) contrast(1.1) saturate(0.5) hue-rotate(200deg);
+  -webkit-mask-image: radial-gradient(ellipse 78% 80% at center,
+    black 38%, rgba(0,0,0,0.6) 65%, transparent 100%);
+  mask-image: radial-gradient(ellipse 78% 80% at center,
+    black 38%, rgba(0,0,0,0.6) 65%, transparent 100%);
+}
+
+/* Landmarks canvas — same position/size as video, dots above feed */
+#scan-landmarks-canvas {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(640px, 54vw);
+  aspect-ratio: 4 / 3;
+  transform: translate(-50%, -50%) scaleX(-1);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* HUD layer — on top of everything */
+#scan-hud {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+
+#scan-header {
+  position: absolute;
+  top: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+#scan-status-text {
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: #4A9EFF;
+  animation: blink-text 1s ease-in-out infinite;
+}
+
+#scan-system-text {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  color: rgba(220, 232, 255, 0.2);
+}
+
+@keyframes blink-text {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+/* ── Corner brackets — frame the video window ────────────────────────────── */
+/* Positioned to match the visible video area (≈54vw × 4:3 centered) */
+
+.scan-corner {
+  position: absolute;
+  width: 44px;
+  height: 44px;
+}
+
+.scan-corner-tl {
+  top: calc(50% - min(320px, 27vw) - 4px);
+  left: calc(50% - min(320px, 27vw) - 4px);
+  border-top: 2px solid rgba(74, 158, 255, 0.85);
+  border-left: 2px solid rgba(74, 158, 255, 0.85);
+}
+
+.scan-corner-tr {
+  top: calc(50% - min(320px, 27vw) - 4px);
+  right: calc(50% - min(320px, 27vw) - 4px);
+  border-top: 2px solid rgba(74, 158, 255, 0.85);
+  border-right: 2px solid rgba(74, 158, 255, 0.85);
+}
+
+.scan-corner-bl {
+  bottom: calc(50% - min(320px, 27vw) - 4px);
+  left: calc(50% - min(320px, 27vw) - 4px);
+  border-bottom: 2px solid rgba(74, 158, 255, 0.85);
+  border-left: 2px solid rgba(74, 158, 255, 0.85);
+}
+
+.scan-corner-br {
+  bottom: calc(50% - min(320px, 27vw) - 4px);
+  right: calc(50% - min(320px, 27vw) - 4px);
+  border-bottom: 2px solid rgba(74, 158, 255, 0.85);
+  border-right: 2px solid rgba(74, 158, 255, 0.85);
+}
+
+/* ── Scan line — spans the visible video width ───────────────────────────── */
+
+#scan-line {
+  position: absolute;
+  left: calc(50% - min(320px, 27vw));
+  right: calc(50% - min(320px, 27vw));
+  height: 2px;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    rgba(74, 158, 255, 0.3) 15%,
+    rgba(74, 158, 255, 0.9) 50%,
+    rgba(74, 158, 255, 0.3) 85%,
+    transparent 100%
+  );
+  box-shadow: 0 0 18px rgba(74, 158, 255, 0.55), 0 0 4px #fff;
+  animation: scan-move 1.8s ease-in-out infinite;
+}
+
+@keyframes scan-move {
+  0%   { top: calc(50% - min(238px, 20vw)); opacity: 0; }
+  5%   { opacity: 1; }
+  45%  { top: calc(50% + min(238px, 20vw)); opacity: 0.8; }
+  50%  { top: calc(50% + min(238px, 20vw)); opacity: 0; }
+  51%  { top: calc(50% - min(238px, 20vw)); opacity: 0; }
+  55%  { opacity: 1; }
+  95%  { top: calc(50% + min(238px, 20vw)); opacity: 0.8; }
+  100% { top: calc(50% + min(238px, 20vw)); opacity: 0; }
+}
+
+/* ── Floating data labels ────────────────────────────────────────────────── */
+
+.scan-datapoint {
+  position: absolute;
+  font-family: 'DM Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  color: rgba(74, 158, 255, 0.45);
+  white-space: nowrap;
+  animation: float-data 3s ease-in-out infinite;
+}
+
+@keyframes float-data {
+  0%, 100% { opacity: 0.35; transform: translateY(0); }
+  50%       { opacity: 0.75; transform: translateY(-4px); }
+}
+
+/* ── Progress bar — bottom center ───────────────────────────────────────── */
+
+#scan-progress-container {
+  position: absolute;
+  bottom: 52px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(480px, 40vw);
+  height: 2px;
+  background: rgba(74, 158, 255, 0.1);
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+#scan-progress-bar {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #2D7DD2, #4A9EFF);
+  border-radius: 99px;
+  box-shadow: 0 0 8px rgba(74, 158, 255, 0.5);
+}
+
+/* ── Footer ──────────────────────────────────────────────────────────────── */
+
+#scan-footer {
+  position: absolute;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+#scan-percentage {
+  font-family: 'Syne', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  color: #4A9EFF;
+  min-width: 44px;
+}
+
+#scan-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  color: rgba(220, 232, 255, 0.35);
+}
+
+/* ── Result overlay ──────────────────────────────────────────────────────── */
+
+#scan-result {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  z-index: 3;
+  background: rgba(6, 8, 13, 0.65);
+  backdrop-filter: blur(10px);
+}
+
+#scan-result-icon {
+  font-size: 64px;
+  line-height: 1;
+}
+
+#scan-result-text {
+  font-family: 'DM Mono', monospace;
+  font-size: 14px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+#scan-result-name {
+  font-family: 'Syne', sans-serif;
+  font-weight: 700;
+  font-size: 26px;
+  letter-spacing: 0.1em;
+}
+
+#scan-result.success #scan-result-icon  { color: #36D399; }
+#scan-result.success #scan-result-text  { color: #36D399; }
+#scan-result.success #scan-result-name  { color: #36D399; }
+#scan-result.denied  #scan-result-icon  { color: #ef4444; }
+#scan-result.denied  #scan-result-text  { color: #ef4444; }
+#scan-result.denied  #scan-result-name  { color: #ef4444; }

--- a/src/jarvis/interfaces/ui/static/wakeup.css.bak-1782259625
+++ b/src/jarvis/interfaces/ui/static/wakeup.css.bak-1782259625
@@ -1,0 +1,298 @@
+/* ═══════════════════════════════════════════════════════════════════════════
+   Jarvis Wake Up — styles
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ── Sleep indicator ─────────────────────────────────────────────────────── */
+
+#sleep-indicator {
+  display: none;
+  position: fixed;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 100;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+}
+
+#sleep-indicator-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: rgba(var(--c-accent), 0.4);
+  animation: pulse-slow 3s ease-in-out infinite;
+}
+
+#sleep-indicator-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(var(--c-fg), 0.15);
+}
+
+@keyframes pulse-slow {
+  0%, 100% { opacity: 0.3; transform: scale(1); }
+  50%       { opacity: 0.8; transform: scale(1.3); }
+}
+
+/* ── Scan overlay ────────────────────────────────────────────────────────── */
+
+#scan-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  pointer-events: none;
+}
+
+/* Dark backdrop — fills the screen around the video window */
+#scan-bg {
+  position: absolute;
+  inset: 0;
+  background: rgba(6, 8, 13, 0.94);
+}
+
+/* Webcam feed — moderate centered window, radial mask fades edges into dark bg */
+#scan-webcam-feed {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(640px, 54vw);
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  transform: translate(-50%, -50%) scaleX(-1);
+  filter: brightness(0.78) contrast(1.1) saturate(0.5) hue-rotate(200deg);
+  -webkit-mask-image: radial-gradient(ellipse 78% 80% at center,
+    black 38%, rgba(0,0,0,0.6) 65%, transparent 100%);
+  mask-image: radial-gradient(ellipse 78% 80% at center,
+    black 38%, rgba(0,0,0,0.6) 65%, transparent 100%);
+}
+
+/* Landmarks canvas — same position/size as video, dots above feed */
+#scan-landmarks-canvas {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: min(640px, 54vw);
+  aspect-ratio: 4 / 3;
+  transform: translate(-50%, -50%) scaleX(-1);
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* HUD layer — on top of everything */
+#scan-hud {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* ── Header ──────────────────────────────────────────────────────────────── */
+
+#scan-header {
+  position: absolute;
+  top: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+#scan-status-text {
+  font-family: 'DM Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: #4A9EFF;
+  animation: blink-text 1s ease-in-out infinite;
+}
+
+#scan-system-text {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  color: rgba(var(--c-fg), 0.2);
+}
+
+@keyframes blink-text {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+
+/* ── Corner brackets — frame the video window ────────────────────────────── */
+/* Positioned to match the visible video area (≈54vw × 4:3 centered) */
+
+.scan-corner {
+  position: absolute;
+  width: 44px;
+  height: 44px;
+}
+
+.scan-corner-tl {
+  top: calc(50% - min(320px, 27vw) - 4px);
+  left: calc(50% - min(320px, 27vw) - 4px);
+  border-top: 2px solid rgba(var(--c-accent), 0.85);
+  border-left: 2px solid rgba(var(--c-accent), 0.85);
+}
+
+.scan-corner-tr {
+  top: calc(50% - min(320px, 27vw) - 4px);
+  right: calc(50% - min(320px, 27vw) - 4px);
+  border-top: 2px solid rgba(var(--c-accent), 0.85);
+  border-right: 2px solid rgba(var(--c-accent), 0.85);
+}
+
+.scan-corner-bl {
+  bottom: calc(50% - min(320px, 27vw) - 4px);
+  left: calc(50% - min(320px, 27vw) - 4px);
+  border-bottom: 2px solid rgba(var(--c-accent), 0.85);
+  border-left: 2px solid rgba(var(--c-accent), 0.85);
+}
+
+.scan-corner-br {
+  bottom: calc(50% - min(320px, 27vw) - 4px);
+  right: calc(50% - min(320px, 27vw) - 4px);
+  border-bottom: 2px solid rgba(var(--c-accent), 0.85);
+  border-right: 2px solid rgba(var(--c-accent), 0.85);
+}
+
+/* ── Scan line — spans the visible video width ───────────────────────────── */
+
+#scan-line {
+  position: absolute;
+  left: calc(50% - min(320px, 27vw));
+  right: calc(50% - min(320px, 27vw));
+  height: 2px;
+  background: linear-gradient(90deg,
+    transparent 0%,
+    rgba(var(--c-accent), 0.3) 15%,
+    rgba(var(--c-accent), 0.9) 50%,
+    rgba(var(--c-accent), 0.3) 85%,
+    transparent 100%
+  );
+  box-shadow: 0 0 18px rgba(var(--c-accent), 0.55), 0 0 4px #fff;
+  animation: scan-move 1.8s ease-in-out infinite;
+}
+
+@keyframes scan-move {
+  0%   { top: calc(50% - min(238px, 20vw)); opacity: 0; }
+  5%   { opacity: 1; }
+  45%  { top: calc(50% + min(238px, 20vw)); opacity: 0.8; }
+  50%  { top: calc(50% + min(238px, 20vw)); opacity: 0; }
+  51%  { top: calc(50% - min(238px, 20vw)); opacity: 0; }
+  55%  { opacity: 1; }
+  95%  { top: calc(50% + min(238px, 20vw)); opacity: 0.8; }
+  100% { top: calc(50% + min(238px, 20vw)); opacity: 0; }
+}
+
+/* ── Floating data labels ────────────────────────────────────────────────── */
+
+.scan-datapoint {
+  position: absolute;
+  font-family: 'DM Mono', monospace;
+  font-size: 8px;
+  letter-spacing: 0.12em;
+  color: rgba(var(--c-accent), 0.45);
+  white-space: nowrap;
+  animation: float-data 3s ease-in-out infinite;
+}
+
+@keyframes float-data {
+  0%, 100% { opacity: 0.35; transform: translateY(0); }
+  50%       { opacity: 0.75; transform: translateY(-4px); }
+}
+
+/* ── Progress bar — bottom center ───────────────────────────────────────── */
+
+#scan-progress-container {
+  position: absolute;
+  bottom: 52px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(480px, 40vw);
+  height: 2px;
+  background: rgba(var(--c-accent), 0.1);
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+#scan-progress-bar {
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(90deg, #2D7DD2, #4A9EFF);
+  border-radius: 99px;
+  box-shadow: 0 0 8px rgba(var(--c-accent), 0.5);
+}
+
+/* ── Footer ──────────────────────────────────────────────────────────────── */
+
+#scan-footer {
+  position: absolute;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+#scan-percentage {
+  font-family: 'Syne', sans-serif;
+  font-weight: 700;
+  font-size: 18px;
+  color: #4A9EFF;
+  min-width: 44px;
+}
+
+#scan-label {
+  font-family: 'DM Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 0.15em;
+  color: rgba(var(--c-fg), 0.35);
+}
+
+/* ── Result overlay ──────────────────────────────────────────────────────── */
+
+#scan-result {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  z-index: 3;
+  background: rgba(6, 8, 13, 0.65);
+  backdrop-filter: blur(10px);
+}
+
+#scan-result-icon {
+  font-size: 64px;
+  line-height: 1;
+}
+
+#scan-result-text {
+  font-family: 'DM Mono', monospace;
+  font-size: 14px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+#scan-result-name {
+  font-family: 'Syne', sans-serif;
+  font-weight: 700;
+  font-size: 26px;
+  letter-spacing: 0.1em;
+}
+
+#scan-result.success #scan-result-icon  { color: #36D399; }
+#scan-result.success #scan-result-text  { color: #36D399; }
+#scan-result.success #scan-result-name  { color: #36D399; }
+#scan-result.denied  #scan-result-icon  { color: #ef4444; }
+#scan-result.denied  #scan-result-text  { color: #ef4444; }
+#scan-result.denied  #scan-result-name  { color: #ef4444; }


### PR DESCRIPTION
## Vue d'ensemble

Refonte complète de la navigation et du système de thème de l'interface Jarvis. Tout est rétrocompatible — aucune fonctionnalité existante n'est cassée.

## Nouvelle page Mission Control (`/mc`)

- Route `/mc` ajoutée dans `ui.py` et exemptée du Bearer auth dans `auth.py`
- Topbar sticky avec 5 onglets : Workspace, Capacités, Configuration, Interface
- Chaque onglet charge la page existante dans une iframe (dashboard, capabilities, settings)
- Logo arc reactor SVG animé en haut à gauche, câblé sur `--accent`, retour home au clic
- Effet atmosphère (aurora) propre à `/mc` via `body[data-mode="mc"] .atmo--aurora`
- Bouton Mission Control de la home redirige vers `/mc` au lieu d'ouvrir un overlay

## Onglet Interface (panneau de personnalisation)

- **Color picker custom** `jarvis-color-picker.js` : roue chromatique, slider teinte, input hex, presets — sans dépendance externe
- Couleurs exposées : Fond principal (`--bg-0`), Accent (`--accent`), Texte principal (`--fg-0`)
- Sliders : Grain, Vignette, Taille texte (11px–24px)
- Export/Import thème JSON (partage entre utilisateurs)
- Persistance `localStorage` côté client
- Reset aux valeurs par défaut

## Système de thème CSS

- 5 variables racines RGB : `--c-fg`, `--c-accent`, `--c-gold`, `--c-green`, `--c-red`
- 327 occurrences de couleurs hardcodées converties vers `rgba(var(--c-X), alpha)` dans tous les CSS
- 349 `font-size` convertis de `px` vers `rem` pour scaling dynamique via le slider taille texte
- Variables dérivées auto-calculées : `--accent-soft`, `--accent-line`, `--fg-1` à `--fg-4`, `--accent-icon`
- Thème appliqué au boot sur toutes les pages via `mission_control.js`

## Orbe Three.js

- `sphereStyle.js` patché pour lire `window.JARVIS_ACCENT_COLOR` au démarrage
- `mission_control.js` injecte la couleur depuis `localStorage` avant le chargement de `sphereStyle.js`
- L'orbe change de couleur en temps réel avec la couleur accent

## Page home

- Pictos de la barre de contrôles câblés sur `--accent-icon` (variante éclaircie de l'accent)
- Fond de la pill câblé sur `--bg-0`
- Bordure câblée sur `--line-3`
- Lien `OUVRIR →` redirige vers `/mc#workspace`

## Injection thème dans les pages standalone

- Pages admin/budget/command/routines : bouton Home flottant ajouté
- Page admin (onglet Logs) : CSS vars du thème injectées dans l'iframe au chargement (`--bg`, `--b1`–`--b4`, `--text`, `--panel`, `--glass`)

## Fichiers créés

- `src/jarvis/interfaces/ui/static/mc.html`
- `src/jarvis/interfaces/ui/static/mc.css`
- `src/jarvis/interfaces/ui/static/mc.js`
- `src/jarvis/interfaces/ui/static/mission_control.js`
- `src/jarvis/interfaces/ui/static/mission_control.css`
- `src/jarvis/interfaces/ui/static/jarvis-color-picker.js`

## Fichiers modifiés

- `src/jarvis/interfaces/api/ui.py` — route `/mc` + assets
- `src/jarvis/engine/auth.py` — exemption `/mc`
- `src/jarvis/interfaces/ui/static/_shared.js` — ROOMS, openMissionControl, détection iframe
- `src/jarvis/interfaces/ui/static/_shared.css` — variables `--c-*`, fonts rem, aurora `/mc`
- `src/jarvis/interfaces/ui/static/config/sphereStyle.js` — couleur accent dynamique
- `src/jarvis/interfaces/ui/static/orb.js` — inchangé
- Tous les `.css` UI — couleurs converties + fonts rem

## Notes

- Les `.bak-*` sont exclus via `.gitignore`
- Onglet Logs (admin) présent mais masqué temporairement — la page existe, l'accès est fonctionnel
- Testé sur VPS Hostinger KVM2, Ubuntu 24.04, Tailscale HTTPS reverse proxy