### PR TITLE
fix(wake/voice): débloque l'accès micro + STT/clap diagnosticables

### DIFF
--- a/src/jarvis/interfaces/ui/static/wake_sequence.js
+++ b/src/jarvis/interfaces/ui/static/wake_sequence.js
@@ -963,12 +963,11 @@
                         visionBundle: opts.visionBundle,
                     }, function (recognized) {
                         faceHandle = null;
-                        if (recognized === false) {
-                            if (typeof opts.onFailure === 'function') {
-                                try { opts.onFailure(); } catch (e) {}
-                            }
-                            return;
-                        }
+                        // Face phase never blocks access (CDC C4). An unrecognized face
+                        // -- or a backend error (no cv2/model, timeout, face not enrolled)
+                        // -- already showed the manual override verdict. We proceed to the
+                        // dashboard regardless: otherwise the user stays trapped on the
+                        // standby screen with the mic unreachable.
                         if (state === STATES.FACE) setState(STATES.CONVERGE);
                     });
                     break;

--- a/src/jarvis/interfaces/voice/agent.py
+++ b/src/jarvis/interfaces/voice/agent.py
@@ -346,9 +346,24 @@ def _build_voice_stt(env: dict) -> object:
     except Exception as e:
         logger.warning("STT '%s' indisponible (%s) -> repli Deepgram", provider, e)
 
+    dg_key = env.get("DEEPGRAM_API_KEY", os.getenv("DEEPGRAM_API_KEY", "")).strip()
+    # A missing/corrupted key fails STT silently at runtime: the mic captures audio
+    # but Jarvis never receives a transcript (mic active, no answer to voice). Surface
+    # it loudly instead so the user can fix .env instead of chasing a ghost.
+    if not dg_key or any(c.isspace() for c in dg_key) or len(dg_key) < 20:
+        logger.error(
+            "DEEPGRAM_API_KEY manquante ou invalide -> la reconnaissance vocale (STT) "
+            "ne fonctionnera pas : le micro capte mais Jarvis ne comprend rien. "
+            "Corrige DEEPGRAM_API_KEY dans .env (cle brute, sans espace ni guillemet) "
+            "ou bascule STT_PROVIDER=openai avec une OPENAI_API_KEY valide."
+        )
     logger.info("STT pipeline = Deepgram (nova-2)")
     return deepgram.STT(
-        model="nova-2", language="fr", smart_format=True, interim_results=True
+        model="nova-2",
+        language="fr",
+        smart_format=True,
+        interim_results=True,
+        api_key=dg_key,
     )
 
 

--- a/src/jarvis/providers/audio/clap_detector.py
+++ b/src/jarvis/providers/audio/clap_detector.py
@@ -129,6 +129,12 @@ class ClapDetector:
 
         self._clap_times.append(now)
 
+        # Per-clap trace so users can confirm detection works and tune
+        # CLAP_AMPLITUDE_THRESHOLD: a double clap needs two of these within the window.
+        logger.info(
+            "ClapDetector: clap détecté ({}/2 dans la fenêtre)", len(self._clap_times)
+        )
+
         if len(self._clap_times) >= 2:
             if now - self._last_trigger >= self.COOLDOWN:
                 self._last_trigger = now


### PR DESCRIPTION
## Contexte

Plusieurs collaborateurs remontent, après le timeout API (corrigé par #26), une UX bloquante : impossible d'activer/utiliser le micro, double-clap sans effet.

## Correctifs

### 1. Réveil / standby ne piège plus l'utilisateur (micro inaccessible)
La phase faciale du wake est conçue pour ne jamais bloquer (CDC C4 : verdict « dérogation manuelle »), mais le caller renvoyait en veille dès que `recognized === false`. Or le backend `verify-face-frame` renvoie `recognized:false` dans tous les cas non nominaux : reconnaissance activée sans visage enrôlé, pas de `cv2`, modèle absent, timeout. Résultat : boucle veille → dashboard jamais atteint → micro jamais accessible.

On enchaîne désormais toujours vers le dashboard après le verdict (le message de dérogation reste affiché). Le clic sur l'écran de veille redevient un échappatoire fiable.

### 2. Micro actif mais voix non traitée (STT muet)
Cause récurrente : `DEEPGRAM_API_KEY` manquante ou corrompue (ex. commande PowerShell collée dans `.env`) → 401 silencieux, le micro capte mais aucun transcript. On valide la clé au démarrage de l'agent et on logue une erreur explicite, en passant la clé explicitement à `deepgram.STT`.

### 3. Double-clap non propagé à l'UI
Le wiring est correct (`run_coroutine_threadsafe` → `proactive_queue.broadcast_event` → `/ws` → CustomEvent `jarvis-wake`). La vraie variable est le seuil audio selon le micro : on logue chaque clap détecté pour confirmer la détection et permettre de régler `CLAP_AMPLITUDE_THRESHOLD`.

## Notes

- Ces correctifs visent la prochaine release v0.3.2 (les collaborateurs sont sur v0.3.1, qui n'a ni #26 ni ceci).
- Les bugs vocal/clap dépendent du runtime (micro, clé Deepgram, navigateur) ; le code est rendu diagnosticable plutôt que silencieux.

## Test plan

- [ ] Cold boot : écran de veille → clic ou double-clap → la séquence atteint le dashboard et le micro est accessible, même sans caméra / sans visage enrôlé
- [ ] Agent vocal avec `DEEPGRAM_API_KEY` vide/invalide : erreur explicite dans `voice.log`
- [ ] Double-clap : `voice.log`/`api.log` montre « clap détecté (n/2) » puis le wake
